### PR TITLE
Increase Timeouts

### DIFF
--- a/audience-demo/jest.config.js
+++ b/audience-demo/jest.config.js
@@ -9,7 +9,7 @@ module.exports = {
 		URL: "http://localhost:3000",
 	},
 	verbose: true,
-	testTimeout: 30000,
+	testTimeout: 100000,
 	transform: {
 		"^.+\\.jsx?$": "babel-jest",
 	},

--- a/collaborative-text-area/jest.config.js
+++ b/collaborative-text-area/jest.config.js
@@ -9,7 +9,7 @@ module.exports = {
 		URL: "http://localhost:3000",
 	},
 	verbose: true,
-	testTimeout: 20000,
+	testTimeout: 60000,
 	transform: {
 		"^.+\\.tsx?$": "babel-jest",
 	},


### PR DESCRIPTION
Tests seems to be non-deterministically timing out often enough that most CI runs fail.

This is an attempt to get CI to pass with no unrelated changes.