### PR TITLE
add instructions in view files for rendering that view

### DIFF
--- a/multi-framework-diceroller/src/view/reactView.jsx
+++ b/multi-framework-diceroller/src/view/reactView.jsx
@@ -5,9 +5,10 @@
 
 import React from "react";
 import ReactDOM from "react-dom";
-
 import { diceValueKey } from "../app";
 
+// To see this view rendered, change the import in app.js to:
+// import { reactDiceRoller as diceRoller } from "./view";
 export const reactDiceRoller = (dice, elem) => {
     ReactDOM.render(<ReactView dice={dice} />, elem);
 }

--- a/multi-framework-diceroller/src/view/vueView.js
+++ b/multi-framework-diceroller/src/view/vueView.js
@@ -6,11 +6,8 @@
 import { createApp } from "vue";
 import { diceValueKey } from "../app";
 
-/**
- * Render Dice into a given HTMLElement as a text character, with a button to roll it.
- * @param dice - The SharedMap holding the collaborative data
- * @param elem - The HTMLElement to render into
- */
+// To see this view rendered, change the import in app.js to:
+// import { vueDiceRoller as diceRoller } from "./view";
 export const  vueDiceRoller = (dice, elem) => {
     const app = createApp({
         template: `

--- a/multi-framework-diceroller/src/view/wcView.js
+++ b/multi-framework-diceroller/src/view/wcView.js
@@ -5,6 +5,19 @@
 
 import { diceValueKey } from "../app";
 
+// To see this view rendered, change the import in app.js to:
+// import { wcDiceRoller as diceRoller } from "./view";
+export const wcDiceRoller = (diceMap, elem) => {
+  customElements.define("wc-dice", Dice);
+  const dice = document.createElement("wc-dice");
+  dice.onRoll = number => diceMap.set(diceValueKey, number);
+  const updateDice = () => dice.setAttribute("value", diceMap.get(diceValueKey));
+  updateDice();
+  diceMap.on("valueChanged", updateDice)
+
+  elem.append(dice);
+}
+
 const template = document.createElement("template");
 
 template.innerHTML = `
@@ -18,15 +31,12 @@ template.innerHTML = `
     <button class="roll"> Roll </button>
   </div>
 `
-
 class Dice extends HTMLElement {
   constructor() {
     super();
-
     const shadow = this.attachShadow({ mode: "open" });
     shadow.appendChild(template.content.cloneNode(true));
     this.diceValue = shadow.querySelector(".dice");
-
     shadow.querySelector(".roll").onclick = () => this.onRoll(Math.floor(Math.random() * 6) + 1);
   }
 
@@ -44,13 +54,3 @@ class Dice extends HTMLElement {
   }
 }
 
-export const wcDiceRoller = (diceMap, elem) => {
-  customElements.define("wc-dice", Dice);
-  const dice = document.createElement("wc-dice");
-  dice.onRoll = number => diceMap.set(diceValueKey, number);
-  const updateDice = () => dice.setAttribute("value", diceMap.get(diceValueKey));
-  updateDice();
-  diceMap.on("valueChanged", updateDice)
-
-  elem.append(dice);
-}


### PR DESCRIPTION
I'm going to point directly to the view files in the docs, so I want to make sure that each view is able to define how to render that view. 