### PR TITLE
Add instructions to multi view dice roller

### DIFF
--- a/multi-framework-diceroller/README.md
+++ b/multi-framework-diceroller/README.md
@@ -13,19 +13,19 @@ npm start
 ```
 ## Changing view frameworks
 
-This repo demonstrates rendering the dice roller using JavaScript, Web Components, React and Vue. The default view is JavaScipt, and to switch to another view framework, change the `renderDiceRoller` import in `src/app.js` line 8 as follows.
+This repo demonstrates rendering the dice roller using JavaScript, Web Components, React and Vue. The default view is JavaScipt, and to switch to another view framework, change the `diceRoller` import in `src/app.js` line 8 as follows.
 
 ```js
 // Default JS view
-import { jsRenderView as renderDiceRoller } from "./view";
+import { jsDiceRoller as diceRoller } from "./view";
 
 // Web Component view
-import { wcRenderView as renderDiceRoller } from "./view";
+import { wcDiceRoller as diceRoller } from "./view";
 
 // React view
-import { reactRenderView as renderDiceRoller } from "./view";
+import { reactDiceRoller as diceRoller } from "./view";
 
 // Vue view
-import { vueRenderView as renderDiceRoller } from "./view";
+import { vueDiceRoller as diceRoller } from "./view";
 
 ```

--- a/multi-framework-diceroller/README.md
+++ b/multi-framework-diceroller/README.md
@@ -13,7 +13,7 @@ npm start
 ```
 ## Changing view frameworks
 
-This repo demonstrates rendering the dice roller using JavaScript, Web Components, React and Vue. The default view is JavaScipt, and to switch to another view framework, change the `diceRoller` import in `src/app.js` line 8 as follows.
+This repo demonstrates rendering the dice roller using JavaScript, Web Components, React and Vue. The default view is JavaScipt. To switch to another view framework, change the `diceRoller` import in `src/app.js` line 8 as follows.
 
 ```js
 // Default JS view

--- a/multi-framework-diceroller/README.md
+++ b/multi-framework-diceroller/README.md
@@ -5,9 +5,27 @@ This repository contains a simple app that enables all connected clients to roll
 
 Node 12.17+
 
-## Getting Started
+## Getting started
 
 ```bash
 npm install
 npm start
+```
+## Changing view frameworks
+
+This repo demonstrates rendering the dice roller using JavaScript, Web Components, React and Vue. The default view is JavaScipt, and to switch to another view framework, change the `renderDiceRoller` import in `src/app.js` line 8 as follows.
+
+```js
+// Default JS view
+import { jsRenderView as renderDiceRoller } from "./view";
+
+// Web Component view
+import { wcRenderView as renderDiceRoller } from "./view";
+
+// React view
+import { reactRenderView as renderDiceRoller } from "./view";
+
+// Vue view
+import { vueRenderView as renderDiceRoller } from "./view";
+
 ```

--- a/multi-framework-diceroller/src/app.js
+++ b/multi-framework-diceroller/src/app.js
@@ -5,7 +5,8 @@
 
 import { SharedMap } from "fluid-framework";
 import { TinyliciousClient } from "@fluidframework/tinylicious-client";
-import { jsRenderView as renderDiceRoller } from "./view";
+// Change jsDiceRoller to wcDiceRoller, reactDiceRoller or vueDiceRoller to see other view frameworks
+import { jsDiceRoller as diceRoller } from "./view";
 
 export const diceValueKey = "dice-value-key";
 
@@ -19,13 +20,13 @@ const createNewDice = async () => {
     const { container } = await client.createContainer(containerSchema);
     container.initialObjects.diceMap.set(diceValueKey, 1);
     const id = container.attach();
-    renderDiceRoller(container.initialObjects.diceMap, root);
+    diceRoller(container.initialObjects.diceMap, root);
     return id;
 }
 
 const loadExistingDice = async (id) => {
     const { container } = await client.getContainer(id, containerSchema);
-    renderDiceRoller(container.initialObjects.diceMap, root);
+    diceRoller(container.initialObjects.diceMap, root);
 }
 
 async function start() {

--- a/multi-framework-diceroller/src/view/jsView.js
+++ b/multi-framework-diceroller/src/view/jsView.js
@@ -19,7 +19,7 @@ template.innerHTML = `
   </div>
 `
 
-export const jsRenderView = (diceMap, elem) => {
+export const jsDiceRoller = (diceMap, elem) => {
     elem.appendChild(template.content.cloneNode(true));
 
     const rollButton = elem.querySelector(".roll");

--- a/multi-framework-diceroller/src/view/reactView.jsx
+++ b/multi-framework-diceroller/src/view/reactView.jsx
@@ -8,7 +8,7 @@ import ReactDOM from "react-dom";
 
 import { diceValueKey } from "../app";
 
-export const reactRenderView = (dice, elem) => {
+export const reactDiceRoller = (dice, elem) => {
     ReactDOM.render(<ReactView dice={dice} />, elem);
 }
 

--- a/multi-framework-diceroller/src/view/vueView.js
+++ b/multi-framework-diceroller/src/view/vueView.js
@@ -11,7 +11,7 @@ import { diceValueKey } from "../app";
  * @param dice - The SharedMap holding the collaborative data
  * @param elem - The HTMLElement to render into
  */
-export const  vueRenderView = (dice, elem) => {
+export const  vueDiceRoller = (dice, elem) => {
     const app = createApp({
         template: `
         <div style="text-align: center" >

--- a/multi-framework-diceroller/src/view/wcView.js
+++ b/multi-framework-diceroller/src/view/wcView.js
@@ -44,7 +44,7 @@ class Dice extends HTMLElement {
   }
 }
 
-export const wcRenderView = (diceMap, elem) => {
+export const wcDiceRoller = (diceMap, elem) => {
   customElements.define("wc-dice", Dice);
   const dice = document.createElement("wc-dice");
   dice.onRoll = number => diceMap.set(diceValueKey, number);


### PR DESCRIPTION
Added readme and comment instructions about loading other views. Also changed function names to be a little more clear. 

I removed the 'render' from `renderDiceRoller` because `jsDiceRoller as diceRoller` seemed easier to understand than `jsDiceRoller as renderDiceRoller`, and I didn't want to go with `jsRenderDiceRoller as renderDiceRoller` either. 