### PR TITLE
Updating root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To get started, clone the repository and navigate to one of the example folders.
 From the example root, you can install and start the example.
 
 1. Run `npm install` from the example root
-2. Run `npm start server` to start the local server
+2. Run `npm start:server` to start the local server
 3. Run `npm start` to start the client
 
 > For more details see the individual example README.md.

--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ To get started, clone the repository and navigate to one of the example folders.
 From the example root, you can install and start the example.
 
 1. Run `npm install` from the example root
-2. Run `npm run start` to start both the client and server
+2. Run `npm start server` to start the local server
+3. Run `npm start` to start the client
 
 > For more details see the individual example README.md.
 
 ## Contributing
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+This project welcomes contributions and suggestions. Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
 the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ To get started, clone the repository and navigate to one of the example folders.
 From the example root, you can install and start the example.
 
 1. Run `npm install` from the example root
-2. Run `npm start:server` to start the local server
-3. Run `npm start` to start the client
+2. Run `npm run start:server` to start the local server
+3. Run `npm start` in a new terminal window to start the client
 
 > For more details see the individual example README.md.
 

--- a/node-demo/package-lock.json
+++ b/node-demo/package-lock.json
@@ -24,7 +24,7 @@
 				"start-server-and-test": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=16.18.38"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@fluidframework/aqueduct": {


### PR DESCRIPTION
`npm run start` does not start local server for any of the examples. Must run npm start:server first to start local azure service/tinylicious