### PR TITLE
build: Misc. cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Welcome to the Fluid Framework Examples Repository!
 
-This codebase includes examples of collaborative applications built with the Fluid Framework. For documentation about the Fluid Framework, go to [FluidFramework.com](https://fluidframework.com/). The Fluid Framework repository lives at [Github.com/Microsoft/FluidFramework](https://github.com/microsoft/fluidframework).
+This codebase includes examples of collaborative applications built with the Fluid Framework.
+For documentation about the Fluid Framework, go to [FluidFramework.com](https://fluidframework.com/).
+The Fluid Framework repository lives at [Github.com/Microsoft/FluidFramework](https://github.com/microsoft/fluidframework).
 
-Each example is a standalone application that defines a Fluid Container and loads it into a webpage.
+Each example in this repository is a standalone application that defines a Fluid Container and loads it into a webpage.
 
 ## Getting Started
 
-To get started, clone the repository and navigate to one of the example folders. From the example root, you can install and start the example.
+To get started, clone the repository and navigate to one of the example folders.
+From the example root, you can install and start the example.
 
 1. Run `npm install` from the example root
 2. Run `npm run start` to start both the client and server

--- a/angular-demo/README.md
+++ b/angular-demo/README.md
@@ -29,15 +29,16 @@ In this readme we'll walk you through the following topics:
 
 To run our local server, Tinylicious, on the default values of `localhost:7070`, enter the following into a terminal window:
 
-```
+```bash
 npx tinylicious
 ```
 
-Now, with our local service running in the background, we need to connect the application to it. The app has already been configured to this so now we just need to run the following in a new terminal window to start the app.
+Now, with our local service running in the background, we need to connect the application to it.
+The app has already been configured to this so now we just need to run the following in a new terminal window to start the app:
 
 ```bash
-npm i
-npm run start
+npm install
+npm start
 ```
 
 ## Modifying the model

--- a/audience-demo/README.md
+++ b/audience-demo/README.md
@@ -1,14 +1,22 @@
 # @fluid-example/audience-demo
 
-This repository contains a simple React application which demonstrates Fluid Audiences. The React client will display all users connected to a Fluid Container.
+This repository contains a simple [React](https://react.dev) application which demonstrates Fluid Audiences.
+The React client will display all users connected to a Fluid Container.
 
 ### Demo workflow
 
-The browser will initially display three user id buttons as well as an optional container id input field. Leave the container id field blank to create a new container or input an existing container id to join an existing container. For your first client, leave the container id blank and choose a user id as there are no collaborative sessions to join yet.
+The browser will initially display three user ID buttons as well as an optional container ID input field.
+Leave the container ID field blank to create a new container or input an existing container ID to join an existing container.
+For your first client, leave the container ID blank and choose a user ID as there are no collaborative sessions to join yet.
 
-The browser will display boxes which represents current members in the audience. The box with the blue border represents the current user who is viewing the browser client while the boxes with the black border represents the other members who are connected to the container. Create a new browser tab and navigate to the first browser's url to simulate a new user entering the collaborative session. To connect to the first session, select a user id. As you open and close new tabs, the corresponding member boxes will appear.
+The browser will display boxes which represents current members in the audience.
+The box with the blue border represents the current user who is viewing the browser client while the boxes with the black border represents the other members who are connected to the container.
+Create a new browser tab and navigate to the first browser's url to simulate a new user entering the collaborative session.
+To connect to the first session, select a user ID.
+As you open and close new tabs, the corresponding member boxes will appear.
 
-Note that new boxes will only generate for each unique user. Joining a container on a new browser while selecting an existing user id will increase the number of connections for that user.
+Note that new boxes will only generate for each unique user.
+Joining a container on a new browser while selecting an existing user ID will increase the number of connections for that user.
 
 ---
 
@@ -16,8 +24,8 @@ Note that new boxes will only generate for each unique user. Joining a container
 
 To run an Azure Client service locally, on the default values of `localhost:7070`, enter the following into a terminal window:
 
-```
-npm run start:server
+```bash
+npx tinylicious
 ```
 
 With the local service running in the background, we need to connect the application to it. Run the following commands in a new terminal window to start the app. Navigate to `localhost:3000` in the browser to view the app.

--- a/audience-demo/README.md
+++ b/audience-demo/README.md
@@ -31,6 +31,6 @@ npx tinylicious
 With the local service running in the background, we need to connect the application to it. Run the following commands in a new terminal window to start the app. Navigate to `localhost:3000` in the browser to view the app.
 
 ```bash
-npm i
-npm run start
+npm install
+npm start
 ```

--- a/brainstorm/README.md
+++ b/brainstorm/README.md
@@ -7,6 +7,14 @@ This application was shown during a [Microsoft Build session](https://aka.ms/OD5
 
 ## Getting Started
 
+This package is based on the [Create React App](https://reactjs.org/docs/create-a-new-react-app.html), so much of the Create React App documentation applies.
+
+### Local Mode
+
+Azure local service is a local, self-contained test service.
+Running `npx @fluidframework/azure-local-service@latest` from your terminal window will launch the Azure local server.
+The server will need to be started first in order to provide the ordering and storage requirement of Fluid runtime.
+
 Follow the steps below to run this in local mode (Azure local service):
 
 1. Run `npm install` from the brainstorm folder root
@@ -14,31 +22,18 @@ Follow the steps below to run this in local mode (Azure local service):
 3. Run `npm start` to start the client
 4. Navigate to `http://localhost:3000` in a browser tab
 
-<br />
+### Remote Mode
 
-| :memo: NOTE |
-| :---------- |
-
-| Azure local service is a local, self-contained test service. Running `npx @fluidframework/azure-local-service@latest` from your terminal window will launch the Azure local server. The server will need to be started first in order to provide the ordering and storage requirement of Fluid runtime.
-
-<br />
+Azure Fluid Relay service is a deployed service implementation that pulls together multiple micro-services that provide the ordering and storage requirement of Fluid runtime.
+By running `npm run start:azure` from your terminal window, the environment variable `REACT_APP_FLUID_CLIENT` will be set first, which will be picked up by the `useAzure` flag, and `AzureConnectionConfig` will use the remote mode config format.
+Please use the values provided as part of the service onboarding process to fill in this configuration.
+Then, the command will connect to your service instance.
 
 Follow the steps below to run this in remote mode (Routerlicious):
 
 1. Run `npm install` from the brainstorm folder root
 2. Run `npm run start:azure` to connect to the Azure Fluid Relay service
 3. Navigate to `http://localhost:3000` in a browser tab
-
-<br />
-
-| :memo: NOTE |
-| :---------- |
-
-| Azure Fluid Relay service is a deployed service implementation that pulls together multiple micro-services that provide the ordering and storage requirement of Fluid runtime. By running `npm run start:azure` from your terminal window, the environment variable `REACT_APP_FLUID_CLIENT` will be set first, which will be picked up by the `useAzure` flag, and `AzureConnectionConfig` will use the remote mode config format. Please use the values provided as part of the service onboarding process to fill in this configuration. Then, the command will connect to your service instance.
-
-<br />
-
-This package is based on the [Create React App](https://reactjs.org/docs/create-a-new-react-app.html), so much of the Create React App documentation applies.
 
 ## Using the Brainstorm App
 
@@ -49,7 +44,8 @@ This package is based on the [Create React App](https://reactjs.org/docs/create-
 
 ## Connecting to the Service
 
-By configuring the `AzureConnectionConfig` that we pass into the `AzureClient` instance, we can connect to both live Azure Fluid Relay and local instances. The `AzureConnectionConfig` is defined by the `connectionConfig` constant in [Config.ts](./src/Config.ts), which specifies the tenant ID, orderer and storage.
+By configuring the `AzureConnectionConfig` that we pass into the `AzureClient` instance, we can connect to both live Azure Fluid Relay and local instances.
+The `AzureConnectionConfig` is defined by the `connectionConfig` constant in [Config.ts](./src/Config.ts), which specifies the tenant ID, orderer and storage.
 
 Now, before you can access any Fluid data, you need to define your container schema after creating a configured `AzureClient` using `AzureConnectionConfig`.
 
@@ -63,7 +59,8 @@ export const containerSchema = {
 };
 ```
 
-Inside [index.tsx](./src/index.tsx), we defined a `start()` function that uses `getContainerId()` to check for the container ID in the URL and determine if this is an existing document (`getContainer()`) or if we need to create a new one (`createContainer()`). When creating a new container, we get its ID from the `container.attach()` call.
+Inside [index.tsx](./src/index.tsx), we defined a `start()` function that uses `getContainerId()` to check for the container ID in the URL and determine if this is an existing document (`getContainer()`) or if we need to create a new one (`createContainer()`).
+When creating a new container, we get its ID from the `container.attach()` call.
 
 ```ts
 export async function start() {
@@ -96,7 +93,8 @@ export async function start() {
 }
 ```
 
-Since `start()` is an async function, we'll need to await for the initialObjects to be returned. Once returned, each `initialObjects` key will point to a connected data structure as defined in the schema.
+Since `start()` is an async function, we'll need to await for the initialObjects to be returned.
+Once returned, each `initialObjects` key will point to a connected data structure as defined in the schema.
 
 ### Running `AzureClient` against local service instance
 
@@ -139,7 +137,10 @@ To keep track of changes made to individual notes, the LetsBrainstorm app makes 
 
 ### Syncing `SharedMap` and View data
 
-The [BrainstormModel](./src/BrainstormModel.ts) defines various functions that are available to a note, including creating and deleting a note, getting likes, moving the note in the note space, changing the note text, and etc. These functions achieve their tasks by making changes to the properties associated with the note. All note properties, such as `noteId`s, `author`, `color`, `postition`, etc, are stored in a `SharedMap` as key-value pairs for easy retrieval. Now, syncing our Fluid and View data requires that we set up an event listener, which mean we need a `useEffect()` hook, defined in [NoteSpace.tsx](./src/view/NoteSpace.tsx).
+The [BrainstormModel](./src/BrainstormModel.ts) defines various functions that are available to a note, including creating and deleting a note, getting likes, moving the note in the note space, changing the note text, and etc.
+These functions achieve their tasks by making changes to the properties associated with the note.
+All note properties, such as `noteId`s, `author`, `color`, `postition`, etc, are stored in a `SharedMap` as key-value pairs for easy retrieval.
+Now, syncing our Fluid and View data requires that we set up an event listener, which mean we need a `useEffect()` hook, defined in [NoteSpace.tsx](./src/view/NoteSpace.tsx).
 
 ```ts
 const [notes, setNotes] = React.useState<readonly NoteData[]>([]);
@@ -232,7 +233,8 @@ React.useEffect(() => {
 
 To sync the data, we created a `setMembersCallback()` function, which retrieves a list of all the active members and convert it to an array, then have a listener keep listening for the "membersChanged" event, and fire the function each time. Now React will handle updating the view each time the new `members` state is modified.
 
-The audience object also has a `getMyself()` function that returns the current client as a member. This is passed in as a view prop so that the user information can be displayed or processed when the user performs different note operations (creating a note, liking a note, and editing a note).
+The audience object also has a `getMyself()` function that returns the current client as a member.
+This is passed in as a view prop so that the user information can be displayed or processed when the user performs different note operations (creating a note, liking a note, and editing a note).
 
 ```ts
 const authorInfo = audience.getMyself();

--- a/brainstorm/README.md
+++ b/brainstorm/README.md
@@ -1,6 +1,7 @@
 # Let's Brainstorm
 
-Brainstorm is an example of using the Fluid Framework to build a collaborative line of business application. In this example each user can create their own sticky notes that are managed on a board.
+Brainstorm is an example of using the Fluid Framework to build a collaborative line of business application.
+In this example each user can create their own sticky notes that are managed on a board.
 
 This application was shown during a [Microsoft Build session](https://aka.ms/OD522).
 
@@ -10,7 +11,7 @@ Follow the steps below to run this in local mode (Azure local service):
 
 1. Run `npm install` from the brainstorm folder root
 2. Run `npm run start:server` to start the Azure local service for testing and development
-3. Run `npm run start` to start the client
+3. Run `npm start` to start the client
 4. Navigate to `http://localhost:3000` in a browser tab
 
 <br />
@@ -42,12 +43,9 @@ This package is based on the [Create React App](https://reactjs.org/docs/create-
 ## Using the Brainstorm App
 
 1. Navigate to `http://localhost:3000`
-
-You'll be taken to a url similar to `http://localhost:3000/**#1621961220840**` the path `#1621961220840` specifies one brainstorm document.
-
-2. Navigate to the same url in another window or tab
-
-Now you can create notes, write text, change colors and more!
+    - You'll be taken to a URL similar to `http://localhost:3000/**#1621961220840**` the path `#1621961220840` specifies one brainstorm document.
+2. Navigate to the same URL in another window or tab
+    - Now you can create notes, write text, change colors and more!
 
 ## Connecting to the Service
 

--- a/brainstorm/package-lock.json
+++ b/brainstorm/package-lock.json
@@ -6161,9 +6161,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001429",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001429.tgz",
-			"integrity": "sha512-511ThLu1hF+5RRRt0zYCf2U2yRr9GPF6m5y90SBCWsvSoYoW7yAGlv/elyPaNfvGCkp6kj/KFZWU0BMA69Prsg==",
+			"version": "1.0.30001486",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
+			"integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg==",
 			"dev": true
 		},
 		"capture-exit": {

--- a/brainstorm/src/view/BrainstormView.tsx
+++ b/brainstorm/src/view/BrainstormView.tsx
@@ -13,7 +13,10 @@ export const BrainstormView = (props: {
 	services: AzureContainerServices;
 }) => {
 	const { container, services } = props;
-	const [model] = React.useState<BrainstormModel>(createBrainstormModel(container));
+	const model: BrainstormModel = React.useMemo(
+		() => createBrainstormModel(container),
+		[container],
+	);
 
 	const audience = services.audience;
 	// retrieve all the members currently in the session

--- a/build.yml
+++ b/build.yml
@@ -31,9 +31,6 @@ parameters:
   - name: react-starter-template
     type: string
     default: react-starter-template
-  # - name: teams-fluid-hello-world
-  #   type: string
-  #   default: teams-fluid-hello-world
 
 trigger:
   - main

--- a/collaborative-text-area/package-lock.json
+++ b/collaborative-text-area/package-lock.json
@@ -6374,9 +6374,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001429",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001429.tgz",
-      "integrity": "sha512-511ThLu1hF+5RRRt0zYCf2U2yRr9GPF6m5y90SBCWsvSoYoW7yAGlv/elyPaNfvGCkp6kj/KFZWU0BMA69Prsg=="
+      "version": "1.0.30001486",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
+      "integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/collaborative-text-area/package.json
+++ b/collaborative-text-area/package.json
@@ -16,12 +16,12 @@
 		"@types/react": "^17.0.34",
 		"@types/react-dom": "^17.0.11",
 		"fluid-framework": "^1.0.1",
+		"prettier": "^2.7.1",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
 		"react-scripts": "4.0.3",
 		"typescript": "^4.5.5",
-		"web-vitals": "^1.1.2",
-		"prettier": "^2.7.1"
+		"web-vitals": "^1.1.2"
 	},
 	"devDependencies": {
 		"@fluidframework/build-common": "^1.1.0",

--- a/multi-framework-diceroller/README.md
+++ b/multi-framework-diceroller/README.md
@@ -2,11 +2,16 @@
 
 This repository contains a simple app that enables all connected clients to roll a dice and view the result, and demonstrates how that dice can be rendered in multiple UI frameworks.
 
-## Requirements
-
-Node 12.17+
-
 ## Getting started
+
+To run an Azure Client service locally, on the default values of `localhost:7070`, enter the following into a terminal window:
+
+```bash
+npx tinylicious
+```
+
+With the local service running in the background, we need to connect the application to it.
+Run the following commands in a new terminal window to start the app. Navigate to `localhost:3000` in the browser to view the app.
 
 ```bash
 npm install

--- a/multi-framework-diceroller/jest-puppeteer.config.js
+++ b/multi-framework-diceroller/jest-puppeteer.config.js
@@ -11,7 +11,7 @@ module.exports = {
         args: ["--disable-setuid-sandbox", "--no-sandbox"],
     },
     server: {
-        command: "npm run start:client",
+        command: "npm run start",
         port: 8080,
         launchTimeout: 100000,
         debug: true,

--- a/multi-framework-diceroller/package-lock.json
+++ b/multi-framework-diceroller/package-lock.json
@@ -5259,34 +5259,6 @@
                 "typedarray": "^0.0.6"
             }
         },
-        "concurrently": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-5.3.0.tgz",
-            "integrity": "sha512-8MhqOB6PWlBfA2vJ8a0bSFKATOdWlHiQlk11IfmQBPaHVP8oP2gsh2MObE6UR3hqDHqvaIvLTyceNW6obVuFHQ==",
-            "dev": true,
-            "requires": {
-                "chalk": "^2.4.2",
-                "date-fns": "^2.0.1",
-                "lodash": "^4.17.15",
-                "read-pkg": "^4.0.1",
-                "rxjs": "^6.5.2",
-                "spawn-command": "^0.0.2-1",
-                "supports-color": "^6.1.0",
-                "tree-kill": "^1.2.2",
-                "yargs": "^13.3.0"
-            },
-            "dependencies": {
-                "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
-            }
-        },
         "connect-history-api-fallback": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
@@ -5558,12 +5530,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
             "integrity": "sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A==",
-            "dev": true
-        },
-        "date-fns": {
-            "version": "2.29.3",
-            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-            "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
             "dev": true
         },
         "debug": {
@@ -7244,12 +7210,6 @@
             "requires": {
                 "parse-passwd": "^1.0.0"
             }
-        },
-        "hosted-git-info": {
-            "version": "2.8.9",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-            "dev": true
         },
         "hpack.js": {
             "version": "2.1.6",
@@ -10930,26 +10890,6 @@
             "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
             "dev": true
         },
-        "normalize-package-data": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-            "dev": true,
-            "requires": {
-                "hosted-git-info": "^2.1.4",
-                "resolve": "^1.10.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-                    "dev": true
-                }
-            }
-        },
         "normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -11257,16 +11197,6 @@
                 "evp_bytestokey": "^1.0.0",
                 "pbkdf2": "^3.0.3",
                 "safe-buffer": "^5.1.1"
-            }
-        },
-        "parse-json": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-            "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
-            "dev": true,
-            "requires": {
-                "error-ex": "^1.3.1",
-                "json-parse-better-errors": "^1.0.1"
             }
         },
         "parse-passwd": {
@@ -11844,25 +11774,6 @@
             "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
             "dev": true
         },
-        "read-pkg": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
-            "integrity": "sha512-+UBirHHDm5J+3WDmLBZYSklRYg82nMlz+enn+GMZ22nSR2f4bzxmhso6rzQW/3mT2PVzpzDTiYIZahk8UmZ44w==",
-            "dev": true,
-            "requires": {
-                "normalize-package-data": "^2.3.2",
-                "parse-json": "^4.0.0",
-                "pify": "^3.0.0"
-            },
-            "dependencies": {
-                "pify": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
-                    "dev": true
-                }
-            }
-        },
         "readable-stream": {
             "version": "2.3.7",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -12180,15 +12091,6 @@
             "dev": true,
             "requires": {
                 "aproba": "^1.1.1"
-            }
-        },
-        "rxjs": {
-            "version": "6.6.7",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-            "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-            "dev": true,
-            "requires": {
-                "tslib": "^1.9.0"
             }
         },
         "safe-buffer": {
@@ -12822,12 +12724,6 @@
             "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
             "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
         },
-        "spawn-command": {
-            "version": "0.0.2-1",
-            "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-            "integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
-            "dev": true
-        },
         "spawnd": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-6.0.2.tgz",
@@ -12838,38 +12734,6 @@
                 "signal-exit": "^3.0.6",
                 "tree-kill": "^1.2.2"
             }
-        },
-        "spdx-correct": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-            "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
-            "dev": true,
-            "requires": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "spdx-exceptions": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-            "dev": true
-        },
-        "spdx-expression-parse": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-            "dev": true,
-            "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "spdx-license-ids": {
-            "version": "3.0.12",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
-            "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
-            "dev": true
         },
         "spdy": {
             "version": "4.0.2",
@@ -13716,12 +13580,6 @@
             "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==",
             "dev": true
         },
-        "tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
-        },
         "tty-browserify": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -14043,16 +13901,6 @@
                 "@jridgewell/trace-mapping": "^0.3.12",
                 "@types/istanbul-lib-coverage": "^2.0.1",
                 "convert-source-map": "^1.6.0"
-            }
-        },
-        "validate-npm-package-license": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-            "dev": true,
-            "requires": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
             }
         },
         "vary": {

--- a/multi-framework-diceroller/package.json
+++ b/multi-framework-diceroller/package.json
@@ -8,14 +8,14 @@
     "scripts": {
         "build": "webpack --env prod --env clean",
         "build:dev": "webpack --env clean",
-        "start": "webpack serve",
-        "start:server": "npx tinylicious",
-        "test:report": "start-server-and-test start:server 7070 jest",
         "format": "npm run prettier:fix",
         "lint": "npm run prettier",
         "lint:fix": "npm run prettier:fix",
         "prettier": "prettier --check . --ignore-path ./.prettierignore",
-        "prettier:fix": "prettier --write . --ignore-path ./.prettierignore"
+        "prettier:fix": "prettier --write . --ignore-path ./.prettierignore",
+        "start": "webpack serve",
+        "start:server": "npx tinylicious",
+        "test:report": "start-server-and-test start:server 7070 jest"
     },
     "dependencies": {
         "@babel/preset-react": "^7.14.5",

--- a/multi-framework-diceroller/package.json
+++ b/multi-framework-diceroller/package.json
@@ -8,8 +8,7 @@
     "scripts": {
         "build": "webpack --env prod --env clean",
         "build:dev": "webpack --env clean",
-        "start": "concurrently \"npm:start:server\" \"npm:start:client\"",
-        "start:client": "webpack serve",
+        "start": "webpack serve",
         "start:server": "npx tinylicious",
         "test:report": "start-server-and-test start:server 7070 jest",
         "format": "npm run prettier:fix",
@@ -32,7 +31,6 @@
         "@fluidframework/build-common": "^1.1.0",
         "babel-loader": "^8.2.2",
         "clean-webpack-plugin": "^3.0.0",
-        "concurrently": "^5.3.0",
         "html-webpack-plugin": "^4.3.0",
         "jest": "^29.2.2",
         "jest-puppeteer": "^6.1.1",

--- a/node-demo/README.md
+++ b/node-demo/README.md
@@ -4,7 +4,7 @@ This repository contains a simple NodeJS application connected with the Fluid Fr
 
 ## Getting started
 
-Run Tinylicious server in the backgroud:
+Run Tinylicious server in the background:
 
 ```sh
 npm run start:server

--- a/node-demo/README.md
+++ b/node-demo/README.md
@@ -1,19 +1,21 @@
 # @fluid-example/node-demo
 
-This repository contains a simple NodeJS application connected with the Fluid Framework. Connected clients generate random numbers and display the result of any changes to the shared state.
+This repository contains a simple NodeJS application connected with the Fluid Framework.
+Connected clients generate random numbers and display the result of any changes to the shared state.
 
 ## Getting started
 
 Run Tinylicious server in the background:
 
-```sh
-npm run start:server
+```bash
+npx tinylicious
 ```
 
 Open a new terminal and run the client:
 
-```sh
-npm run start:client
+```bash
+npm install
+npm start
 ```
 
 To create a new Fluid container press Enter. The container id will be printed in the terminal. Copy the container id, launch a new terminal window, and type/paste the initial container id to have multiple collaborative NodeJS clients.

--- a/node-demo/package-lock.json
+++ b/node-demo/package-lock.json
@@ -519,9 +519,9 @@
 			}
 		},
 		"@sideway/formula": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-			"integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+			"integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
 			"dev": true
 		},
 		"@sideway/pinpoint": {

--- a/node-demo/package.json
+++ b/node-demo/package.json
@@ -5,7 +5,7 @@
 	"main": "./src/index.js",
 	"scripts": {
 		"build": "npm build",
-		"start:client": "node ./src/index.js",
+		"start": "node ./src/index.js",
 		"start:server": "npx tinylicious@latest",
 		"test": "mocha --timeout 20000 ./test/*.test.js",
 		"test:report": "start-server-and-test start:server 7070 test",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
+      "integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
       "requires": {
         "@babel/highlight": "^7.18.6"
       }
@@ -199,9 +199,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "has-flag": {
       "version": "4.0.0",

--- a/react-demo/README.md
+++ b/react-demo/README.md
@@ -15,22 +15,22 @@ Concepts you will learn:
 
 In this example you will do the following:
 
-- [@fluid-example/react-demo](#fluid-examplereact-demo)
-	- [Demo introduction](#demo-introduction)
-	- [Use Create React App](#use-create-react-app)
-		- [Using NPM](#using-npm)
-		- [Using Yarn](#using-yarn)
-		- [Start the app](#start-the-app)
-	- [Install Fluid package dependencies](#install-fluid-package-dependencies)
-		- [Using NPM](#using-npm-1)
-		- [Using Yarn](#using-yarn-1)
-	- [Import and initialize Fluid dependencies](#import-and-initialize-fluid-dependencies)
-		- [Configure the service client](#configure-the-service-client)
-	- [Get the Fluid `SharedMap`](#get-the-fluid-sharedmap)
-		- [Get the SharedMap on load](#get-the-sharedmap-on-load)
-		- [Sync Fluid and view data](#sync-fluid-and-view-data)
-	- [Update the view](#update-the-view)
-	- [Next steps](#next-steps)
+-   [@fluid-example/react-demo](#fluid-examplereact-demo)
+    -   [Demo introduction](#demo-introduction)
+    -   [Use Create React App](#use-create-react-app)
+        -   [Using NPM](#using-npm)
+        -   [Using Yarn](#using-yarn)
+        -   [Start the app](#start-the-app)
+    -   [Install Fluid package dependencies](#install-fluid-package-dependencies)
+        -   [Using NPM](#using-npm-1)
+        -   [Using Yarn](#using-yarn-1)
+    -   [Import and initialize Fluid dependencies](#import-and-initialize-fluid-dependencies)
+        -   [Configure the service client](#configure-the-service-client)
+    -   [Get the Fluid `SharedMap`](#get-the-fluid-sharedmap)
+        -   [Get the SharedMap on load](#get-the-sharedmap-on-load)
+        -   [Sync Fluid and view data](#sync-fluid-and-view-data)
+    -   [Update the view](#update-the-view)
+    -   [Next steps](#next-steps)
 
 ## Use Create React App
 

--- a/react-demo/README.md
+++ b/react-demo/README.md
@@ -15,12 +15,22 @@ Concepts you will learn:
 
 In this example you will do the following:
 
--   [Use Create React App](#use-create-react-app)
--   [Install Fluid package dependencies](#install-fluid-package-dependencies)
--   [Import and initialize Fluid dependencies](#import-and-initialize-fluid-dependencies)
--   [Get the Fluid SharedMap](#get-the-fluid-sharedmap)
--   [Update the view](#update-the-view)
--   [Next steps](#next-steps)
+- [@fluid-example/react-demo](#fluid-examplereact-demo)
+	- [Demo introduction](#demo-introduction)
+	- [Use Create React App](#use-create-react-app)
+		- [Using NPM](#using-npm)
+		- [Using Yarn](#using-yarn)
+		- [Start the app](#start-the-app)
+	- [Install Fluid package dependencies](#install-fluid-package-dependencies)
+		- [Using NPM](#using-npm-1)
+		- [Using Yarn](#using-yarn-1)
+	- [Import and initialize Fluid dependencies](#import-and-initialize-fluid-dependencies)
+		- [Configure the service client](#configure-the-service-client)
+	- [Get the Fluid `SharedMap`](#get-the-fluid-sharedmap)
+		- [Get the SharedMap on load](#get-the-sharedmap-on-load)
+		- [Sync Fluid and view data](#sync-fluid-and-view-data)
+	- [Update the view](#update-the-view)
+	- [Next steps](#next-steps)
 
 ## Use Create React App
 
@@ -49,7 +59,8 @@ npx tinylicious
 Open up a new terminal tab and start up our React app
 
 ```bash
-npm run start
+npm install
+npm start
 ```
 
 ## Install Fluid package dependencies
@@ -76,7 +87,8 @@ Lastly, open up the `App.js` file, as that will be the only file edited.
 
 ## Import and initialize Fluid dependencies
 
-`TinyliciousClient` is a client for `Tinylicious`, a local Fluid server used for testing our application. The client will include a method for creating a [Fluid container]({{< relref "containers.md" >}}) with a set of initial [DDSes]({{< relref "dds.md" >}}) or [shared objects]({{< relref "glossary.md#shared-objects" >}}) that are defined in the `containerSchema`.
+`TinyliciousClient` is a client for `Tinylicious`, a local Fluid server used for testing our application.
+The client will include a method for creating a [Fluid Container](https://fluidframework.com/docs/build/containers) with a set of initial [DDSes](https://fluidframework.com/docs/build/dds) or [shared objects](https://fluidframework.com/docs/glossary/#shared-object) that are defined in the `containerSchema`.
 
 > The Fluid container interacts with the processes and distributes operations, manages the lifecycle of Fluid objects, and provides a request API for accessing Fluid objects.
 
@@ -116,7 +128,9 @@ const timeKey = "time-key";
 
 ## Get the Fluid `SharedMap`
 
-Fluid applications can be loaded in one of two states, creating or loading. This demo differentiates these states by the presence, or absence of a hash string (`localhost:3000/#abc`), which will also serves as the container `id`. The function below will return the `myMap` SharedMap, defined above, from either a new container, or an existing container, based on the presence of a hash long enough to include an `id` value.
+Fluid applications can be loaded in one of two states, creating or loading.
+This demo differentiates these states by the presence, or absence of a hash string (`localhost:3000/#abc`), which will also serves as the container `id`.
+The function below will return the `myMap` SharedMap, defined above, from either a new container, or an existing container, based on the presence of a hash long enough to include an `id` value.
 
 ```js
 const getMyMap = async () => {
@@ -152,7 +166,8 @@ React.useEffect(() => {
 
 ### Sync Fluid and view data
 
-Syncing our Fluid and view data requires that the app create an event listener, which is another opportunity for `useEffect`. This second `useEffect` function will return early if `fluidMap` is not defined and run again once `fluidMap` has been set thanks to the added dependency.
+Syncing our Fluid and view data requires that the app create an event listener, which is another opportunity for `useEffect`.
+This second `useEffect` function will return early if `fluidMap` is not defined and run again once `fluidMap` has been set thanks to the added dependency.
 
 To sync the data we're going to create a `syncView` function, call that function once to initialize the view, and then continue calling that function each time the map's "valueChanged" event is raised.
 
@@ -178,9 +193,12 @@ React.useEffect(() => {
 
 ## Update the view
 
-In this simple multi-user app, you are going to build a button that, when pressed, shows the current timestamp. We will store that timestamp in Fluid so that each co-authors will automatically see the most recent timestamp at which any author pressed the button.
+In this simple multi-user app, you are going to build a button that, when pressed, shows the current timestamp.
+We will store that timestamp in Fluid so that each co-authors will automatically see the most recent timestamp at which any author pressed the button.
 
-To make sure the app does not render too soon, it returns a blank `<div />` until the `viewData` is defined. Once that's done, it renders a button that sets the `timeKey` key in `myMap` to the current timestamp. Each time this button is pressed, every user will see the latest value stored in the `time` state variable.
+To make sure the app does not render too soon, it returns a blank `<div />` until the `viewData` is defined.
+Once that's done, it renders a button that sets the `timeKey` key in `myMap` to the current timestamp.
+Each time this button is pressed, every user will see the latest value stored in the `time` state variable.
 
 ```jsx
 // update the App return
@@ -198,7 +216,8 @@ return (
 );
 ```
 
-When the app loads it will update the URL. Copy that new URL into a second browser and note that if you click the button in one browser, the other browser updates as well.
+When the app loads it will update the URL.
+Copy that new URL into a second browser and note that if you click the button in one browser, the other browser updates as well.
 
 ![react-demo](https://user-images.githubusercontent.com/1434956/111496992-faf2dc00-86fd-11eb-815d-5cc539d8f3c8.gif)
 

--- a/react-demo/package.json
+++ b/react-demo/package.json
@@ -13,15 +13,15 @@
 	"scripts": {
 		"build": "react-scripts build",
 		"eject": "react-scripts eject",
-		"start": "react-scripts start",
-		"start:server": "npx tinylicious",
-		"test": "react-scripts test",
-		"test:report": "start-server-and-test start:server 7070 jest",
 		"format": "npm run prettier:fix",
 		"lint": "npm run prettier",
 		"lint:fix": "npm run prettier:fix",
 		"prettier": "prettier --check . --ignore-path ./.prettierignore",
-		"prettier:fix": "prettier --write . --ignore-path ./.prettierignore"
+		"prettier:fix": "prettier --write . --ignore-path ./.prettierignore",
+		"start": "react-scripts start",
+		"start:server": "npx tinylicious",
+		"test": "react-scripts test",
+		"test:report": "start-server-and-test start:server 7070 jest"
 	},
 	"browserslist": {
 		"production": [

--- a/react-starter-template/README.md
+++ b/react-starter-template/README.md
@@ -42,11 +42,12 @@ In this readme we'll walk you through the following topics:
 
 To run our local server, Tinylicious, on the default values of `localhost:7070`, enter the following into a terminal window:
 
-```
+```bash
 npx tinylicious
 ```
 
-Now, with our local service running in the background, we need to connect the application to it. The app has already been configured to this so now we just need to run the following in a new terminal window to start the app.
+Now, with our local service running in the background, we need to connect the application to it.
+The app has already been configured to this so now we just need to run the following in a new terminal window to start the app:
 
 ```bash
 npm install

--- a/react-starter-template/README.md
+++ b/react-starter-template/README.md
@@ -49,8 +49,8 @@ npx tinylicious
 Now, with our local service running in the background, we need to connect the application to it. The app has already been configured to this so now we just need to run the following in a new terminal window to start the app.
 
 ```bash
-npm i
-npm run start
+npm install
+npm start
 ```
 
 ## Modifying the model

--- a/react-starter-template/package-lock.json
+++ b/react-starter-template/package-lock.json
@@ -6804,9 +6804,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001486",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
-			"integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg=="
+			"version": "1.0.30001429",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001429.tgz",
+			"integrity": "sha512-511ThLu1hF+5RRRt0zYCf2U2yRr9GPF6m5y90SBCWsvSoYoW7yAGlv/elyPaNfvGCkp6kj/KFZWU0BMA69Prsg=="
 		},
 		"capture-exit": {
 			"version": "2.0.0",

--- a/react-starter-template/package-lock.json
+++ b/react-starter-template/package-lock.json
@@ -6804,9 +6804,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001429",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001429.tgz",
-			"integrity": "sha512-511ThLu1hF+5RRRt0zYCf2U2yRr9GPF6m5y90SBCWsvSoYoW7yAGlv/elyPaNfvGCkp6kj/KFZWU0BMA69Prsg=="
+			"version": "1.0.30001486",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
+			"integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg=="
 		},
 		"capture-exit": {
 			"version": "2.0.0",


### PR DESCRIPTION
This PR includes misc. cleanup done while verifying all of the apps are working as intended. They include:

* package-lock updates
* Misc. documentation improvements (mostly formatting)
* Updating package app start flows to ensure all packages use the same flow (`npx tinylicious` in one terminal, `npm install` and `npm start` in another).
* Fix a potential bug in `BrainstormView` where React state was not correctly updated when dependency (container) changed. Fix is to use `useMemo` in place of `useState`.