### PR TITLE
Remove azureclient dep from mfwd

### DIFF
--- a/multi-framework-diceroller/package-lock.json
+++ b/multi-framework-diceroller/package-lock.json
@@ -1467,34 +1467,6 @@
                 }
             }
         },
-        "@fluidframework/azure-client": {
-            "version": "0.48.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-0.48.1.tgz",
-            "integrity": "sha512-NSZFzUn2uFzNw/K/Ry+RKfaIDUv6f3Vzv6NcmYKflAWYRbP/Fid1OIk00WiRmop77RZvc9Tv+obMFJqqPXybhg==",
-            "requires": {
-                "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/container-definitions": "^0.39.8",
-                "@fluidframework/container-loader": "^0.48.1",
-                "@fluidframework/core-interfaces": "^0.39.7",
-                "@fluidframework/driver-definitions": "^0.39.6",
-                "@fluidframework/driver-utils": "^0.48.1",
-                "@fluidframework/fluid-static": "^0.48.1",
-                "@fluidframework/map": "^0.48.1",
-                "@fluidframework/protocol-definitions": "^0.1024.0",
-                "@fluidframework/routerlicious-driver": "^0.48.1",
-                "@fluidframework/runtime-utils": "^0.48.1",
-                "@fluidframework/server-services-client": "^0.1031.0-37526",
-                "axios": "^0.21.1",
-                "uuid": "^8.3.1"
-            },
-            "dependencies": {
-                "uuid": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-                }
-            }
-        },
         "@fluidframework/common-definitions": {
             "version": "0.20.1",
             "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",

--- a/multi-framework-diceroller/package.json
+++ b/multi-framework-diceroller/package.json
@@ -15,7 +15,6 @@
     },
     "dependencies": {
         "@babel/preset-react": "^7.14.5",
-        "@fluidframework/azure-client": "^0.48.1",
         "@fluidframework/tinylicious-client": "^0.48.1",
         "fluid-framework": "^0.48.1",
         "react": "^17.0.2",


### PR DESCRIPTION
This example doesn't use `AzureClient` so we can remove the package from its dependencies