### PR TITLE
Replace readline-async with readline-sync

### DIFF
--- a/node-demo/package.json
+++ b/node-demo/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@fluidframework/tinylicious-client": "^0.49.2",
     "fluid-framework": "^0.49.2",
-    "readline-async": "^0.1.0"
+    "readline-sync": "^1.4.10"
   },
   "type": "module"
 }

--- a/node-demo/src/index.js
+++ b/node-demo/src/index.js
@@ -1,6 +1,6 @@
 import { SharedMap } from "fluid-framework";
 import { TinyliciousClient } from "@fluidframework/tinylicious-client";
-import readlineAsync  from "readline-async";
+import readlineSync from "readline-sync";
 
 const schema = {
     initialObjects: { map: SharedMap }
@@ -40,18 +40,8 @@ function loadCli(map) {
     map.on("valueChanged", updateConsole);
 }
 
-async function readInput() {
-    let containerId = "";
-    console.log("Type a Container ID or press Enter to continue: ");
-    await readlineAsync().then( line => {
-        console.log("You entered: " + line);
-        containerId = line;
-    });
-    return containerId;
-}
-
 async function start() {
-    const containerId = await readInput();
+    const containerId = readlineSync.question("Type a Container ID or press Enter to continue: ");
 
     if(containerId.length === 0 || containerId === 'undefined' || containerId === 'null') {
         await createContainer();


### PR DESCRIPTION
`readline-async` seems to be causing `Ctrl-C` not to work once the application is running, so replacing it with a simpler option that keeps it working.

Partially fixes https://github.com/microsoft/FluidFramework/issues/9208 (pending a PR to fix the [corresponding code in the documentation](https://github.com/microsoft/FluidFramework/blob/main/docs/content/docs/recipes/node.md)).