### PR TITLE
Only support Node 18 and newer

### DIFF
--- a/angular-demo/package-lock.json
+++ b/angular-demo/package-lock.json
@@ -28,7 +28,7 @@
 				"@angular/compiler-cli": "~13.3.11",
 				"@fluidframework/build-common": "^1.1.0",
 				"@types/debug": "^4.1.7",
-				"@types/node": "^16.18.38",
+				"@types/node": "^18.0.0",
 				"jest": "^29.3.0",
 				"jest-junit": "^10.0.0",
 				"jest-puppeteer": "^6.1.1",
@@ -5328,9 +5328,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "16.18.46",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.46.tgz",
-			"integrity": "sha512-Mnq3O9Xz52exs3mlxMcQuA7/9VFe/dXcrgAyfjLkABIqxXKOgBRjyazTxUbjsxDa4BP7hhPliyjVTP9RDP14xg==",
+			"version": "18.17.16",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.16.tgz",
+			"integrity": "sha512-e0zgs7qe1XH/X3KEPnldfkD07LH9O1B9T31U8qoO7lqGSjj3/IrBuvqMeJ1aYejXRK3KOphIUDw6pLIplEW17A==",
 			"dev": true
 		},
 		"node_modules/@types/parse-json": {

--- a/angular-demo/package.json
+++ b/angular-demo/package.json
@@ -42,7 +42,7 @@
 		"@angular/compiler-cli": "~13.3.11",
 		"@fluidframework/build-common": "^1.1.0",
 		"@types/debug": "^4.1.7",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.0.0",
 		"jest": "^29.3.0",
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^6.1.1",

--- a/brainstorm/package-lock.json
+++ b/brainstorm/package-lock.json
@@ -26,7 +26,7 @@
 				"@testing-library/jest-dom": "^5.11.4",
 				"@testing-library/react": "^11.1.0",
 				"@testing-library/user-event": "^12.1.10",
-				"@types/node": "^16.18.38",
+				"@types/node": "^18.0.0",
 				"@types/react": "^16.9.15",
 				"@types/react-dom": "^16.9.4",
 				"@types/uuid": "^8.3.0",
@@ -40,7 +40,7 @@
 				"typescript": "~4.5.5"
 			},
 			"engines": {
-				"node": ">=16.18.38"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -6137,9 +6137,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "16.18.46",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.46.tgz",
-			"integrity": "sha512-Mnq3O9Xz52exs3mlxMcQuA7/9VFe/dXcrgAyfjLkABIqxXKOgBRjyazTxUbjsxDa4BP7hhPliyjVTP9RDP14xg==",
+			"version": "18.17.16",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.16.tgz",
+			"integrity": "sha512-e0zgs7qe1XH/X3KEPnldfkD07LH9O1B9T31U8qoO7lqGSjj3/IrBuvqMeJ1aYejXRK3KOphIUDw6pLIplEW17A==",
 			"devOptional": true
 		},
 		"node_modules/@types/parse-json": {

--- a/brainstorm/package.json
+++ b/brainstorm/package.json
@@ -52,7 +52,7 @@
 		]
 	},
 	"engines": {
-		"node": ">=16.18.38"
+		"node": ">=18.0.0"
 	},
 	"dependencies": {
 		"@fluentui/react": "^8.71.0",
@@ -72,7 +72,7 @@
 		"@testing-library/jest-dom": "^5.11.4",
 		"@testing-library/react": "^11.1.0",
 		"@testing-library/user-event": "^12.1.10",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.0.0",
 		"@types/react": "^16.9.15",
 		"@types/react-dom": "^16.9.4",
 		"@types/uuid": "^8.3.0",

--- a/collaborative-text-area/package-lock.json
+++ b/collaborative-text-area/package-lock.json
@@ -20,7 +20,7 @@
 				"@fluidframework/build-common": "^2.0.0",
 				"@testing-library/react": "^11.2.7",
 				"@testing-library/user-event": "^12.8.3",
-				"@types/node": "^16.18.38",
+				"@types/node": "^18.0.0",
 				"@types/react": "^17.0.34",
 				"@types/react-dom": "^17.0.11",
 				"jest": "^29.2.2",
@@ -33,7 +33,7 @@
 				"typescript": "^4.5.5"
 			},
 			"engines": {
-				"node": ">=16.18.38"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -3248,6 +3248,12 @@
 				"uuid": "^8.3.1"
 			}
 		},
+		"node_modules/@fluidframework/server-memory-orderer/node_modules/@types/node": {
+			"version": "16.18.51",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.51.tgz",
+			"integrity": "sha512-LKA7ZhY30I8PiUOzBzhtnIULQTACpiEpPXLiYMWyS+tPAORf+rmXUadHZXB/KFrFyMjeHeKc1GFvLd+3f7LE3w==",
+			"dev": true
+		},
 		"node_modules/@fluidframework/server-memory-orderer/node_modules/ws": {
 			"version": "7.5.9",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
@@ -3369,6 +3375,12 @@
 				"sillyname": "^0.1.0",
 				"uuid": "^8.3.1"
 			}
+		},
+		"node_modules/@fluidframework/server-services-core/node_modules/@types/node": {
+			"version": "16.18.51",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.51.tgz",
+			"integrity": "sha512-LKA7ZhY30I8PiUOzBzhtnIULQTACpiEpPXLiYMWyS+tPAORf+rmXUadHZXB/KFrFyMjeHeKc1GFvLd+3f7LE3w==",
+			"dev": true
 		},
 		"node_modules/@fluidframework/server-services-shared": {
 			"version": "1.0.1",
@@ -6657,9 +6669,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "16.18.46",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.46.tgz",
-			"integrity": "sha512-Mnq3O9Xz52exs3mlxMcQuA7/9VFe/dXcrgAyfjLkABIqxXKOgBRjyazTxUbjsxDa4BP7hhPliyjVTP9RDP14xg==",
+			"version": "18.17.16",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.16.tgz",
+			"integrity": "sha512-e0zgs7qe1XH/X3KEPnldfkD07LH9O1B9T31U8qoO7lqGSjj3/IrBuvqMeJ1aYejXRK3KOphIUDw6pLIplEW17A==",
 			"dev": true
 		},
 		"node_modules/@types/parse-json": {

--- a/collaborative-text-area/package.json
+++ b/collaborative-text-area/package.json
@@ -8,7 +8,7 @@
 	"author": "Microsoft and contributors",
 	"private": true,
 	"engines": {
-		"node": ">=16.18.38"
+		"node": ">=18.0.0"
 	},
 	"dependencies": {
 		"@fluid-experimental/react-inputs": "^1.3.7",
@@ -22,7 +22,7 @@
 		"@fluidframework/build-common": "^2.0.0",
 		"@testing-library/react": "^11.2.7",
 		"@testing-library/user-event": "^12.8.3",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.0.0",
 		"@types/react": "^17.0.34",
 		"@types/react-dom": "^17.0.11",
 		"jest": "^29.2.2",

--- a/multi-framework-diceroller/package-lock.json
+++ b/multi-framework-diceroller/package-lock.json
@@ -35,7 +35,7 @@
                 "webpack-dev-server": "^4.15.1"
             },
             "engines": {
-                "node": ">=16.18.38"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@ampproject/remapping": {

--- a/multi-framework-diceroller/package.json
+++ b/multi-framework-diceroller/package.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "author": "Microsoft",
     "engines": {
-        "node": ">=16.18.38"
+        "node": ">=18.0.0"
     },
     "scripts": {
         "build": "webpack --env prod --env clean",

--- a/node-demo/package.json
+++ b/node-demo/package.json
@@ -20,7 +20,7 @@
 	},
 	"license": "MIT",
 	"engines": {
-		"node": ">=16.18.38"
+		"node": ">=18.0.0"
 	},
 	"dependencies": {
 		"@fluidframework/tinylicious-client": "^1.3.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "syncpack": "^11.2.1"
       },
       "engines": {
-        "node": ">=16.18.38"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/microsoft/FluidExamples#readme",
   "engines": {
-    "node": ">=16.18.38"
+    "node": ">=18.0.0"
   },
   "devDependencies": {
     "syncpack": "^11.2.1"

--- a/react-demo/package-lock.json
+++ b/react-demo/package-lock.json
@@ -29,7 +29,7 @@
 				"tinylicious": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=16.18.38"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {

--- a/react-demo/package.json
+++ b/react-demo/package.json
@@ -39,7 +39,7 @@
 		]
 	},
 	"engines": {
-		"node": ">=16.18.38"
+		"node": ">=18.0.0"
 	},
 	"dependencies": {
 		"@fluidframework/tinylicious-client": "^1.3.7",

--- a/react-starter-template/package-lock.json
+++ b/react-starter-template/package-lock.json
@@ -25,7 +25,7 @@
 				"@testing-library/react": "^11.2.7",
 				"@testing-library/user-event": "^12.8.3",
 				"@types/jest": "^26.0.23",
-				"@types/node": "^16.18.38",
+				"@types/node": "^18.0.0",
 				"@types/react": "^17.0.9",
 				"@types/react-dom": "^17.0.6",
 				"@types/react-router-dom": "^5.1.7",
@@ -41,7 +41,7 @@
 				"typescript": "^4.5.5"
 			},
 			"engines": {
-				"node": ">=16.18.38"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -3513,6 +3513,12 @@
 				"uuid": "^8.3.1"
 			}
 		},
+		"node_modules/@fluidframework/server-memory-orderer/node_modules/@types/node": {
+			"version": "16.18.51",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.51.tgz",
+			"integrity": "sha512-LKA7ZhY30I8PiUOzBzhtnIULQTACpiEpPXLiYMWyS+tPAORf+rmXUadHZXB/KFrFyMjeHeKc1GFvLd+3f7LE3w==",
+			"dev": true
+		},
 		"node_modules/@fluidframework/server-memory-orderer/node_modules/ws": {
 			"version": "7.5.9",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
@@ -3634,6 +3640,12 @@
 				"sillyname": "^0.1.0",
 				"uuid": "^8.3.1"
 			}
+		},
+		"node_modules/@fluidframework/server-services-core/node_modules/@types/node": {
+			"version": "16.18.51",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.51.tgz",
+			"integrity": "sha512-LKA7ZhY30I8PiUOzBzhtnIULQTACpiEpPXLiYMWyS+tPAORf+rmXUadHZXB/KFrFyMjeHeKc1GFvLd+3f7LE3w==",
+			"dev": true
 		},
 		"node_modules/@fluidframework/server-services-shared": {
 			"version": "1.0.1",
@@ -7115,9 +7127,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "16.18.46",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.46.tgz",
-			"integrity": "sha512-Mnq3O9Xz52exs3mlxMcQuA7/9VFe/dXcrgAyfjLkABIqxXKOgBRjyazTxUbjsxDa4BP7hhPliyjVTP9RDP14xg==",
+			"version": "18.17.16",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.16.tgz",
+			"integrity": "sha512-e0zgs7qe1XH/X3KEPnldfkD07LH9O1B9T31U8qoO7lqGSjj3/IrBuvqMeJ1aYejXRK3KOphIUDw6pLIplEW17A==",
 			"dev": true
 		},
 		"node_modules/@types/parse-json": {

--- a/react-starter-template/package.json
+++ b/react-starter-template/package.json
@@ -23,7 +23,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ./.prettierignore"
 	},
 	"engines": {
-		"node": ">=16.18.38"
+		"node": ">=18.0.0"
 	},
 	"dependencies": {
 		"@fluentui/react": "^8.17.1",
@@ -42,7 +42,7 @@
 		"@testing-library/react": "^11.2.7",
 		"@testing-library/user-event": "^12.8.3",
 		"@types/jest": "^26.0.23",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.0.0",
 		"@types/react": "^17.0.9",
 		"@types/react-dom": "^17.0.6",
 		"@types/react-router-dom": "^5.1.7",


### PR DESCRIPTION
Require at least Node 18.

This removes support for older unsupported major versions of NodeJs.