### PR TITLE
Bump to internal 7.1.0

### DIFF
--- a/angular-demo/package-lock.json
+++ b/angular-demo/package-lock.json
@@ -17,8 +17,8 @@
 				"@angular/platform-browser": "~13.3.11",
 				"@angular/platform-browser-dynamic": "~13.3.11",
 				"@angular/router": "~13.3.11",
-				"@fluidframework/tinylicious-client": "^2.0.0-internal.7.0.0",
-				"fluid-framework": "^2.0.0-internal.7.0.0",
+				"@fluidframework/tinylicious-client": "^2.0.0-internal.7.1.0",
+				"fluid-framework": "^2.0.0-internal.7.1.0",
 				"tslib": "^2.3.0",
 				"zone.js": "~0.11.4"
 			},
@@ -2531,12 +2531,12 @@
 			}
 		},
 		"node_modules/@fluid-internal/client-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-N9NLm6+1pZ4u2kCMYsj0MbOvPhRWd2sWerdtJOVACICYNZjptiKGi9gU8Wf1vWliILKXC4gJmQUWXWOp+E4piQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-CUjL3pjmfpyZ2eRddgpE48b8wjIIDmKL5aiLw6eqoO0HWo2er3kV0nPX8rwMRNA+tuHahz14afLQ+nb0wA5V3A==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@types/events": "^3.0.0",
 				"base64-js": "^1.5.1",
 				"buffer": "^6.0.3",
@@ -2569,24 +2569,24 @@
 			}
 		},
 		"node_modules/@fluidframework/aqueduct": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-oz4JCEHpve0QyfD2+huzeOiGyOpfa+e7wiknQ03iHQPLKVFpiSz1cX5sbr6DFdCovz5Ub90Ot8rneuzMH8F9IA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-c9p0BFGnFwvCewBxjOLiFc1/zZ+ybMRUTij1BgkFuaP/fSnZamKSvecNdhfGvoDcWIDsQPb0gb/wppX3TU21vg==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/synthesize": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/request-handler": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/synthesize": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/view-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -2660,30 +2660,30 @@
 			}
 		},
 		"node_modules/@fluidframework/container-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-OWBJLiXkXZrB2kb9HNcj7BLSyEvzyALCVzZhtTVDd1LT5cUwPPx92fLfLHmLglhnJwW7UK+/UvggjAqNxAlbQA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-zUxrbGbbNwPdT+WDmXz7oeomZuqUzUQqDLAkgxO/qFnwdqh9pBI6nkzuXeGwQEOLScLkDUNRzJwimfKqFmBt2w==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/container-loader": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-lPJwdDR8ZCXRHiLhZzewWVr5jItlQ4MHrMa95wLdGxoPxpkkAMZBYLOLxmsIp7W1QQ6+mHZYw9ECv6B5TojroA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-EbHroDko65kyw92YprxMjBXi61vEVpL+uogZyQ0Jlkfvkor0xiVgtfgwKxFdUy+j6uElzYGonm6jRJMh+ga+6w==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
 				"events": "^3.1.0",
@@ -2705,22 +2705,22 @@
 			}
 		},
 		"node_modules/@fluidframework/container-runtime": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-Ju+58IfRVZeQS5zgk0u6QHq9av0GQABV33BAioKOqtB685a1fbVhgTTPX74KtQlB0MKaXyt0mZNW9oXUkoUSpA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-I1Lf53ZBZtnVpEbwSDaLVwoCGa/CX2vEbv5t/lHLFKrjGmNxzahx1ZWAw46jjg3ZBPEpdiYbwqKpCoRHg44a6A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"double-ended-queue": "^2.1.0-0",
 				"events": "^3.1.0",
 				"lz4js": "^0.2.0",
@@ -2729,15 +2729,15 @@
 			}
 		},
 		"node_modules/@fluidframework/container-runtime-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-ujWp607A5Lg2ZjN8QKYV28LstvGzGXFxXy/2phME4bPOQT9EtPD7uejLbAPVUg7LmJgDFOBQD1VuAI6Vlx92MQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-kC85xUSfrr03+JiUrnnjwJ2PVtcylGt/1UB/b8CWAC4T4P70roqEH48vZbnunjY5yJ7vmzHk7AThrsiGGhN6Sg==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/container-runtime/node_modules/uuid": {
@@ -2753,44 +2753,44 @@
 			}
 		},
 		"node_modules/@fluidframework/core-interfaces": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-znZqbn0ew7aqrnjFf+sfNsnajjZ9z9PHycrfzkVfo6YAW1WKuTi7VmZwUyLGVDIAJ86qlQW4/kI9WL4OypzSFA=="
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-HAqosUcAeyZWr1fQaE2CkR+0aMs3nHCQiDa+XhpQarJKNB6wMkscQ+AgzqxmAH6tX8R5Yz6gaPDEp/zScCepXQ=="
 		},
 		"node_modules/@fluidframework/core-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-nEs40QaYzCBlb0PVG2YFCQU++nsnpdHdkl83ilbtdGlYw37GUS+3vl5UbFqGv3EvRdjl4bu1nXi3Pve0AOESUA=="
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-R9fhUy0OPPFiCBEA+G2kPvKOD2YipkCbpRMNVLC1o0khaadcuB2Ji8xEy/1/bZAkjO+LiiZj49dxTqSxEuSDXA=="
 		},
 		"node_modules/@fluidframework/datastore": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-jpRJ9ArExfNvGcj+ymPq52jSd+KphExV6ryYXGr9T8K2+akSS4ap0G/zzgOSvnxDk69jUev38s9DISr3wLHCVg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-5Rxt2kwHiUv80OjksWVoXOqBfJc5gaRex4o4ALNL2BuTMnewQuQ4OJHzCvLIDGkDSgl0FgHXpoNac9HEAEEi8A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"lodash": "^4.17.21",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/datastore-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-PF/xp9c6C9o2fcmGTdBcfSCSJ6aOnYHdDtTYaFiGtWlFfLm0vfZo04NBkSsIUAvGE0UyOe8m40y6uYs1R5lJiA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-HkLqqhTD1pLEQ6uBgD6GpfQh0q+zbxVURLKIJ808PzUpXUWPK+c4R2+HA+sebQz/CcrO+VYlE+MO7TYct38eog==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/datastore/node_modules/uuid": {
@@ -2806,41 +2806,41 @@
 			}
 		},
 		"node_modules/@fluidframework/driver-base": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-w0uGZGJOcDrjNQDHOs3GurcVak/Ssj9xlWiJZ8sx8U9aq84c+BvTbZpjUb9FViP0JQI6NWVnjIMTW4AqWeeDuw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-5hUfYI7tte0JL+UXADpU03W+k3BG5RPRDlvJCt+4pPMz9yrhtpjR5mHJL0M3WsuY/uACuCAN5Wfe9taHg4HhzA==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-yPsYKh7CPOaYrxmAMMDzKkiTRsy99XX97Wibjr4gjQ5rRgnE8wIMC0Y3PHvRgUwj1pPcZEArFTFnCIxUhs3lvw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-KnN+c3EWDP1jOlQU4horUbNNzfCDWUQdo3bxnYGy46Dfkag//OGUNF85JzHHeWKnPaB/YBcfWc8TuT/TBlcbsQ==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-dyKGoKk/4WFIEujmO+hZJIy8s6E6JV0mVUewkSY/LKdzJ6gZtjOKMyKhoR+jMPcvhq4CoMdSZz+lrh/fAf4sWg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-OnggpLFQBNFh0jLVHC3aZE1P13yat2+nKQlFnKD5gtmkBKbHKqWkrhdyX0xcfpsAHlD8NbStsscYfkz336NIQw==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/gitresources": "^2.0.1",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"axios": "^0.26.0",
 				"lz4js": "^0.2.0",
 				"url": "^0.11.0",
@@ -2860,70 +2860,70 @@
 			}
 		},
 		"node_modules/@fluidframework/fluid-static": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-MCWVw5Bbh1wMvyqolb2vrnRLAt6ETtc+OAhR3IH0VmID0JxG9PxNnAXo1iwj8YlZKMcLWHokcW1PA5wjyChMzw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-o90QGQoIyouZaBc74muLDG3Ny4O0fLZaLvkyA++nsB4lDAPFcsjjq+QQASPPCvwye591Z4jRcWV3ghDZsT6V6g==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/aqueduct": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/aqueduct": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/request-handler": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/gitresources": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-2.0.1.tgz",
-			"integrity": "sha512-N8lHCEkoEE7uLtjo7VMAl7psnuQDYSO2z61dbb4zUSWOVZ6E0cyhjR5N3dZtffhbTq0qPiYYN3Ss5M06Yri6OA=="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-2.0.2.tgz",
+			"integrity": "sha512-v9hI+uT8B5kwFAs+x6naqb7rOAX84r9ixjyIrE7Gqa9sBHIZ8pP9zKqNIdcS+Y14IqGiJYGDmwzM7Km6ThILCw=="
 		},
 		"node_modules/@fluidframework/map": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-ztuF8GgO2c/tZJwHHzbzXQ3UAhAfIQlIE4hW+wGy5txW6yqnvmUjpUDWqunnFp1h36DrNq9ro3RcB/labJf5bQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-OzoNKQ8ic/k+ZJSSieGtxeNLLbluu5H9wWr/6X/AZZV+WdaSAHNOlyD8hgh7Ae+7uRwx9ChfLuCBp1CgOcRS1A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"node_modules/@fluidframework/merge-tree": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-vnfR2ZgaImUvpfqkdyI+d6lEnrM+ioD2+tiHcBemii3q6PSK6+qbtwbFuslAUj/VVKjirIChPQCPwIHNH2nl0A==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-FamAnrAd8SHX2LKdjaKxoyvSX/w6hzoeSRtl9Oz8M89vrjGGT6Vz9s4D2gFaUY1rWhuYXW6aIAaOsmrgYekYoQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/protocol-base": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-2.0.1.tgz",
-			"integrity": "sha512-h/AiwgQhGFfKZaJLebEcvJ0G7j+6FOHwlEyd9nT7BfLp/zdwW63Jd4gA4PsQXmpzurRxskYuoYUKyWJGcO7E0Q==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-2.0.2.tgz",
+			"integrity": "sha512-9AbQ8FuZ5UNZgOWmNaWxs7CH08H9qRYX6OkTUbRXNjdJaFRSCBCkPSA23aHD85EN49UEkkpfoyH1SsQchHuR4Q==",
 			"dependencies": {
 				"@fluidframework/common-utils": "^3.0.0",
-				"@fluidframework/gitresources": "~2.0.1",
+				"@fluidframework/gitresources": "~2.0.2",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"events": "^3.1.0"
 			}
@@ -2942,33 +2942,33 @@
 			"integrity": "sha512-t0jm6u4RX77Fn3rnoxDmavzo26y/JBsNIz5iptnamBgUTOo37i7wXr9VPB8+AjCEd3kcXPyFEoNa8zIEvgOekQ=="
 		},
 		"node_modules/@fluidframework/request-handler": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-I7TZUmiAc0lhD6Y3AeHACXvS4GtIbK5xc+Ph042J7eWZPUgydD50AOH7bXBjuUXdRhF35i1X23vR+UEq0tp95Q==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-lMaxH2tjDT+MFKlatFBvmRbRxpmHgvSAwGXTUILxM5uOW32RURDu3GmgGb+BpGAmXyjKNwLaUgHBONCegK9sQQ==",
 			"dependencies": {
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/routerlicious-driver": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-+O1Omih8k3gLXfClw3A6CFlgNccBkujUBkeW/4t67LXVr2Z3/q4OOqfSmXVEFePyjiJZ0O6mErAXRRJ78euJVA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-NyciUkBlKNmMcy5yvilYsC6pyYExASrjx/3Pg8z5Df950hclLP4JNu1aJdraB9K7WUUuo50Pz75ZFEKHhvOu/g==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/gitresources": "^2.0.1",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"@fluidframework/server-services-client": "^2.0.1",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"socket.io-client": "^4.6.1",
@@ -2989,48 +2989,48 @@
 			}
 		},
 		"node_modules/@fluidframework/runtime-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-uIqvypcpfhBEwmAlKjCvofwsioeJvbo35umWqXsX6qOUp68xrbMsMwDB1C7o4gA6cjiicNTZH4lhbsOUJV67jA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-54g4ORqpZVoKlt2H74KJeDtsZWI2G2MSpUIExOOtPbTfgJYzA7cldCUwR8soAXMLEA+NreHycyR/cwzSJlT6nw==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0"
 			}
 		},
 		"node_modules/@fluidframework/runtime-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-E5oenqEdtNuO5FvbirN2dogltVofqhl9Cqu9d3wZnFonfczuMDgBX5rPcQFp+5B8E5t4YXlKe0V7MXx1j6o+Qw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-Rz/qG/N+GlW3jSfgw4WcVjiaT8sa6KNIgdS4oqcVAM+sLSnTA7SWtn7uga68wtg5J43Rzgb2e9iW39D1S0RofQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/sequence": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-c17zZQjevyoQD4YZFbBXnQSCC47ucsokYcj0NtPKFWj/weF/ha0ZZ4sgIaXNWOLN4WYgOpliGeyNMf33zp9Xog==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-9mnSQ+l6FNcfqIPbsrl1lJP7GiAnc5YwcdN4odRKBXaKRbLBJNS8WGAyYDNmAMHi+kVbGZ0F9eoYH1P6wtNMkQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -3539,13 +3539,13 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-client": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-2.0.1.tgz",
-			"integrity": "sha512-VJrmSHYuvVXZ6VUi8rlSzAoQP7R2D8ohKBISLwD97VH1pyl7leuQ1cos7SFJRriIJySHyzveqrbNw8vYpeJXIg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-2.0.2.tgz",
+			"integrity": "sha512-YbK9Hz2URRJreK1IoZZCOCFrIPNxnayIT3xbu7SfeU8nG9ui6+QyjO1WS58/oTM9+raQCmgZaIfzfENXzpVqZA==",
 			"dependencies": {
 				"@fluidframework/common-utils": "^3.0.0",
-				"@fluidframework/gitresources": "~2.0.1",
-				"@fluidframework/protocol-base": "~2.0.1",
+				"@fluidframework/gitresources": "~2.0.2",
+				"@fluidframework/protocol-base": "~2.0.2",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -4077,21 +4077,21 @@
 			}
 		},
 		"node_modules/@fluidframework/shared-object-base": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-SxvDleS9NhBIpEe0kFVuSOwABuUtxtEDqSTUZWu/4MEVUuaGE3/+NjYXIvJylNQIxtSiMmAg/1uIomi7UG/+HA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-RCM+iQ1kFkSMiUyxe/v7VkLmpfsy6I8kULD7+vbv29ltKFM3YKio3DkmUvPIJICzAlj6QnFdthYS88NTdeyqOQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -4108,21 +4108,21 @@
 			}
 		},
 		"node_modules/@fluidframework/synthesize": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-48XxrYddsePCDA34w4YJhoSiNQ1c5QcgEV+LNmz7yvFXWlnWQGwxpvDoVFZnu5nDShVyrtfQVaOwuXe0bOEAVQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-kMrDLm8k8WmB3W3iEYxsYxfo0b5gHSFcZIfkNhP5QXenPAPbzCmvIaJg2Zo8rxY+grymfOpvlXW8bf9G/IBbVw==",
 			"dependencies": {
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/telemetry-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-1oZhXUBA05i+OYD0huPYhmDxVE/P58HaKoaVundSu1zsu7h2sel+xPE7cUpKVl74PIu5gjDgQeVM6bClNjPlFw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-0Din0dxWTBKXGRAvBuxPeV6t5yg3jTbCFWlv4o6tPRrqNRGuOrzvb7lrEoJ21kcTLQRdnGISefdO8LLJZ7zUeQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"debug": "^4.1.1",
 				"events": "^3.1.0",
@@ -4142,22 +4142,22 @@
 			}
 		},
 		"node_modules/@fluidframework/tinylicious-client": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-hmAt4z16KaYKHntM8BWpZdXV9B/sqJhgwUZnFVej17Lew6ZwagJ13OH5WUirdREW4O0ewzs9k8HEMMUZi1vReg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-7S9Hn/JIlQ2sn8c/l194P1a1HIjNPO9M6p0WZbWtq+CSR0hNT4+MZSlvKfwbwO1x9toT3jO1Yn+XEOQWouYD3g==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/fluid-static": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -4174,16 +4174,15 @@
 			}
 		},
 		"node_modules/@fluidframework/tinylicious-driver": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-ILIi5Mt7e+PZTat5wFyT6acU4j8wfKcs+lyZakpzC5RA1TRcfgV7kYihsBcbiFUMRxPERawg9nSQcHwAeTqhPA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-jjvk3f2NXimgKfZKlkAxZZdNhr4zMVF9ToF2PTO+9kXEco8hRdWMTKJUltQjbx+KJ0AFAA477v2H6IiCCFN2QA==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/server-services-client": "^2.0.1",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^9.0.0"
 			}
@@ -4201,11 +4200,11 @@
 			}
 		},
 		"node_modules/@fluidframework/view-interfaces": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-GyCbK0GUHOr5dAfPfW4DwUmLBlPmQ42gEf28i2s5iuIqFe0GApdxNd+Al0YGzRDsNB8JwRbHjFjwraV1ebgTUQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-St867vvX3iHKzZSrmbCCrDgWlP7VxWhTUzUcFA9/Xr404HWl1Zy88E9Rd2oxw3/ass2biyAuUPppElIFh+0MzQ==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@gar/promisify": {
@@ -9302,16 +9301,16 @@
 			}
 		},
 		"node_modules/fluid-framework": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-rlSS3mDBgal/TWyFLBQWTNyxxDGlJKxsx2BHAkp0ULQVYzldebRI8uIuYuwGDHG0f4/IFy2zjgrve1vzXN3pJQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-7gEXLH8CqirQlsbSo3AL33xB9PXOoEIzmntx5pDLfmoMaJigEewSOLBhviss3TSL8oJ7elM4DlkXxjqA6EGt0g==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/sequence": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/fluid-static": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/sequence": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/fn.name": {

--- a/angular-demo/package-lock.json
+++ b/angular-demo/package-lock.json
@@ -26,7 +26,7 @@
 				"@angular-devkit/build-angular": "~13.3.9",
 				"@angular/cli": "~13.3.9",
 				"@angular/compiler-cli": "~13.3.11",
-				"@fluidframework/build-common": "^2.0.0-151899",
+				"@fluidframework/build-common": "^2.0.2",
 				"@types/debug": "^4.1.7",
 				"@types/node": "^18.0.0",
 				"jest": "^29.3.0",
@@ -2603,9 +2603,9 @@
 			}
 		},
 		"node_modules/@fluidframework/build-common": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.0.tgz",
-			"integrity": "sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.2.tgz",
+			"integrity": "sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==",
 			"dev": true,
 			"bin": {
 				"gen-version": "bin/gen-version"

--- a/angular-demo/package.json
+++ b/angular-demo/package.json
@@ -31,8 +31,8 @@
 		"@angular/platform-browser": "~13.3.11",
 		"@angular/platform-browser-dynamic": "~13.3.11",
 		"@angular/router": "~13.3.11",
-		"@fluidframework/tinylicious-client": "^2.0.0-internal.7.0.0",
-		"fluid-framework": "^2.0.0-internal.7.0.0",
+		"@fluidframework/tinylicious-client": "^2.0.0-internal.7.1.0",
+		"fluid-framework": "^2.0.0-internal.7.1.0",
 		"tslib": "^2.3.0",
 		"zone.js": "~0.11.4"
 	},

--- a/angular-demo/package.json
+++ b/angular-demo/package.json
@@ -40,7 +40,7 @@
 		"@angular-devkit/build-angular": "~13.3.9",
 		"@angular/cli": "~13.3.9",
 		"@angular/compiler-cli": "~13.3.11",
-		"@fluidframework/build-common": "^2.0.0-151899",
+		"@fluidframework/build-common": "^2.0.2",
 		"@types/debug": "^4.1.7",
 		"@types/node": "^18.0.0",
 		"jest": "^29.3.0",

--- a/audience-demo/package-lock.json
+++ b/audience-demo/package-lock.json
@@ -16,7 +16,7 @@
 			},
 			"devDependencies": {
 				"@fluidframework/azure-local-service": "^2.0.0-internal.7.1.0",
-				"@fluidframework/build-common": "^2.0.0-151899",
+				"@fluidframework/build-common": "^2.0.2",
 				"@testing-library/jest-dom": "^6.1.3",
 				"@testing-library/react": "^14.0.0",
 				"@testing-library/user-event": "^13.5.0",
@@ -2730,9 +2730,9 @@
 			}
 		},
 		"node_modules/@fluidframework/build-common": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.0.tgz",
-			"integrity": "sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.2.tgz",
+			"integrity": "sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==",
 			"dev": true,
 			"bin": {
 				"gen-version": "bin/gen-version"

--- a/audience-demo/package-lock.json
+++ b/audience-demo/package-lock.json
@@ -8,14 +8,14 @@
 			"name": "@fluid-example/audience-demo",
 			"version": "0.1.0",
 			"dependencies": {
-				"@fluidframework/azure-client": "^2.0.0-internal.7.0.0",
-				"@fluidframework/test-client-utils": "^2.0.0-internal.5.4.2",
-				"fluid-framework": "^2.0.0-internal.7.0.0",
+				"@fluidframework/azure-client": "^2.0.0-internal.7.1.0",
+				"@fluidframework/test-runtime-utils": "^2.0.0-internal.7.1.0",
+				"fluid-framework": "^2.0.0-internal.7.1.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0"
 			},
 			"devDependencies": {
-				"@fluidframework/azure-local-service": "^2.0.0-internal.7.0.0",
+				"@fluidframework/azure-local-service": "^2.0.0-internal.7.1.0",
 				"@fluidframework/build-common": "^2.0.0-151899",
 				"@testing-library/jest-dom": "^6.1.3",
 				"@testing-library/react": "^14.0.0",
@@ -2648,12 +2648,12 @@
 			}
 		},
 		"node_modules/@fluid-internal/client-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-N9NLm6+1pZ4u2kCMYsj0MbOvPhRWd2sWerdtJOVACICYNZjptiKGi9gU8Wf1vWliILKXC4gJmQUWXWOp+E4piQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-CUjL3pjmfpyZ2eRddgpE48b8wjIIDmKL5aiLw6eqoO0HWo2er3kV0nPX8rwMRNA+tuHahz14afLQ+nb0wA5V3A==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@types/events": "^3.0.0",
 				"base64-js": "^1.5.1",
 				"buffer": "^6.0.3",
@@ -2663,24 +2663,24 @@
 			}
 		},
 		"node_modules/@fluidframework/aqueduct": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-oz4JCEHpve0QyfD2+huzeOiGyOpfa+e7wiknQ03iHQPLKVFpiSz1cX5sbr6DFdCovz5Ub90Ot8rneuzMH8F9IA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-c9p0BFGnFwvCewBxjOLiFc1/zZ+ybMRUTij1BgkFuaP/fSnZamKSvecNdhfGvoDcWIDsQPb0gb/wppX3TU21vg==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/synthesize": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/request-handler": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/synthesize": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/view-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -2697,30 +2697,30 @@
 			}
 		},
 		"node_modules/@fluidframework/azure-client": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-zsZUFs+zKBCb8a7Q731sMl8OkMu4aa/AdqiVWNBq1QMkwmOQffaXEKG84/yw7S8ybsQpOeoi/0AaRiM1an7cJg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-PwiARzeJo5hiSpLWOb9Ctjn6x7kIuVFtk4wXBEZt8sl1v+tIm8blly6InOODrlnekRImovhC+aVV8s9aHj3wtA==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/fluid-static": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/server-services-client": "^2.0.1",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"axios": "^0.26.0"
 			}
 		},
 		"node_modules/@fluidframework/azure-local-service": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-phMYlQ5OH1DL76Aq6h5KDlFJ9T1oYCTMA8f8jGqbrRq0nPAM6uZTaxcZXJt07fir/aE1rSxURXrQltOvKv6P8w==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-2Awjnpv0Y2Frt/L13f5phPXzo3b7yQCp6MJwX4f+RWoFsmUfW5ycBb/QQVpHTNcL1BXTgWJJ7Rfa5sA4muXcBQ==",
 			"dev": true,
 			"dependencies": {
 				"tinylicious": "^2.0.1"
@@ -2758,30 +2758,30 @@
 			}
 		},
 		"node_modules/@fluidframework/container-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-OWBJLiXkXZrB2kb9HNcj7BLSyEvzyALCVzZhtTVDd1LT5cUwPPx92fLfLHmLglhnJwW7UK+/UvggjAqNxAlbQA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-zUxrbGbbNwPdT+WDmXz7oeomZuqUzUQqDLAkgxO/qFnwdqh9pBI6nkzuXeGwQEOLScLkDUNRzJwimfKqFmBt2w==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/container-loader": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-lPJwdDR8ZCXRHiLhZzewWVr5jItlQ4MHrMa95wLdGxoPxpkkAMZBYLOLxmsIp7W1QQ6+mHZYw9ECv6B5TojroA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-EbHroDko65kyw92YprxMjBXi61vEVpL+uogZyQ0Jlkfvkor0xiVgtfgwKxFdUy+j6uElzYGonm6jRJMh+ga+6w==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
 				"events": "^3.1.0",
@@ -2803,22 +2803,22 @@
 			}
 		},
 		"node_modules/@fluidframework/container-runtime": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-Ju+58IfRVZeQS5zgk0u6QHq9av0GQABV33BAioKOqtB685a1fbVhgTTPX74KtQlB0MKaXyt0mZNW9oXUkoUSpA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-I1Lf53ZBZtnVpEbwSDaLVwoCGa/CX2vEbv5t/lHLFKrjGmNxzahx1ZWAw46jjg3ZBPEpdiYbwqKpCoRHg44a6A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"double-ended-queue": "^2.1.0-0",
 				"events": "^3.1.0",
 				"lz4js": "^0.2.0",
@@ -2827,15 +2827,15 @@
 			}
 		},
 		"node_modules/@fluidframework/container-runtime-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-ujWp607A5Lg2ZjN8QKYV28LstvGzGXFxXy/2phME4bPOQT9EtPD7uejLbAPVUg7LmJgDFOBQD1VuAI6Vlx92MQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-kC85xUSfrr03+JiUrnnjwJ2PVtcylGt/1UB/b8CWAC4T4P70roqEH48vZbnunjY5yJ7vmzHk7AThrsiGGhN6Sg==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/container-runtime/node_modules/uuid": {
@@ -2851,44 +2851,44 @@
 			}
 		},
 		"node_modules/@fluidframework/core-interfaces": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-znZqbn0ew7aqrnjFf+sfNsnajjZ9z9PHycrfzkVfo6YAW1WKuTi7VmZwUyLGVDIAJ86qlQW4/kI9WL4OypzSFA=="
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-HAqosUcAeyZWr1fQaE2CkR+0aMs3nHCQiDa+XhpQarJKNB6wMkscQ+AgzqxmAH6tX8R5Yz6gaPDEp/zScCepXQ=="
 		},
 		"node_modules/@fluidframework/core-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-nEs40QaYzCBlb0PVG2YFCQU++nsnpdHdkl83ilbtdGlYw37GUS+3vl5UbFqGv3EvRdjl4bu1nXi3Pve0AOESUA=="
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-R9fhUy0OPPFiCBEA+G2kPvKOD2YipkCbpRMNVLC1o0khaadcuB2Ji8xEy/1/bZAkjO+LiiZj49dxTqSxEuSDXA=="
 		},
 		"node_modules/@fluidframework/datastore": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-jpRJ9ArExfNvGcj+ymPq52jSd+KphExV6ryYXGr9T8K2+akSS4ap0G/zzgOSvnxDk69jUev38s9DISr3wLHCVg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-5Rxt2kwHiUv80OjksWVoXOqBfJc5gaRex4o4ALNL2BuTMnewQuQ4OJHzCvLIDGkDSgl0FgHXpoNac9HEAEEi8A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"lodash": "^4.17.21",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/datastore-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-PF/xp9c6C9o2fcmGTdBcfSCSJ6aOnYHdDtTYaFiGtWlFfLm0vfZo04NBkSsIUAvGE0UyOe8m40y6uYs1R5lJiA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-HkLqqhTD1pLEQ6uBgD6GpfQh0q+zbxVURLKIJ808PzUpXUWPK+c4R2+HA+sebQz/CcrO+VYlE+MO7TYct38eog==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/datastore/node_modules/uuid": {
@@ -2904,41 +2904,41 @@
 			}
 		},
 		"node_modules/@fluidframework/driver-base": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-w0uGZGJOcDrjNQDHOs3GurcVak/Ssj9xlWiJZ8sx8U9aq84c+BvTbZpjUb9FViP0JQI6NWVnjIMTW4AqWeeDuw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-5hUfYI7tte0JL+UXADpU03W+k3BG5RPRDlvJCt+4pPMz9yrhtpjR5mHJL0M3WsuY/uACuCAN5Wfe9taHg4HhzA==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-yPsYKh7CPOaYrxmAMMDzKkiTRsy99XX97Wibjr4gjQ5rRgnE8wIMC0Y3PHvRgUwj1pPcZEArFTFnCIxUhs3lvw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-KnN+c3EWDP1jOlQU4horUbNNzfCDWUQdo3bxnYGy46Dfkag//OGUNF85JzHHeWKnPaB/YBcfWc8TuT/TBlcbsQ==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-dyKGoKk/4WFIEujmO+hZJIy8s6E6JV0mVUewkSY/LKdzJ6gZtjOKMyKhoR+jMPcvhq4CoMdSZz+lrh/fAf4sWg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-OnggpLFQBNFh0jLVHC3aZE1P13yat2+nKQlFnKD5gtmkBKbHKqWkrhdyX0xcfpsAHlD8NbStsscYfkz336NIQw==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/gitresources": "^2.0.1",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"axios": "^0.26.0",
 				"lz4js": "^0.2.0",
 				"url": "^0.11.0",
@@ -2958,21 +2958,21 @@
 			}
 		},
 		"node_modules/@fluidframework/fluid-static": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-MCWVw5Bbh1wMvyqolb2vrnRLAt6ETtc+OAhR3IH0VmID0JxG9PxNnAXo1iwj8YlZKMcLWHokcW1PA5wjyChMzw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-o90QGQoIyouZaBc74muLDG3Ny4O0fLZaLvkyA++nsB4lDAPFcsjjq+QQASPPCvwye591Z4jRcWV3ghDZsT6V6g==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/aqueduct": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/aqueduct": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/request-handler": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/gitresources": {
@@ -2981,38 +2981,38 @@
 			"integrity": "sha512-N8lHCEkoEE7uLtjo7VMAl7psnuQDYSO2z61dbb4zUSWOVZ6E0cyhjR5N3dZtffhbTq0qPiYYN3Ss5M06Yri6OA=="
 		},
 		"node_modules/@fluidframework/map": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-ztuF8GgO2c/tZJwHHzbzXQ3UAhAfIQlIE4hW+wGy5txW6yqnvmUjpUDWqunnFp1h36DrNq9ro3RcB/labJf5bQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-OzoNKQ8ic/k+ZJSSieGtxeNLLbluu5H9wWr/6X/AZZV+WdaSAHNOlyD8hgh7Ae+7uRwx9ChfLuCBp1CgOcRS1A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"node_modules/@fluidframework/merge-tree": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-vnfR2ZgaImUvpfqkdyI+d6lEnrM+ioD2+tiHcBemii3q6PSK6+qbtwbFuslAUj/VVKjirIChPQCPwIHNH2nl0A==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-FamAnrAd8SHX2LKdjaKxoyvSX/w6hzoeSRtl9Oz8M89vrjGGT6Vz9s4D2gFaUY1rWhuYXW6aIAaOsmrgYekYoQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/protocol-base": {
@@ -3035,33 +3035,33 @@
 			}
 		},
 		"node_modules/@fluidframework/request-handler": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-I7TZUmiAc0lhD6Y3AeHACXvS4GtIbK5xc+Ph042J7eWZPUgydD50AOH7bXBjuUXdRhF35i1X23vR+UEq0tp95Q==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-lMaxH2tjDT+MFKlatFBvmRbRxpmHgvSAwGXTUILxM5uOW32RURDu3GmgGb+BpGAmXyjKNwLaUgHBONCegK9sQQ==",
 			"dependencies": {
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/routerlicious-driver": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-+O1Omih8k3gLXfClw3A6CFlgNccBkujUBkeW/4t67LXVr2Z3/q4OOqfSmXVEFePyjiJZ0O6mErAXRRJ78euJVA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-NyciUkBlKNmMcy5yvilYsC6pyYExASrjx/3Pg8z5Df950hclLP4JNu1aJdraB9K7WUUuo50Pz75ZFEKHhvOu/g==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/gitresources": "^2.0.1",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"@fluidframework/server-services-client": "^2.0.1",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"socket.io-client": "^4.6.1",
@@ -3082,48 +3082,48 @@
 			}
 		},
 		"node_modules/@fluidframework/runtime-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-uIqvypcpfhBEwmAlKjCvofwsioeJvbo35umWqXsX6qOUp68xrbMsMwDB1C7o4gA6cjiicNTZH4lhbsOUJV67jA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-54g4ORqpZVoKlt2H74KJeDtsZWI2G2MSpUIExOOtPbTfgJYzA7cldCUwR8soAXMLEA+NreHycyR/cwzSJlT6nw==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0"
 			}
 		},
 		"node_modules/@fluidframework/runtime-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-E5oenqEdtNuO5FvbirN2dogltVofqhl9Cqu9d3wZnFonfczuMDgBX5rPcQFp+5B8E5t4YXlKe0V7MXx1j6o+Qw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-Rz/qG/N+GlW3jSfgw4WcVjiaT8sa6KNIgdS4oqcVAM+sLSnTA7SWtn7uga68wtg5J43Rzgb2e9iW39D1S0RofQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/sequence": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-c17zZQjevyoQD4YZFbBXnQSCC47ucsokYcj0NtPKFWj/weF/ha0ZZ4sgIaXNWOLN4WYgOpliGeyNMf33zp9Xog==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-9mnSQ+l6FNcfqIPbsrl1lJP7GiAnc5YwcdN4odRKBXaKRbLBJNS8WGAyYDNmAMHi+kVbGZ0F9eoYH1P6wtNMkQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -3532,21 +3532,21 @@
 			}
 		},
 		"node_modules/@fluidframework/shared-object-base": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-SxvDleS9NhBIpEe0kFVuSOwABuUtxtEDqSTUZWu/4MEVUuaGE3/+NjYXIvJylNQIxtSiMmAg/1uIomi7UG/+HA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-RCM+iQ1kFkSMiUyxe/v7VkLmpfsy6I8kULD7+vbv29ltKFM3YKio3DkmUvPIJICzAlj6QnFdthYS88NTdeyqOQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -3563,21 +3563,21 @@
 			}
 		},
 		"node_modules/@fluidframework/synthesize": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-48XxrYddsePCDA34w4YJhoSiNQ1c5QcgEV+LNmz7yvFXWlnWQGwxpvDoVFZnu5nDShVyrtfQVaOwuXe0bOEAVQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-kMrDLm8k8WmB3W3iEYxsYxfo0b5gHSFcZIfkNhP5QXenPAPbzCmvIaJg2Zo8rxY+grymfOpvlXW8bf9G/IBbVw==",
 			"dependencies": {
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/telemetry-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-1oZhXUBA05i+OYD0huPYhmDxVE/P58HaKoaVundSu1zsu7h2sel+xPE7cUpKVl74PIu5gjDgQeVM6bClNjPlFw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-0Din0dxWTBKXGRAvBuxPeV6t5yg3jTbCFWlv4o6tPRrqNRGuOrzvb7lrEoJ21kcTLQRdnGISefdO8LLJZ7zUeQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"debug": "^4.1.1",
 				"events": "^3.1.0",
@@ -3596,278 +3596,47 @@
 				"uuid": "dist/bin/uuid"
 			}
 		},
-		"node_modules/@fluidframework/test-client-utils": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-A0bj4oT5mjO9NBO/smMXuK+ibZPGKLhzqh6m/+lKTqcv+CKgpMj909gj0Dfnf9uuMEVS6VEt+BhvtASR5o2eWg==",
-			"dependencies": {
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/test-client-utils/node_modules/@fluidframework/common-definitions": {
-			"version": "0.20.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-			"integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
-		},
-		"node_modules/@fluidframework/test-client-utils/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
 		"node_modules/@fluidframework/test-runtime-utils": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-z+VnytJXLmW5Mfy1HYyGQTUE5RRPsychaBDCrClfIoOOe1mH8NsiRjbO8AfzWan4lxOklCuFEhj78M67w6fBxA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-9xpfAbPBy2DT9k5Pja7SIbr+UGdZhX45gcBHVXX6kZXDgJmWbbLYBYZVtiFKfu9VZPLn7C5g9njym3xFlhpCXw==",
 			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/protocol-definitions": "^3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"axios": "^0.26.0",
 				"events": "^3.1.0",
 				"jsrsasign": "^10.5.25",
-				"uuid": "^8.3.1"
+				"uuid": "^9.0.0"
 			}
 		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/common-definitions": {
-			"version": "0.20.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-			"integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/container-definitions": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-0+oKYkATmxPtuhWB2ivdSsHY0W6/B93IHO3Ws0amuBegq3IY8VTWw3gghR0vAFOrZV/1qNRIgkJwTn/QWAoiSA==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/container-runtime-definitions": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-qVNCgFat772a2RB4YGDdSwez1vQwHtpDJZPKBpZtAKfiBaihOdqYEcPZLqv6qQ45v7xls+zP3FOWtK3vZm3m6w==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/core-interfaces": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-mMlo6NrWzXbYcpCn9fAM2dHrljFNLDiLgxiR4QNvcGvAtTWpwoUtuHjQDj0KtIBsYiqCzRuinqrCIHgQgubFzA=="
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/core-utils": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-X+VGrq6dGHHWDcMPgSKGvPwG3tIR87/b3xRZSsH3VdPnvd/AGPXdv1/n/jniAZqj+IqfCqP46EFdaMQ+F+F9KA=="
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/datastore-definitions": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-vC14rkXxg7fbIDDcettMEQz2GaXjxVPNzhYnn6HM/VJzGUehdOYnbHTLlhpMPflcb5usOT/UZs/2EqmApwk5AQ==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/driver-base": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-cTjOUwI0pxSAGRuxHNkFPzlnbQtBPqtiM6e3Dky/shrKsN1yBDrWvwvELBOlrV+7v0FJ4/EveyKS3PWSKzXrOA==",
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/driver-definitions": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-co1fPzILKmO0dXwM08HZrzTXoZjOCd7Pu169prNbpVzoJIMs6AJqFqJ3Y4mPL/NyeTLM/P+mNBBauCyYqns5PQ==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/protocol-definitions": "^1.1.0"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/driver-utils": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-UDkJxg5sWd6S/L/pZBZE1oZGJ+sKaPqkMCe2UBVYv8xjyXS/Hd8sp32MBGST11jUs5+RCgI6VGtfgQ36300Awg==",
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/gitresources": "^0.1039.1000",
-				"@fluidframework/protocol-base": "^0.1039.1000",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"axios": "^0.26.0",
-				"lz4js": "^0.2.0",
-				"url": "^0.11.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/gitresources": {
-			"version": "0.1039.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1039.1000.tgz",
-			"integrity": "sha512-O1LAJQL6/TGXZPKHLE8Z8J8KlQ5wpODP+Pj/Q7KvNYWkIUOWepXyq873MobT2adN4hlUdwia4jqif9jaNcIQBA=="
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1039.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1039.1000.tgz",
-			"integrity": "sha512-ohQTfRUugH3oHV1TAU+6KXUmQLZTpWW0EMx6Aa2XJZrd5IGHrJuFTo2RNsfeKKRQmdswbUG1DqrA2O6eJnEtkA==",
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1039.1000",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/routerlicious-driver": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-ZVPs2+xCqTxarQZGkcTNFP62R3Yx7cn5sGH/62qJGcNa0LMlISsT+DThy9sOPxC71VvQpvGFH5r7y+28azYQ7w==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/gitresources": "^0.1039.1000",
-				"@fluidframework/protocol-base": "^0.1039.1000",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1039.1000",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"cross-fetch": "^3.1.5",
-				"json-stringify-safe": "5.0.1",
-				"socket.io-client": "^4.6.1",
-				"url-parse": "^1.5.8",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/runtime-definitions": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-DbGPq2FuzlNYZ9azGcQ3Qfj1adPVgJpYToWGMY8HIHGrTkerD365DZz3IxzCJFEh0kvWVJbyxMsvGgBdNdaHeQ==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/protocol-definitions": "^1.1.0"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/runtime-utils": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-vndWP/46v117tiHmc3U+dtPOeb2b/fhPOGMzqDsas8UFGQWdgspFY40PaspVJJC6r4CVU5XhxGJzfywBhNglsA==",
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1039.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1039.1000.tgz",
-			"integrity": "sha512-wyDH6VdcV5px+sCSAQ/5No/w+T0Mg6M7XZ5bTl/IBN/v05yxFZME3vUCt/zkviZSMYj2MoCkYT3YvD4BHAdrkw==",
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1039.1000",
-				"@fluidframework/protocol-base": "^0.1039.1000",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/telemetry-utils": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-9RiMi4DrMK13m5oz9mv/Yow9Pch5/zadYsyjM0sIaUPM7tWFDl8k+Pv7PrNy4JdQJL/QEQ8ZIv2RGOqikDLFaA==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"uuid": "^8.3.1"
+		"node_modules/@fluidframework/test-runtime-utils/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@fluidframework/view-interfaces": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-GyCbK0GUHOr5dAfPfW4DwUmLBlPmQ42gEf28i2s5iuIqFe0GApdxNd+Al0YGzRDsNB8JwRbHjFjwraV1ebgTUQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-St867vvX3iHKzZSrmbCCrDgWlP7VxWhTUzUcFA9/Xr404HWl1Zy88E9Rd2oxw3/ass2biyAuUPppElIFh+0MzQ==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@hapi/hoek": {
@@ -10610,16 +10379,16 @@
 			"dev": true
 		},
 		"node_modules/fluid-framework": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-rlSS3mDBgal/TWyFLBQWTNyxxDGlJKxsx2BHAkp0ULQVYzldebRI8uIuYuwGDHG0f4/IFy2zjgrve1vzXN3pJQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-7gEXLH8CqirQlsbSo3AL33xB9PXOoEIzmntx5pDLfmoMaJigEewSOLBhviss3TSL8oJ7elM4DlkXxjqA6EGt0g==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/sequence": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/fluid-static": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/sequence": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/fn.name": {
@@ -22616,6 +22385,7 @@
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
 			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"dev": true,
 			"bin": {
 				"uuid": "dist/bin/uuid"
 			}

--- a/audience-demo/package.json
+++ b/audience-demo/package.json
@@ -38,7 +38,7 @@
 	},
 	"devDependencies": {
 		"@fluidframework/azure-local-service": "^2.0.0-internal.7.1.0",
-		"@fluidframework/build-common": "^2.0.0-151899",
+		"@fluidframework/build-common": "^2.0.2",
 		"@testing-library/jest-dom": "^6.1.3",
 		"@testing-library/react": "^14.0.0",
 		"@testing-library/user-event": "^13.5.0",

--- a/audience-demo/package.json
+++ b/audience-demo/package.json
@@ -3,9 +3,9 @@
 	"version": "0.1.0",
 	"private": true,
 	"dependencies": {
-		"@fluidframework/azure-client": "^2.0.0-internal.7.0.0",
-		"@fluidframework/test-client-utils": "^2.0.0-internal.5.4.2",
-		"fluid-framework": "^2.0.0-internal.7.0.0",
+		"@fluidframework/azure-client": "^2.0.0-internal.7.1.0",
+		"@fluidframework/test-runtime-utils": "^2.0.0-internal.7.1.0",
+		"fluid-framework": "^2.0.0-internal.7.1.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0"
 	},
@@ -37,7 +37,7 @@
 		]
 	},
 	"devDependencies": {
-		"@fluidframework/azure-local-service": "^2.0.0-internal.7.0.0",
+		"@fluidframework/azure-local-service": "^2.0.0-internal.7.1.0",
 		"@fluidframework/build-common": "^2.0.0-151899",
 		"@testing-library/jest-dom": "^6.1.3",
 		"@testing-library/react": "^14.0.0",

--- a/audience-demo/src/AudienceDisplay.js
+++ b/audience-demo/src/AudienceDisplay.js
@@ -6,7 +6,7 @@ Licensed under the MIT License.
 import { useEffect, useState } from "react";
 import { SharedMap } from "fluid-framework";
 import { AzureClient } from "@fluidframework/azure-client";
-import { InsecureTokenProvider } from "@fluidframework/test-client-utils";
+import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
 
 /**
  * Load the Fluid container and return the services object so that we can use it later

--- a/brainstorm/README.md
+++ b/brainstorm/README.md
@@ -104,7 +104,7 @@ Once returned, each `initialObjects` key will point to a connected data structur
 
     ```typescript
     import { AzureClient, AzureConnectionConfig } from "@fluidframework/azure-client";
-    import { InsecureTokenProvider } from "@fluidframework/test-client-utils";
+    import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
     const clientProps = {
     	connection: {
     		type: "local",

--- a/brainstorm/package-lock.json
+++ b/brainstorm/package-lock.json
@@ -10,12 +10,12 @@
 			"license": "MIT",
 			"dependencies": {
 				"@fluentui/react": "^8.71.0",
-				"@fluidframework/azure-client": "^2.0.0-internal.7.0.0",
-				"@fluidframework/routerlicious-driver": "^2.0.0-internal.7.0.0",
-				"@fluidframework/test-client-utils": "^2.0.0-internal.5.4.2",
+				"@fluidframework/azure-client": "^2.0.0-internal.7.1.0",
+				"@fluidframework/routerlicious-driver": "^2.0.0-internal.7.1.0",
+				"@fluidframework/test-runtime-utils": "^2.0.0-internal.7.1.0",
 				"axios": "^1.3.6",
 				"cross-env": "^7.0.3",
-				"fluid-framework": "^2.0.0-internal.7.0.0",
+				"fluid-framework": "^2.0.0-internal.7.1.0",
 				"react": "^16.10.2",
 				"react-dnd": "^14.0.2",
 				"react-dnd-html5-backend": "^14.0.0",
@@ -23,7 +23,7 @@
 				"uuid": "^8.3.2"
 			},
 			"devDependencies": {
-				"@fluidframework/azure-local-service": "^2.0.0-internal.7.0.0",
+				"@fluidframework/azure-local-service": "^2.0.0-internal.7.1.0",
 				"@fluidframework/build-common": "^2.0.0-151899",
 				"@testing-library/jest-dom": "^5.11.4",
 				"@testing-library/react": "^11.1.0",
@@ -2682,12 +2682,12 @@
 			}
 		},
 		"node_modules/@fluid-internal/client-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-N9NLm6+1pZ4u2kCMYsj0MbOvPhRWd2sWerdtJOVACICYNZjptiKGi9gU8Wf1vWliILKXC4gJmQUWXWOp+E4piQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-CUjL3pjmfpyZ2eRddgpE48b8wjIIDmKL5aiLw6eqoO0HWo2er3kV0nPX8rwMRNA+tuHahz14afLQ+nb0wA5V3A==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@types/events": "^3.0.0",
 				"base64-js": "^1.5.1",
 				"buffer": "^6.0.3",
@@ -2697,24 +2697,24 @@
 			}
 		},
 		"node_modules/@fluidframework/aqueduct": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-oz4JCEHpve0QyfD2+huzeOiGyOpfa+e7wiknQ03iHQPLKVFpiSz1cX5sbr6DFdCovz5Ub90Ot8rneuzMH8F9IA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-c9p0BFGnFwvCewBxjOLiFc1/zZ+ybMRUTij1BgkFuaP/fSnZamKSvecNdhfGvoDcWIDsQPb0gb/wppX3TU21vg==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/synthesize": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/request-handler": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/synthesize": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/view-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -2731,23 +2731,23 @@
 			}
 		},
 		"node_modules/@fluidframework/azure-client": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-zsZUFs+zKBCb8a7Q731sMl8OkMu4aa/AdqiVWNBq1QMkwmOQffaXEKG84/yw7S8ybsQpOeoi/0AaRiM1an7cJg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-PwiARzeJo5hiSpLWOb9Ctjn6x7kIuVFtk4wXBEZt8sl1v+tIm8blly6InOODrlnekRImovhC+aVV8s9aHj3wtA==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/fluid-static": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/server-services-client": "^2.0.1",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"axios": "^0.26.0"
 			}
 		},
@@ -2773,9 +2773,9 @@
 			}
 		},
 		"node_modules/@fluidframework/azure-local-service": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-phMYlQ5OH1DL76Aq6h5KDlFJ9T1oYCTMA8f8jGqbrRq0nPAM6uZTaxcZXJt07fir/aE1rSxURXrQltOvKv6P8w==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-2Awjnpv0Y2Frt/L13f5phPXzo3b7yQCp6MJwX4f+RWoFsmUfW5ycBb/QQVpHTNcL1BXTgWJJ7Rfa5sA4muXcBQ==",
 			"dev": true,
 			"dependencies": {
 				"tinylicious": "^2.0.1"
@@ -2792,11 +2792,6 @@
 			"bin": {
 				"gen-version": "bin/gen-version"
 			}
-		},
-		"node_modules/@fluidframework/common-definitions": {
-			"version": "0.20.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-			"integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
 		},
 		"node_modules/@fluidframework/common-utils": {
 			"version": "3.0.0",
@@ -2818,12 +2813,12 @@
 			"integrity": "sha512-t0jm6u4RX77Fn3rnoxDmavzo26y/JBsNIz5iptnamBgUTOo37i7wXr9VPB8+AjCEd3kcXPyFEoNa8zIEvgOekQ=="
 		},
 		"node_modules/@fluidframework/container-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-OWBJLiXkXZrB2kb9HNcj7BLSyEvzyALCVzZhtTVDd1LT5cUwPPx92fLfLHmLglhnJwW7UK+/UvggjAqNxAlbQA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-zUxrbGbbNwPdT+WDmXz7oeomZuqUzUQqDLAkgxO/qFnwdqh9pBI6nkzuXeGwQEOLScLkDUNRzJwimfKqFmBt2w==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"events": "^3.1.0"
 			}
@@ -2842,19 +2837,19 @@
 			}
 		},
 		"node_modules/@fluidframework/container-loader": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-lPJwdDR8ZCXRHiLhZzewWVr5jItlQ4MHrMa95wLdGxoPxpkkAMZBYLOLxmsIp7W1QQ6+mHZYw9ECv6B5TojroA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-EbHroDko65kyw92YprxMjBXi61vEVpL+uogZyQ0Jlkfvkor0xiVgtfgwKxFdUy+j6uElzYGonm6jRJMh+ga+6w==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
 				"events": "^3.1.0",
@@ -2889,22 +2884,22 @@
 			}
 		},
 		"node_modules/@fluidframework/container-runtime": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-Ju+58IfRVZeQS5zgk0u6QHq9av0GQABV33BAioKOqtB685a1fbVhgTTPX74KtQlB0MKaXyt0mZNW9oXUkoUSpA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-I1Lf53ZBZtnVpEbwSDaLVwoCGa/CX2vEbv5t/lHLFKrjGmNxzahx1ZWAw46jjg3ZBPEpdiYbwqKpCoRHg44a6A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"double-ended-queue": "^2.1.0-0",
 				"events": "^3.1.0",
 				"lz4js": "^0.2.0",
@@ -2913,15 +2908,15 @@
 			}
 		},
 		"node_modules/@fluidframework/container-runtime-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-ujWp607A5Lg2ZjN8QKYV28LstvGzGXFxXy/2phME4bPOQT9EtPD7uejLbAPVUg7LmJgDFOBQD1VuAI6Vlx92MQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-kC85xUSfrr03+JiUrnnjwJ2PVtcylGt/1UB/b8CWAC4T4P70roqEH48vZbnunjY5yJ7vmzHk7AThrsiGGhN6Sg==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/container-runtime-definitions/node_modules/@fluidframework/common-definitions": {
@@ -2963,44 +2958,44 @@
 			}
 		},
 		"node_modules/@fluidframework/core-interfaces": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-znZqbn0ew7aqrnjFf+sfNsnajjZ9z9PHycrfzkVfo6YAW1WKuTi7VmZwUyLGVDIAJ86qlQW4/kI9WL4OypzSFA=="
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-HAqosUcAeyZWr1fQaE2CkR+0aMs3nHCQiDa+XhpQarJKNB6wMkscQ+AgzqxmAH6tX8R5Yz6gaPDEp/zScCepXQ=="
 		},
 		"node_modules/@fluidframework/core-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-nEs40QaYzCBlb0PVG2YFCQU++nsnpdHdkl83ilbtdGlYw37GUS+3vl5UbFqGv3EvRdjl4bu1nXi3Pve0AOESUA=="
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-R9fhUy0OPPFiCBEA+G2kPvKOD2YipkCbpRMNVLC1o0khaadcuB2Ji8xEy/1/bZAkjO+LiiZj49dxTqSxEuSDXA=="
 		},
 		"node_modules/@fluidframework/datastore": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-jpRJ9ArExfNvGcj+ymPq52jSd+KphExV6ryYXGr9T8K2+akSS4ap0G/zzgOSvnxDk69jUev38s9DISr3wLHCVg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-5Rxt2kwHiUv80OjksWVoXOqBfJc5gaRex4o4ALNL2BuTMnewQuQ4OJHzCvLIDGkDSgl0FgHXpoNac9HEAEEi8A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"lodash": "^4.17.21",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/datastore-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-PF/xp9c6C9o2fcmGTdBcfSCSJ6aOnYHdDtTYaFiGtWlFfLm0vfZo04NBkSsIUAvGE0UyOe8m40y6uYs1R5lJiA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-HkLqqhTD1pLEQ6uBgD6GpfQh0q+zbxVURLKIJ808PzUpXUWPK+c4R2+HA+sebQz/CcrO+VYlE+MO7TYct38eog==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/datastore-definitions/node_modules/@fluidframework/common-definitions": {
@@ -3042,17 +3037,17 @@
 			}
 		},
 		"node_modules/@fluidframework/driver-base": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-w0uGZGJOcDrjNQDHOs3GurcVak/Ssj9xlWiJZ8sx8U9aq84c+BvTbZpjUb9FViP0JQI6NWVnjIMTW4AqWeeDuw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-5hUfYI7tte0JL+UXADpU03W+k3BG5RPRDlvJCt+4pPMz9yrhtpjR5mHJL0M3WsuY/uACuCAN5Wfe9taHg4HhzA==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-base/node_modules/@fluidframework/common-definitions": {
@@ -3069,11 +3064,11 @@
 			}
 		},
 		"node_modules/@fluidframework/driver-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-yPsYKh7CPOaYrxmAMMDzKkiTRsy99XX97Wibjr4gjQ5rRgnE8wIMC0Y3PHvRgUwj1pPcZEArFTFnCIxUhs3lvw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-KnN+c3EWDP1jOlQU4horUbNNzfCDWUQdo3bxnYGy46Dfkag//OGUNF85JzHHeWKnPaB/YBcfWc8TuT/TBlcbsQ==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0"
 			}
 		},
@@ -3091,18 +3086,18 @@
 			}
 		},
 		"node_modules/@fluidframework/driver-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-dyKGoKk/4WFIEujmO+hZJIy8s6E6JV0mVUewkSY/LKdzJ6gZtjOKMyKhoR+jMPcvhq4CoMdSZz+lrh/fAf4sWg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-OnggpLFQBNFh0jLVHC3aZE1P13yat2+nKQlFnKD5gtmkBKbHKqWkrhdyX0xcfpsAHlD8NbStsscYfkz336NIQw==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/gitresources": "^2.0.1",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"axios": "^0.26.0",
 				"lz4js": "^0.2.0",
 				"url": "^0.11.0",
@@ -3143,21 +3138,21 @@
 			}
 		},
 		"node_modules/@fluidframework/fluid-static": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-MCWVw5Bbh1wMvyqolb2vrnRLAt6ETtc+OAhR3IH0VmID0JxG9PxNnAXo1iwj8YlZKMcLWHokcW1PA5wjyChMzw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-o90QGQoIyouZaBc74muLDG3Ny4O0fLZaLvkyA++nsB4lDAPFcsjjq+QQASPPCvwye591Z4jRcWV3ghDZsT6V6g==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/aqueduct": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/aqueduct": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/request-handler": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/fluid-static/node_modules/@fluidframework/common-definitions": {
@@ -3179,20 +3174,20 @@
 			"integrity": "sha512-N8lHCEkoEE7uLtjo7VMAl7psnuQDYSO2z61dbb4zUSWOVZ6E0cyhjR5N3dZtffhbTq0qPiYYN3Ss5M06Yri6OA=="
 		},
 		"node_modules/@fluidframework/map": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-ztuF8GgO2c/tZJwHHzbzXQ3UAhAfIQlIE4hW+wGy5txW6yqnvmUjpUDWqunnFp1h36DrNq9ro3RcB/labJf5bQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-OzoNKQ8ic/k+ZJSSieGtxeNLLbluu5H9wWr/6X/AZZV+WdaSAHNOlyD8hgh7Ae+7uRwx9ChfLuCBp1CgOcRS1A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"path-browserify": "^1.0.1"
 			}
 		},
@@ -3210,20 +3205,20 @@
 			}
 		},
 		"node_modules/@fluidframework/merge-tree": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-vnfR2ZgaImUvpfqkdyI+d6lEnrM+ioD2+tiHcBemii3q6PSK6+qbtwbFuslAUj/VVKjirIChPQCPwIHNH2nl0A==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-FamAnrAd8SHX2LKdjaKxoyvSX/w6hzoeSRtl9Oz8M89vrjGGT6Vz9s4D2gFaUY1rWhuYXW6aIAaOsmrgYekYoQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/merge-tree/node_modules/@fluidframework/common-definitions": {
@@ -3263,42 +3258,34 @@
 				"@fluidframework/common-definitions": "^1.0.0"
 			}
 		},
-		"node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.1.0.tgz",
-			"integrity": "sha512-Q4YA6FBlB2cHicgvfs9z3LPKnfZMdx5JrmIEGOmxFmom/l9EV1F43sXl6K9/j5se8tQ9V9L8drFbDzqVf37roQ==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
 		"node_modules/@fluidframework/request-handler": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-I7TZUmiAc0lhD6Y3AeHACXvS4GtIbK5xc+Ph042J7eWZPUgydD50AOH7bXBjuUXdRhF35i1X23vR+UEq0tp95Q==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-lMaxH2tjDT+MFKlatFBvmRbRxpmHgvSAwGXTUILxM5uOW32RURDu3GmgGb+BpGAmXyjKNwLaUgHBONCegK9sQQ==",
 			"dependencies": {
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/routerlicious-driver": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-+O1Omih8k3gLXfClw3A6CFlgNccBkujUBkeW/4t67LXVr2Z3/q4OOqfSmXVEFePyjiJZ0O6mErAXRRJ78euJVA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-NyciUkBlKNmMcy5yvilYsC6pyYExASrjx/3Pg8z5Df950hclLP4JNu1aJdraB9K7WUUuo50Pz75ZFEKHhvOu/g==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/gitresources": "^2.0.1",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"@fluidframework/server-services-client": "^2.0.1",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"socket.io-client": "^4.6.1",
@@ -3332,13 +3319,13 @@
 			}
 		},
 		"node_modules/@fluidframework/runtime-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-uIqvypcpfhBEwmAlKjCvofwsioeJvbo35umWqXsX6qOUp68xrbMsMwDB1C7o4gA6cjiicNTZH4lhbsOUJV67jA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-54g4ORqpZVoKlt2H74KJeDtsZWI2G2MSpUIExOOtPbTfgJYzA7cldCUwR8soAXMLEA+NreHycyR/cwzSJlT6nw==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0"
 			}
 		},
@@ -3356,20 +3343,20 @@
 			}
 		},
 		"node_modules/@fluidframework/runtime-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-E5oenqEdtNuO5FvbirN2dogltVofqhl9Cqu9d3wZnFonfczuMDgBX5rPcQFp+5B8E5t4YXlKe0V7MXx1j6o+Qw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-Rz/qG/N+GlW3jSfgw4WcVjiaT8sa6KNIgdS4oqcVAM+sLSnTA7SWtn7uga68wtg5J43Rzgb2e9iW39D1S0RofQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/runtime-utils/node_modules/@fluidframework/common-definitions": {
@@ -3386,20 +3373,20 @@
 			}
 		},
 		"node_modules/@fluidframework/sequence": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-c17zZQjevyoQD4YZFbBXnQSCC47ucsokYcj0NtPKFWj/weF/ha0ZZ4sgIaXNWOLN4WYgOpliGeyNMf33zp9Xog==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-9mnSQ+l6FNcfqIPbsrl1lJP7GiAnc5YwcdN4odRKBXaKRbLBJNS8WGAyYDNmAMHi+kVbGZ0F9eoYH1P6wtNMkQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -3938,21 +3925,21 @@
 			}
 		},
 		"node_modules/@fluidframework/shared-object-base": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-SxvDleS9NhBIpEe0kFVuSOwABuUtxtEDqSTUZWu/4MEVUuaGE3/+NjYXIvJylNQIxtSiMmAg/1uIomi7UG/+HA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-RCM+iQ1kFkSMiUyxe/v7VkLmpfsy6I8kULD7+vbv29ltKFM3YKio3DkmUvPIJICzAlj6QnFdthYS88NTdeyqOQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -3982,21 +3969,21 @@
 			}
 		},
 		"node_modules/@fluidframework/synthesize": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-48XxrYddsePCDA34w4YJhoSiNQ1c5QcgEV+LNmz7yvFXWlnWQGwxpvDoVFZnu5nDShVyrtfQVaOwuXe0bOEAVQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-kMrDLm8k8WmB3W3iEYxsYxfo0b5gHSFcZIfkNhP5QXenPAPbzCmvIaJg2Zo8rxY+grymfOpvlXW8bf9G/IBbVw==",
 			"dependencies": {
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/telemetry-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-1oZhXUBA05i+OYD0huPYhmDxVE/P58HaKoaVundSu1zsu7h2sel+xPE7cUpKVl74PIu5gjDgQeVM6bClNjPlFw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-0Din0dxWTBKXGRAvBuxPeV6t5yg3jTbCFWlv4o6tPRrqNRGuOrzvb7lrEoJ21kcTLQRdnGISefdO8LLJZ7zUeQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"debug": "^4.1.1",
 				"events": "^3.1.0",
@@ -4028,244 +4015,40 @@
 				"uuid": "dist/bin/uuid"
 			}
 		},
-		"node_modules/@fluidframework/test-client-utils": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-A0bj4oT5mjO9NBO/smMXuK+ibZPGKLhzqh6m/+lKTqcv+CKgpMj909gj0Dfnf9uuMEVS6VEt+BhvtASR5o2eWg==",
-			"dependencies": {
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
 		"node_modules/@fluidframework/test-runtime-utils": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-z+VnytJXLmW5Mfy1HYyGQTUE5RRPsychaBDCrClfIoOOe1mH8NsiRjbO8AfzWan4lxOklCuFEhj78M67w6fBxA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-9xpfAbPBy2DT9k5Pja7SIbr+UGdZhX45gcBHVXX6kZXDgJmWbbLYBYZVtiFKfu9VZPLn7C5g9njym3xFlhpCXw==",
 			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/protocol-definitions": "^3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"axios": "^0.26.0",
 				"events": "^3.1.0",
 				"jsrsasign": "^10.5.25",
-				"uuid": "^8.3.1"
+				"uuid": "^9.0.0"
 			}
 		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/common-definitions": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-1.0.0.tgz",
+			"integrity": "sha512-t0jm6u4RX77Fn3rnoxDmavzo26y/JBsNIz5iptnamBgUTOo37i7wXr9VPB8+AjCEd3kcXPyFEoNa8zIEvgOekQ=="
+		},
+		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/protocol-definitions": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-3.0.0.tgz",
+			"integrity": "sha512-FUIw5B5aTVJ831zAvsNUzKGFCkPoswmUeeYfZtVlq2wRpO2Ffm28TYhbkrAGFOtCd0BiByJDho6Oo+iZbNBgUA==",
 			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/container-definitions": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-0+oKYkATmxPtuhWB2ivdSsHY0W6/B93IHO3Ws0amuBegq3IY8VTWw3gghR0vAFOrZV/1qNRIgkJwTn/QWAoiSA==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/container-runtime-definitions": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-qVNCgFat772a2RB4YGDdSwez1vQwHtpDJZPKBpZtAKfiBaihOdqYEcPZLqv6qQ45v7xls+zP3FOWtK3vZm3m6w==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/core-interfaces": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-mMlo6NrWzXbYcpCn9fAM2dHrljFNLDiLgxiR4QNvcGvAtTWpwoUtuHjQDj0KtIBsYiqCzRuinqrCIHgQgubFzA=="
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/core-utils": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-X+VGrq6dGHHWDcMPgSKGvPwG3tIR87/b3xRZSsH3VdPnvd/AGPXdv1/n/jniAZqj+IqfCqP46EFdaMQ+F+F9KA=="
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/datastore-definitions": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-vC14rkXxg7fbIDDcettMEQz2GaXjxVPNzhYnn6HM/VJzGUehdOYnbHTLlhpMPflcb5usOT/UZs/2EqmApwk5AQ==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/driver-base": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-cTjOUwI0pxSAGRuxHNkFPzlnbQtBPqtiM6e3Dky/shrKsN1yBDrWvwvELBOlrV+7v0FJ4/EveyKS3PWSKzXrOA==",
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/driver-definitions": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-co1fPzILKmO0dXwM08HZrzTXoZjOCd7Pu169prNbpVzoJIMs6AJqFqJ3Y4mPL/NyeTLM/P+mNBBauCyYqns5PQ==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/protocol-definitions": "^1.1.0"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/driver-utils": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-UDkJxg5sWd6S/L/pZBZE1oZGJ+sKaPqkMCe2UBVYv8xjyXS/Hd8sp32MBGST11jUs5+RCgI6VGtfgQ36300Awg==",
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/gitresources": "^0.1039.1000",
-				"@fluidframework/protocol-base": "^0.1039.1000",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"axios": "^0.26.0",
-				"lz4js": "^0.2.0",
-				"url": "^0.11.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/gitresources": {
-			"version": "0.1039.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1039.1000.tgz",
-			"integrity": "sha512-O1LAJQL6/TGXZPKHLE8Z8J8KlQ5wpODP+Pj/Q7KvNYWkIUOWepXyq873MobT2adN4hlUdwia4jqif9jaNcIQBA=="
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1039.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1039.1000.tgz",
-			"integrity": "sha512-ohQTfRUugH3oHV1TAU+6KXUmQLZTpWW0EMx6Aa2XJZrd5IGHrJuFTo2RNsfeKKRQmdswbUG1DqrA2O6eJnEtkA==",
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1039.1000",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/routerlicious-driver": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-ZVPs2+xCqTxarQZGkcTNFP62R3Yx7cn5sGH/62qJGcNa0LMlISsT+DThy9sOPxC71VvQpvGFH5r7y+28azYQ7w==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/gitresources": "^0.1039.1000",
-				"@fluidframework/protocol-base": "^0.1039.1000",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1039.1000",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"cross-fetch": "^3.1.5",
-				"json-stringify-safe": "5.0.1",
-				"socket.io-client": "^4.6.1",
-				"url-parse": "^1.5.8",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/runtime-definitions": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-DbGPq2FuzlNYZ9azGcQ3Qfj1adPVgJpYToWGMY8HIHGrTkerD365DZz3IxzCJFEh0kvWVJbyxMsvGgBdNdaHeQ==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/protocol-definitions": "^1.1.0"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/runtime-utils": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-vndWP/46v117tiHmc3U+dtPOeb2b/fhPOGMzqDsas8UFGQWdgspFY40PaspVJJC6r4CVU5XhxGJzfywBhNglsA==",
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1039.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1039.1000.tgz",
-			"integrity": "sha512-wyDH6VdcV5px+sCSAQ/5No/w+T0Mg6M7XZ5bTl/IBN/v05yxFZME3vUCt/zkviZSMYj2MoCkYT3YvD4BHAdrkw==",
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1039.1000",
-				"@fluidframework/protocol-base": "^0.1039.1000",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/test-runtime-utils/node_modules/@fluidframework/telemetry-utils": {
-			"version": "2.0.0-internal.5.4.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.5.4.2.tgz",
-			"integrity": "sha512-9RiMi4DrMK13m5oz9mv/Yow9Pch5/zadYsyjM0sIaUPM7tWFDl8k+Pv7PrNy4JdQJL/QEQ8ZIv2RGOqikDLFaA==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.5.4.2 <2.0.0-internal.5.5.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"uuid": "^8.3.1"
+				"@fluidframework/common-definitions": "^1.0.0"
 			}
 		},
 		"node_modules/@fluidframework/test-runtime-utils/node_modules/axios": {
@@ -4276,12 +4059,24 @@
 				"follow-redirects": "^1.14.8"
 			}
 		},
+		"node_modules/@fluidframework/test-runtime-utils/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
 		"node_modules/@fluidframework/view-interfaces": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-GyCbK0GUHOr5dAfPfW4DwUmLBlPmQ42gEf28i2s5iuIqFe0GApdxNd+Al0YGzRDsNB8JwRbHjFjwraV1ebgTUQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-St867vvX3iHKzZSrmbCCrDgWlP7VxWhTUzUcFA9/Xr404HWl1Zy88E9Rd2oxw3/ass2biyAuUPppElIFh+0MzQ==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@hapi/hoek": {
@@ -11406,16 +11201,16 @@
 			"dev": true
 		},
 		"node_modules/fluid-framework": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-rlSS3mDBgal/TWyFLBQWTNyxxDGlJKxsx2BHAkp0ULQVYzldebRI8uIuYuwGDHG0f4/IFy2zjgrve1vzXN3pJQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-7gEXLH8CqirQlsbSo3AL33xB9PXOoEIzmntx5pDLfmoMaJigEewSOLBhviss3TSL8oJ7elM4DlkXxjqA6EGt0g==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/sequence": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/fluid-static": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/sequence": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/fn.name": {

--- a/brainstorm/package-lock.json
+++ b/brainstorm/package-lock.json
@@ -24,7 +24,7 @@
 			},
 			"devDependencies": {
 				"@fluidframework/azure-local-service": "^2.0.0-internal.7.1.0",
-				"@fluidframework/build-common": "^2.0.0-151899",
+				"@fluidframework/build-common": "^2.0.2",
 				"@testing-library/jest-dom": "^5.11.4",
 				"@testing-library/react": "^11.1.0",
 				"@testing-library/user-event": "^12.1.10",
@@ -2785,9 +2785,9 @@
 			}
 		},
 		"node_modules/@fluidframework/build-common": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.0.tgz",
-			"integrity": "sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.2.tgz",
+			"integrity": "sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==",
 			"dev": true,
 			"bin": {
 				"gen-version": "bin/gen-version"

--- a/brainstorm/package.json
+++ b/brainstorm/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluidframework/azure-local-service": "^2.0.0-internal.7.1.0",
-		"@fluidframework/build-common": "^2.0.0-151899",
+		"@fluidframework/build-common": "^2.0.2",
 		"@testing-library/jest-dom": "^5.11.4",
 		"@testing-library/react": "^11.1.0",
 		"@testing-library/user-event": "^12.1.10",

--- a/brainstorm/package.json
+++ b/brainstorm/package.json
@@ -56,12 +56,12 @@
 	},
 	"dependencies": {
 		"@fluentui/react": "^8.71.0",
-		"@fluidframework/azure-client": "^2.0.0-internal.7.0.0",
-		"@fluidframework/routerlicious-driver": "^2.0.0-internal.7.0.0",
-		"@fluidframework/test-client-utils": "^2.0.0-internal.5.4.2",
+		"@fluidframework/azure-client": "^2.0.0-internal.7.1.0",
+		"@fluidframework/routerlicious-driver": "^2.0.0-internal.7.1.0",
+		"@fluidframework/test-runtime-utils": "^2.0.0-internal.7.1.0",
 		"axios": "^1.3.6",
 		"cross-env": "^7.0.3",
-		"fluid-framework": "^2.0.0-internal.7.0.0",
+		"fluid-framework": "^2.0.0-internal.7.1.0",
 		"react": "^16.10.2",
 		"react-dnd": "^14.0.2",
 		"react-dnd-html5-backend": "^14.0.0",
@@ -69,7 +69,7 @@
 		"uuid": "^8.3.2"
 	},
 	"devDependencies": {
-		"@fluidframework/azure-local-service": "^2.0.0-internal.7.0.0",
+		"@fluidframework/azure-local-service": "^2.0.0-internal.7.1.0",
 		"@fluidframework/build-common": "^2.0.0-151899",
 		"@testing-library/jest-dom": "^5.11.4",
 		"@testing-library/react": "^11.1.0",

--- a/brainstorm/src/Config.ts
+++ b/brainstorm/src/Config.ts
@@ -6,7 +6,7 @@ import {
 import { SharedMap } from "fluid-framework";
 import { getRandomName } from "@fluidframework/server-services-client";
 import { v4 as uuid } from "uuid";
-import { InsecureTokenProvider } from "@fluidframework/test-client-utils";
+import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
 import { AzureFunctionTokenProvider } from "./AzureFunctionTokenProvider";
 
 export const useAzure = process.env.REACT_APP_FLUID_CLIENT === "azure";

--- a/collaborative-text-area/package-lock.json
+++ b/collaborative-text-area/package-lock.json
@@ -17,7 +17,7 @@
 				"react-dom": "^17.0.2"
 			},
 			"devDependencies": {
-				"@fluidframework/build-common": "^2.0.0-151899",
+				"@fluidframework/build-common": "^2.0.2",
 				"@testing-library/react": "^11.2.7",
 				"@testing-library/user-event": "^12.8.3",
 				"@types/node": "^18.0.0",
@@ -2532,9 +2532,9 @@
 			}
 		},
 		"node_modules/@fluidframework/build-common": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.0.tgz",
-			"integrity": "sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.2.tgz",
+			"integrity": "sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==",
 			"dev": true,
 			"bin": {
 				"gen-version": "bin/gen-version"

--- a/collaborative-text-area/package-lock.json
+++ b/collaborative-text-area/package-lock.json
@@ -9,9 +9,9 @@
 			"version": "0.1.0",
 			"license": "MIT",
 			"dependencies": {
-				"@fluid-experimental/react-inputs": "^2.0.0-internal.7.0.0",
-				"@fluidframework/tinylicious-client": "^2.0.0-internal.7.0.0",
-				"fluid-framework": "^2.0.0-internal.7.0.0",
+				"@fluid-experimental/react-inputs": "^2.0.0-internal.7.1.0",
+				"@fluidframework/tinylicious-client": "^2.0.0-internal.7.1.0",
+				"fluid-framework": "^2.0.0-internal.7.1.0",
 				"prettier": "^2.7.1",
 				"react": "^17.0.2",
 				"react-dom": "^17.0.2"
@@ -2470,25 +2470,25 @@
 			}
 		},
 		"node_modules/@fluid-experimental/react-inputs": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/react-inputs/-/react-inputs-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-UajX4G5VdWx1p/kM81qYCYlx1P5uNWIsMHJvbWRfGQfb38AXIELHZy2fcOQZYn4vJEPTKjDdBhfH4+Nv78e0zw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/react-inputs/-/react-inputs-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-pQ8V9ZRSCCQJiaIsXzBxQ/lbRy5u+CDWbp4oHfulcp4/HYGgl01pLhH3PTQaykdPI0/GQUU+U8asnYcEa/6A4g==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/cell": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/sequence": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/cell": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/sequence": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"react": "^17.0.1"
 			}
 		},
 		"node_modules/@fluid-internal/client-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-N9NLm6+1pZ4u2kCMYsj0MbOvPhRWd2sWerdtJOVACICYNZjptiKGi9gU8Wf1vWliILKXC4gJmQUWXWOp+E4piQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-CUjL3pjmfpyZ2eRddgpE48b8wjIIDmKL5aiLw6eqoO0HWo2er3kV0nPX8rwMRNA+tuHahz14afLQ+nb0wA5V3A==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@types/events": "^3.0.0",
 				"base64-js": "^1.5.1",
 				"buffer": "^6.0.3",
@@ -2498,24 +2498,24 @@
 			}
 		},
 		"node_modules/@fluidframework/aqueduct": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-oz4JCEHpve0QyfD2+huzeOiGyOpfa+e7wiknQ03iHQPLKVFpiSz1cX5sbr6DFdCovz5Ub90Ot8rneuzMH8F9IA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-c9p0BFGnFwvCewBxjOLiFc1/zZ+ybMRUTij1BgkFuaP/fSnZamKSvecNdhfGvoDcWIDsQPb0gb/wppX3TU21vg==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/synthesize": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/request-handler": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/synthesize": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/view-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -2541,17 +2541,17 @@
 			}
 		},
 		"node_modules/@fluidframework/cell": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-MCH4VOY2hUwr+30RevGTVErFeKs2r3ijmCF4rX5WlU6SO6yMJD82eVaq5Ehfq/lruGVIg95tfimGGQ8nyf77rA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-FE6Amw/ThRCbbIMQ96drx93o/b9hUkSB7tAE+LvVnm8ligt7z9VNiDbJZbwmgCSxY0WST6uwIMdBydbqb2OtCA==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/common-definitions": {
@@ -2580,30 +2580,30 @@
 			"integrity": "sha512-t0jm6u4RX77Fn3rnoxDmavzo26y/JBsNIz5iptnamBgUTOo37i7wXr9VPB8+AjCEd3kcXPyFEoNa8zIEvgOekQ=="
 		},
 		"node_modules/@fluidframework/container-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-OWBJLiXkXZrB2kb9HNcj7BLSyEvzyALCVzZhtTVDd1LT5cUwPPx92fLfLHmLglhnJwW7UK+/UvggjAqNxAlbQA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-zUxrbGbbNwPdT+WDmXz7oeomZuqUzUQqDLAkgxO/qFnwdqh9pBI6nkzuXeGwQEOLScLkDUNRzJwimfKqFmBt2w==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/container-loader": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-lPJwdDR8ZCXRHiLhZzewWVr5jItlQ4MHrMa95wLdGxoPxpkkAMZBYLOLxmsIp7W1QQ6+mHZYw9ECv6B5TojroA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-EbHroDko65kyw92YprxMjBXi61vEVpL+uogZyQ0Jlkfvkor0xiVgtfgwKxFdUy+j6uElzYGonm6jRJMh+ga+6w==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
 				"events": "^3.1.0",
@@ -2625,22 +2625,22 @@
 			}
 		},
 		"node_modules/@fluidframework/container-runtime": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-Ju+58IfRVZeQS5zgk0u6QHq9av0GQABV33BAioKOqtB685a1fbVhgTTPX74KtQlB0MKaXyt0mZNW9oXUkoUSpA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-I1Lf53ZBZtnVpEbwSDaLVwoCGa/CX2vEbv5t/lHLFKrjGmNxzahx1ZWAw46jjg3ZBPEpdiYbwqKpCoRHg44a6A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"double-ended-queue": "^2.1.0-0",
 				"events": "^3.1.0",
 				"lz4js": "^0.2.0",
@@ -2649,15 +2649,15 @@
 			}
 		},
 		"node_modules/@fluidframework/container-runtime-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-ujWp607A5Lg2ZjN8QKYV28LstvGzGXFxXy/2phME4bPOQT9EtPD7uejLbAPVUg7LmJgDFOBQD1VuAI6Vlx92MQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-kC85xUSfrr03+JiUrnnjwJ2PVtcylGt/1UB/b8CWAC4T4P70roqEH48vZbnunjY5yJ7vmzHk7AThrsiGGhN6Sg==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/container-runtime/node_modules/uuid": {
@@ -2673,44 +2673,44 @@
 			}
 		},
 		"node_modules/@fluidframework/core-interfaces": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-znZqbn0ew7aqrnjFf+sfNsnajjZ9z9PHycrfzkVfo6YAW1WKuTi7VmZwUyLGVDIAJ86qlQW4/kI9WL4OypzSFA=="
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-HAqosUcAeyZWr1fQaE2CkR+0aMs3nHCQiDa+XhpQarJKNB6wMkscQ+AgzqxmAH6tX8R5Yz6gaPDEp/zScCepXQ=="
 		},
 		"node_modules/@fluidframework/core-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-nEs40QaYzCBlb0PVG2YFCQU++nsnpdHdkl83ilbtdGlYw37GUS+3vl5UbFqGv3EvRdjl4bu1nXi3Pve0AOESUA=="
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-R9fhUy0OPPFiCBEA+G2kPvKOD2YipkCbpRMNVLC1o0khaadcuB2Ji8xEy/1/bZAkjO+LiiZj49dxTqSxEuSDXA=="
 		},
 		"node_modules/@fluidframework/datastore": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-jpRJ9ArExfNvGcj+ymPq52jSd+KphExV6ryYXGr9T8K2+akSS4ap0G/zzgOSvnxDk69jUev38s9DISr3wLHCVg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-5Rxt2kwHiUv80OjksWVoXOqBfJc5gaRex4o4ALNL2BuTMnewQuQ4OJHzCvLIDGkDSgl0FgHXpoNac9HEAEEi8A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"lodash": "^4.17.21",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/datastore-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-PF/xp9c6C9o2fcmGTdBcfSCSJ6aOnYHdDtTYaFiGtWlFfLm0vfZo04NBkSsIUAvGE0UyOe8m40y6uYs1R5lJiA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-HkLqqhTD1pLEQ6uBgD6GpfQh0q+zbxVURLKIJ808PzUpXUWPK+c4R2+HA+sebQz/CcrO+VYlE+MO7TYct38eog==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/datastore/node_modules/uuid": {
@@ -2726,41 +2726,41 @@
 			}
 		},
 		"node_modules/@fluidframework/driver-base": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-w0uGZGJOcDrjNQDHOs3GurcVak/Ssj9xlWiJZ8sx8U9aq84c+BvTbZpjUb9FViP0JQI6NWVnjIMTW4AqWeeDuw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-5hUfYI7tte0JL+UXADpU03W+k3BG5RPRDlvJCt+4pPMz9yrhtpjR5mHJL0M3WsuY/uACuCAN5Wfe9taHg4HhzA==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-yPsYKh7CPOaYrxmAMMDzKkiTRsy99XX97Wibjr4gjQ5rRgnE8wIMC0Y3PHvRgUwj1pPcZEArFTFnCIxUhs3lvw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-KnN+c3EWDP1jOlQU4horUbNNzfCDWUQdo3bxnYGy46Dfkag//OGUNF85JzHHeWKnPaB/YBcfWc8TuT/TBlcbsQ==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-dyKGoKk/4WFIEujmO+hZJIy8s6E6JV0mVUewkSY/LKdzJ6gZtjOKMyKhoR+jMPcvhq4CoMdSZz+lrh/fAf4sWg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-OnggpLFQBNFh0jLVHC3aZE1P13yat2+nKQlFnKD5gtmkBKbHKqWkrhdyX0xcfpsAHlD8NbStsscYfkz336NIQw==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/gitresources": "^2.0.1",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"axios": "^0.26.0",
 				"lz4js": "^0.2.0",
 				"url": "^0.11.0",
@@ -2780,70 +2780,70 @@
 			}
 		},
 		"node_modules/@fluidframework/fluid-static": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-MCWVw5Bbh1wMvyqolb2vrnRLAt6ETtc+OAhR3IH0VmID0JxG9PxNnAXo1iwj8YlZKMcLWHokcW1PA5wjyChMzw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-o90QGQoIyouZaBc74muLDG3Ny4O0fLZaLvkyA++nsB4lDAPFcsjjq+QQASPPCvwye591Z4jRcWV3ghDZsT6V6g==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/aqueduct": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/aqueduct": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/request-handler": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/gitresources": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-2.0.1.tgz",
-			"integrity": "sha512-N8lHCEkoEE7uLtjo7VMAl7psnuQDYSO2z61dbb4zUSWOVZ6E0cyhjR5N3dZtffhbTq0qPiYYN3Ss5M06Yri6OA=="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-2.0.2.tgz",
+			"integrity": "sha512-v9hI+uT8B5kwFAs+x6naqb7rOAX84r9ixjyIrE7Gqa9sBHIZ8pP9zKqNIdcS+Y14IqGiJYGDmwzM7Km6ThILCw=="
 		},
 		"node_modules/@fluidframework/map": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-ztuF8GgO2c/tZJwHHzbzXQ3UAhAfIQlIE4hW+wGy5txW6yqnvmUjpUDWqunnFp1h36DrNq9ro3RcB/labJf5bQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-OzoNKQ8ic/k+ZJSSieGtxeNLLbluu5H9wWr/6X/AZZV+WdaSAHNOlyD8hgh7Ae+7uRwx9ChfLuCBp1CgOcRS1A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"node_modules/@fluidframework/merge-tree": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-vnfR2ZgaImUvpfqkdyI+d6lEnrM+ioD2+tiHcBemii3q6PSK6+qbtwbFuslAUj/VVKjirIChPQCPwIHNH2nl0A==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-FamAnrAd8SHX2LKdjaKxoyvSX/w6hzoeSRtl9Oz8M89vrjGGT6Vz9s4D2gFaUY1rWhuYXW6aIAaOsmrgYekYoQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/protocol-base": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-2.0.1.tgz",
-			"integrity": "sha512-h/AiwgQhGFfKZaJLebEcvJ0G7j+6FOHwlEyd9nT7BfLp/zdwW63Jd4gA4PsQXmpzurRxskYuoYUKyWJGcO7E0Q==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-2.0.2.tgz",
+			"integrity": "sha512-9AbQ8FuZ5UNZgOWmNaWxs7CH08H9qRYX6OkTUbRXNjdJaFRSCBCkPSA23aHD85EN49UEkkpfoyH1SsQchHuR4Q==",
 			"dependencies": {
 				"@fluidframework/common-utils": "^3.0.0",
-				"@fluidframework/gitresources": "~2.0.1",
+				"@fluidframework/gitresources": "~2.0.2",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"events": "^3.1.0"
 			}
@@ -2862,33 +2862,33 @@
 			"integrity": "sha512-t0jm6u4RX77Fn3rnoxDmavzo26y/JBsNIz5iptnamBgUTOo37i7wXr9VPB8+AjCEd3kcXPyFEoNa8zIEvgOekQ=="
 		},
 		"node_modules/@fluidframework/request-handler": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-I7TZUmiAc0lhD6Y3AeHACXvS4GtIbK5xc+Ph042J7eWZPUgydD50AOH7bXBjuUXdRhF35i1X23vR+UEq0tp95Q==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-lMaxH2tjDT+MFKlatFBvmRbRxpmHgvSAwGXTUILxM5uOW32RURDu3GmgGb+BpGAmXyjKNwLaUgHBONCegK9sQQ==",
 			"dependencies": {
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/routerlicious-driver": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-+O1Omih8k3gLXfClw3A6CFlgNccBkujUBkeW/4t67LXVr2Z3/q4OOqfSmXVEFePyjiJZ0O6mErAXRRJ78euJVA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-NyciUkBlKNmMcy5yvilYsC6pyYExASrjx/3Pg8z5Df950hclLP4JNu1aJdraB9K7WUUuo50Pz75ZFEKHhvOu/g==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/gitresources": "^2.0.1",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"@fluidframework/server-services-client": "^2.0.1",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"socket.io-client": "^4.6.1",
@@ -2909,48 +2909,48 @@
 			}
 		},
 		"node_modules/@fluidframework/runtime-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-uIqvypcpfhBEwmAlKjCvofwsioeJvbo35umWqXsX6qOUp68xrbMsMwDB1C7o4gA6cjiicNTZH4lhbsOUJV67jA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-54g4ORqpZVoKlt2H74KJeDtsZWI2G2MSpUIExOOtPbTfgJYzA7cldCUwR8soAXMLEA+NreHycyR/cwzSJlT6nw==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0"
 			}
 		},
 		"node_modules/@fluidframework/runtime-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-E5oenqEdtNuO5FvbirN2dogltVofqhl9Cqu9d3wZnFonfczuMDgBX5rPcQFp+5B8E5t4YXlKe0V7MXx1j6o+Qw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-Rz/qG/N+GlW3jSfgw4WcVjiaT8sa6KNIgdS4oqcVAM+sLSnTA7SWtn7uga68wtg5J43Rzgb2e9iW39D1S0RofQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/sequence": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-c17zZQjevyoQD4YZFbBXnQSCC47ucsokYcj0NtPKFWj/weF/ha0ZZ4sgIaXNWOLN4WYgOpliGeyNMf33zp9Xog==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-9mnSQ+l6FNcfqIPbsrl1lJP7GiAnc5YwcdN4odRKBXaKRbLBJNS8WGAyYDNmAMHi+kVbGZ0F9eoYH1P6wtNMkQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -3342,13 +3342,13 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-client": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-2.0.1.tgz",
-			"integrity": "sha512-VJrmSHYuvVXZ6VUi8rlSzAoQP7R2D8ohKBISLwD97VH1pyl7leuQ1cos7SFJRriIJySHyzveqrbNw8vYpeJXIg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-2.0.2.tgz",
+			"integrity": "sha512-YbK9Hz2URRJreK1IoZZCOCFrIPNxnayIT3xbu7SfeU8nG9ui6+QyjO1WS58/oTM9+raQCmgZaIfzfENXzpVqZA==",
 			"dependencies": {
 				"@fluidframework/common-utils": "^3.0.0",
-				"@fluidframework/gitresources": "~2.0.1",
-				"@fluidframework/protocol-base": "~2.0.1",
+				"@fluidframework/gitresources": "~2.0.2",
+				"@fluidframework/protocol-base": "~2.0.2",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -3766,21 +3766,21 @@
 			}
 		},
 		"node_modules/@fluidframework/shared-object-base": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-SxvDleS9NhBIpEe0kFVuSOwABuUtxtEDqSTUZWu/4MEVUuaGE3/+NjYXIvJylNQIxtSiMmAg/1uIomi7UG/+HA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-RCM+iQ1kFkSMiUyxe/v7VkLmpfsy6I8kULD7+vbv29ltKFM3YKio3DkmUvPIJICzAlj6QnFdthYS88NTdeyqOQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -3797,21 +3797,21 @@
 			}
 		},
 		"node_modules/@fluidframework/synthesize": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-48XxrYddsePCDA34w4YJhoSiNQ1c5QcgEV+LNmz7yvFXWlnWQGwxpvDoVFZnu5nDShVyrtfQVaOwuXe0bOEAVQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-kMrDLm8k8WmB3W3iEYxsYxfo0b5gHSFcZIfkNhP5QXenPAPbzCmvIaJg2Zo8rxY+grymfOpvlXW8bf9G/IBbVw==",
 			"dependencies": {
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/telemetry-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-1oZhXUBA05i+OYD0huPYhmDxVE/P58HaKoaVundSu1zsu7h2sel+xPE7cUpKVl74PIu5gjDgQeVM6bClNjPlFw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-0Din0dxWTBKXGRAvBuxPeV6t5yg3jTbCFWlv4o6tPRrqNRGuOrzvb7lrEoJ21kcTLQRdnGISefdO8LLJZ7zUeQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"debug": "^4.1.1",
 				"events": "^3.1.0",
@@ -3831,22 +3831,22 @@
 			}
 		},
 		"node_modules/@fluidframework/tinylicious-client": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-hmAt4z16KaYKHntM8BWpZdXV9B/sqJhgwUZnFVej17Lew6ZwagJ13OH5WUirdREW4O0ewzs9k8HEMMUZi1vReg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-7S9Hn/JIlQ2sn8c/l194P1a1HIjNPO9M6p0WZbWtq+CSR0hNT4+MZSlvKfwbwO1x9toT3jO1Yn+XEOQWouYD3g==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/fluid-static": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -3863,16 +3863,15 @@
 			}
 		},
 		"node_modules/@fluidframework/tinylicious-driver": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-ILIi5Mt7e+PZTat5wFyT6acU4j8wfKcs+lyZakpzC5RA1TRcfgV7kYihsBcbiFUMRxPERawg9nSQcHwAeTqhPA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-jjvk3f2NXimgKfZKlkAxZZdNhr4zMVF9ToF2PTO+9kXEco8hRdWMTKJUltQjbx+KJ0AFAA477v2H6IiCCFN2QA==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/server-services-client": "^2.0.1",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^9.0.0"
 			}
@@ -3890,11 +3889,11 @@
 			}
 		},
 		"node_modules/@fluidframework/view-interfaces": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-GyCbK0GUHOr5dAfPfW4DwUmLBlPmQ42gEf28i2s5iuIqFe0GApdxNd+Al0YGzRDsNB8JwRbHjFjwraV1ebgTUQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-St867vvX3iHKzZSrmbCCrDgWlP7VxWhTUzUcFA9/Xr404HWl1Zy88E9Rd2oxw3/ass2biyAuUPppElIFh+0MzQ==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@hapi/hoek": {
@@ -12014,16 +12013,16 @@
 			"dev": true
 		},
 		"node_modules/fluid-framework": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-rlSS3mDBgal/TWyFLBQWTNyxxDGlJKxsx2BHAkp0ULQVYzldebRI8uIuYuwGDHG0f4/IFy2zjgrve1vzXN3pJQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-7gEXLH8CqirQlsbSo3AL33xB9PXOoEIzmntx5pDLfmoMaJigEewSOLBhviss3TSL8oJ7elM4DlkXxjqA6EGt0g==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/sequence": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/fluid-static": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/sequence": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/fn.name": {

--- a/collaborative-text-area/package.json
+++ b/collaborative-text-area/package.json
@@ -19,7 +19,7 @@
 		"react-dom": "^17.0.2"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0-151899",
+		"@fluidframework/build-common": "^2.0.2",
 		"@testing-library/react": "^11.2.7",
 		"@testing-library/user-event": "^12.8.3",
 		"@types/node": "^18.0.0",

--- a/collaborative-text-area/package.json
+++ b/collaborative-text-area/package.json
@@ -11,9 +11,9 @@
 		"node": ">=18.0.0"
 	},
 	"dependencies": {
-		"@fluid-experimental/react-inputs": "^2.0.0-internal.7.0.0",
-		"@fluidframework/tinylicious-client": "^2.0.0-internal.7.0.0",
-		"fluid-framework": "^2.0.0-internal.7.0.0",
+		"@fluid-experimental/react-inputs": "^2.0.0-internal.7.1.0",
+		"@fluidframework/tinylicious-client": "^2.0.0-internal.7.1.0",
+		"fluid-framework": "^2.0.0-internal.7.1.0",
 		"prettier": "^2.7.1",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2"

--- a/multi-framework-diceroller/package-lock.json
+++ b/multi-framework-diceroller/package-lock.json
@@ -10,8 +10,8 @@
             "license": "MIT",
             "dependencies": {
                 "@babel/preset-react": "^7.14.5",
-                "@fluidframework/tinylicious-client": "^2.0.0-internal.7.0.0",
-                "fluid-framework": "^2.0.0-internal.7.0.0",
+                "@fluidframework/tinylicious-client": "^2.0.0-internal.7.1.0",
+                "fluid-framework": "^2.0.0-internal.7.1.0",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
                 "vue": "^3.2.11"
@@ -1793,12 +1793,12 @@
             }
         },
         "node_modules/@fluid-internal/client-utils": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-N9NLm6+1pZ4u2kCMYsj0MbOvPhRWd2sWerdtJOVACICYNZjptiKGi9gU8Wf1vWliILKXC4gJmQUWXWOp+E4piQ==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-CUjL3pjmfpyZ2eRddgpE48b8wjIIDmKL5aiLw6eqoO0HWo2er3kV0nPX8rwMRNA+tuHahz14afLQ+nb0wA5V3A==",
             "dependencies": {
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@types/events": "^3.0.0",
                 "base64-js": "^1.5.1",
                 "buffer": "^6.0.3",
@@ -1808,24 +1808,24 @@
             }
         },
         "node_modules/@fluidframework/aqueduct": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-oz4JCEHpve0QyfD2+huzeOiGyOpfa+e7wiknQ03iHQPLKVFpiSz1cX5sbr6DFdCovz5Ub90Ot8rneuzMH8F9IA==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-c9p0BFGnFwvCewBxjOLiFc1/zZ+ybMRUTij1BgkFuaP/fSnZamKSvecNdhfGvoDcWIDsQPb0gb/wppX3TU21vg==",
             "dependencies": {
-                "@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/container-runtime": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/request-handler": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/synthesize": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/view-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/container-runtime": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/request-handler": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/synthesize": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/view-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "uuid": "^9.0.0"
             }
         },
@@ -1876,30 +1876,30 @@
             "integrity": "sha512-t0jm6u4RX77Fn3rnoxDmavzo26y/JBsNIz5iptnamBgUTOo37i7wXr9VPB8+AjCEd3kcXPyFEoNa8zIEvgOekQ=="
         },
         "node_modules/@fluidframework/container-definitions": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-OWBJLiXkXZrB2kb9HNcj7BLSyEvzyALCVzZhtTVDd1LT5cUwPPx92fLfLHmLglhnJwW7UK+/UvggjAqNxAlbQA==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-zUxrbGbbNwPdT+WDmXz7oeomZuqUzUQqDLAkgxO/qFnwdqh9pBI6nkzuXeGwQEOLScLkDUNRzJwimfKqFmBt2w==",
             "dependencies": {
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/protocol-definitions": "^3.0.0",
                 "events": "^3.1.0"
             }
         },
         "node_modules/@fluidframework/container-loader": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-lPJwdDR8ZCXRHiLhZzewWVr5jItlQ4MHrMa95wLdGxoPxpkkAMZBYLOLxmsIp7W1QQ6+mHZYw9ECv6B5TojroA==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-EbHroDko65kyw92YprxMjBXi61vEVpL+uogZyQ0Jlkfvkor0xiVgtfgwKxFdUy+j6uElzYGonm6jRJMh+ga+6w==",
             "dependencies": {
-                "@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/protocol-base": "^2.0.1",
                 "@fluidframework/protocol-definitions": "^3.0.0",
-                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "debug": "^4.1.1",
                 "double-ended-queue": "^2.1.0-0",
                 "events": "^3.1.0",
@@ -1921,22 +1921,22 @@
             }
         },
         "node_modules/@fluidframework/container-runtime": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-Ju+58IfRVZeQS5zgk0u6QHq9av0GQABV33BAioKOqtB685a1fbVhgTTPX74KtQlB0MKaXyt0mZNW9oXUkoUSpA==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-I1Lf53ZBZtnVpEbwSDaLVwoCGa/CX2vEbv5t/lHLFKrjGmNxzahx1ZWAw46jjg3ZBPEpdiYbwqKpCoRHg44a6A==",
             "dependencies": {
-                "@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/protocol-definitions": "^3.0.0",
-                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "double-ended-queue": "^2.1.0-0",
                 "events": "^3.1.0",
                 "lz4js": "^0.2.0",
@@ -1945,15 +1945,15 @@
             }
         },
         "node_modules/@fluidframework/container-runtime-definitions": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-ujWp607A5Lg2ZjN8QKYV28LstvGzGXFxXy/2phME4bPOQT9EtPD7uejLbAPVUg7LmJgDFOBQD1VuAI6Vlx92MQ==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-kC85xUSfrr03+JiUrnnjwJ2PVtcylGt/1UB/b8CWAC4T4P70roqEH48vZbnunjY5yJ7vmzHk7AThrsiGGhN6Sg==",
             "dependencies": {
-                "@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/protocol-definitions": "^3.0.0",
-                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
             }
         },
         "node_modules/@fluidframework/container-runtime/node_modules/uuid": {
@@ -1969,44 +1969,44 @@
             }
         },
         "node_modules/@fluidframework/core-interfaces": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-znZqbn0ew7aqrnjFf+sfNsnajjZ9z9PHycrfzkVfo6YAW1WKuTi7VmZwUyLGVDIAJ86qlQW4/kI9WL4OypzSFA=="
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-HAqosUcAeyZWr1fQaE2CkR+0aMs3nHCQiDa+XhpQarJKNB6wMkscQ+AgzqxmAH6tX8R5Yz6gaPDEp/zScCepXQ=="
         },
         "node_modules/@fluidframework/core-utils": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-nEs40QaYzCBlb0PVG2YFCQU++nsnpdHdkl83ilbtdGlYw37GUS+3vl5UbFqGv3EvRdjl4bu1nXi3Pve0AOESUA=="
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-R9fhUy0OPPFiCBEA+G2kPvKOD2YipkCbpRMNVLC1o0khaadcuB2Ji8xEy/1/bZAkjO+LiiZj49dxTqSxEuSDXA=="
         },
         "node_modules/@fluidframework/datastore": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-jpRJ9ArExfNvGcj+ymPq52jSd+KphExV6ryYXGr9T8K2+akSS4ap0G/zzgOSvnxDk69jUev38s9DISr3wLHCVg==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-5Rxt2kwHiUv80OjksWVoXOqBfJc5gaRex4o4ALNL2BuTMnewQuQ4OJHzCvLIDGkDSgl0FgHXpoNac9HEAEEi8A==",
             "dependencies": {
-                "@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/protocol-definitions": "^3.0.0",
-                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "lodash": "^4.17.21",
                 "uuid": "^9.0.0"
             }
         },
         "node_modules/@fluidframework/datastore-definitions": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-PF/xp9c6C9o2fcmGTdBcfSCSJ6aOnYHdDtTYaFiGtWlFfLm0vfZo04NBkSsIUAvGE0UyOe8m40y6uYs1R5lJiA==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-HkLqqhTD1pLEQ6uBgD6GpfQh0q+zbxVURLKIJ808PzUpXUWPK+c4R2+HA+sebQz/CcrO+VYlE+MO7TYct38eog==",
             "dependencies": {
-                "@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/protocol-definitions": "^3.0.0",
-                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
             }
         },
         "node_modules/@fluidframework/datastore/node_modules/uuid": {
@@ -2022,41 +2022,41 @@
             }
         },
         "node_modules/@fluidframework/driver-base": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-w0uGZGJOcDrjNQDHOs3GurcVak/Ssj9xlWiJZ8sx8U9aq84c+BvTbZpjUb9FViP0JQI6NWVnjIMTW4AqWeeDuw==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-5hUfYI7tte0JL+UXADpU03W+k3BG5RPRDlvJCt+4pPMz9yrhtpjR5mHJL0M3WsuY/uACuCAN5Wfe9taHg4HhzA==",
             "dependencies": {
-                "@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/protocol-definitions": "^3.0.0",
-                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
             }
         },
         "node_modules/@fluidframework/driver-definitions": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-yPsYKh7CPOaYrxmAMMDzKkiTRsy99XX97Wibjr4gjQ5rRgnE8wIMC0Y3PHvRgUwj1pPcZEArFTFnCIxUhs3lvw==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-KnN+c3EWDP1jOlQU4horUbNNzfCDWUQdo3bxnYGy46Dfkag//OGUNF85JzHHeWKnPaB/YBcfWc8TuT/TBlcbsQ==",
             "dependencies": {
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/protocol-definitions": "^3.0.0"
             }
         },
         "node_modules/@fluidframework/driver-utils": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-dyKGoKk/4WFIEujmO+hZJIy8s6E6JV0mVUewkSY/LKdzJ6gZtjOKMyKhoR+jMPcvhq4CoMdSZz+lrh/fAf4sWg==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-OnggpLFQBNFh0jLVHC3aZE1P13yat2+nKQlFnKD5gtmkBKbHKqWkrhdyX0xcfpsAHlD8NbStsscYfkz336NIQw==",
             "dependencies": {
-                "@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/gitresources": "^2.0.1",
                 "@fluidframework/protocol-base": "^2.0.1",
                 "@fluidframework/protocol-definitions": "^3.0.0",
-                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "axios": "^0.26.0",
                 "lz4js": "^0.2.0",
                 "url": "^0.11.0",
@@ -2076,70 +2076,70 @@
             }
         },
         "node_modules/@fluidframework/fluid-static": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-MCWVw5Bbh1wMvyqolb2vrnRLAt6ETtc+OAhR3IH0VmID0JxG9PxNnAXo1iwj8YlZKMcLWHokcW1PA5wjyChMzw==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-o90QGQoIyouZaBc74muLDG3Ny4O0fLZaLvkyA++nsB4lDAPFcsjjq+QQASPPCvwye591Z4jRcWV3ghDZsT6V6g==",
             "dependencies": {
-                "@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/aqueduct": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/aqueduct": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/protocol-definitions": "^3.0.0",
-                "@fluidframework/request-handler": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+                "@fluidframework/request-handler": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
             }
         },
         "node_modules/@fluidframework/gitresources": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-2.0.1.tgz",
-            "integrity": "sha512-N8lHCEkoEE7uLtjo7VMAl7psnuQDYSO2z61dbb4zUSWOVZ6E0cyhjR5N3dZtffhbTq0qPiYYN3Ss5M06Yri6OA=="
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-2.0.2.tgz",
+            "integrity": "sha512-v9hI+uT8B5kwFAs+x6naqb7rOAX84r9ixjyIrE7Gqa9sBHIZ8pP9zKqNIdcS+Y14IqGiJYGDmwzM7Km6ThILCw=="
         },
         "node_modules/@fluidframework/map": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-ztuF8GgO2c/tZJwHHzbzXQ3UAhAfIQlIE4hW+wGy5txW6yqnvmUjpUDWqunnFp1h36DrNq9ro3RcB/labJf5bQ==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-OzoNKQ8ic/k+ZJSSieGtxeNLLbluu5H9wWr/6X/AZZV+WdaSAHNOlyD8hgh7Ae+7uRwx9ChfLuCBp1CgOcRS1A==",
             "dependencies": {
-                "@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/protocol-definitions": "^3.0.0",
-                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "path-browserify": "^1.0.1"
             }
         },
         "node_modules/@fluidframework/merge-tree": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-vnfR2ZgaImUvpfqkdyI+d6lEnrM+ioD2+tiHcBemii3q6PSK6+qbtwbFuslAUj/VVKjirIChPQCPwIHNH2nl0A==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-FamAnrAd8SHX2LKdjaKxoyvSX/w6hzoeSRtl9Oz8M89vrjGGT6Vz9s4D2gFaUY1rWhuYXW6aIAaOsmrgYekYoQ==",
             "dependencies": {
-                "@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/protocol-definitions": "^3.0.0",
-                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
             }
         },
         "node_modules/@fluidframework/protocol-base": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-2.0.1.tgz",
-            "integrity": "sha512-h/AiwgQhGFfKZaJLebEcvJ0G7j+6FOHwlEyd9nT7BfLp/zdwW63Jd4gA4PsQXmpzurRxskYuoYUKyWJGcO7E0Q==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-2.0.2.tgz",
+            "integrity": "sha512-9AbQ8FuZ5UNZgOWmNaWxs7CH08H9qRYX6OkTUbRXNjdJaFRSCBCkPSA23aHD85EN49UEkkpfoyH1SsQchHuR4Q==",
             "dependencies": {
                 "@fluidframework/common-utils": "^3.0.0",
-                "@fluidframework/gitresources": "~2.0.1",
+                "@fluidframework/gitresources": "~2.0.2",
                 "@fluidframework/protocol-definitions": "^3.0.0",
                 "events": "^3.1.0"
             }
@@ -2158,33 +2158,33 @@
             "integrity": "sha512-t0jm6u4RX77Fn3rnoxDmavzo26y/JBsNIz5iptnamBgUTOo37i7wXr9VPB8+AjCEd3kcXPyFEoNa8zIEvgOekQ=="
         },
         "node_modules/@fluidframework/request-handler": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-I7TZUmiAc0lhD6Y3AeHACXvS4GtIbK5xc+Ph042J7eWZPUgydD50AOH7bXBjuUXdRhF35i1X23vR+UEq0tp95Q==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-lMaxH2tjDT+MFKlatFBvmRbRxpmHgvSAwGXTUILxM5uOW32RURDu3GmgGb+BpGAmXyjKNwLaUgHBONCegK9sQQ==",
             "dependencies": {
-                "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+                "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
             }
         },
         "node_modules/@fluidframework/routerlicious-driver": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-+O1Omih8k3gLXfClw3A6CFlgNccBkujUBkeW/4t67LXVr2Z3/q4OOqfSmXVEFePyjiJZ0O6mErAXRRJ78euJVA==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-NyciUkBlKNmMcy5yvilYsC6pyYExASrjx/3Pg8z5Df950hclLP4JNu1aJdraB9K7WUUuo50Pz75ZFEKHhvOu/g==",
             "dependencies": {
-                "@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/gitresources": "^2.0.1",
                 "@fluidframework/protocol-base": "^2.0.1",
                 "@fluidframework/protocol-definitions": "^3.0.0",
                 "@fluidframework/server-services-client": "^2.0.1",
-                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "cross-fetch": "^3.1.5",
                 "json-stringify-safe": "5.0.1",
                 "socket.io-client": "^4.6.1",
@@ -2205,48 +2205,48 @@
             }
         },
         "node_modules/@fluidframework/runtime-definitions": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-uIqvypcpfhBEwmAlKjCvofwsioeJvbo35umWqXsX6qOUp68xrbMsMwDB1C7o4gA6cjiicNTZH4lhbsOUJV67jA==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-54g4ORqpZVoKlt2H74KJeDtsZWI2G2MSpUIExOOtPbTfgJYzA7cldCUwR8soAXMLEA+NreHycyR/cwzSJlT6nw==",
             "dependencies": {
-                "@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/protocol-definitions": "^3.0.0"
             }
         },
         "node_modules/@fluidframework/runtime-utils": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-E5oenqEdtNuO5FvbirN2dogltVofqhl9Cqu9d3wZnFonfczuMDgBX5rPcQFp+5B8E5t4YXlKe0V7MXx1j6o+Qw==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-Rz/qG/N+GlW3jSfgw4WcVjiaT8sa6KNIgdS4oqcVAM+sLSnTA7SWtn7uga68wtg5J43Rzgb2e9iW39D1S0RofQ==",
             "dependencies": {
-                "@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/protocol-definitions": "^3.0.0",
-                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
             }
         },
         "node_modules/@fluidframework/sequence": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-c17zZQjevyoQD4YZFbBXnQSCC47ucsokYcj0NtPKFWj/weF/ha0ZZ4sgIaXNWOLN4WYgOpliGeyNMf33zp9Xog==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-9mnSQ+l6FNcfqIPbsrl1lJP7GiAnc5YwcdN4odRKBXaKRbLBJNS8WGAyYDNmAMHi+kVbGZ0F9eoYH1P6wtNMkQ==",
             "dependencies": {
-                "@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/merge-tree": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/merge-tree": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/protocol-definitions": "^3.0.0",
-                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "uuid": "^9.0.0"
             }
         },
@@ -2659,13 +2659,13 @@
             }
         },
         "node_modules/@fluidframework/server-services-client": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-2.0.1.tgz",
-            "integrity": "sha512-VJrmSHYuvVXZ6VUi8rlSzAoQP7R2D8ohKBISLwD97VH1pyl7leuQ1cos7SFJRriIJySHyzveqrbNw8vYpeJXIg==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-2.0.2.tgz",
+            "integrity": "sha512-YbK9Hz2URRJreK1IoZZCOCFrIPNxnayIT3xbu7SfeU8nG9ui6+QyjO1WS58/oTM9+raQCmgZaIfzfENXzpVqZA==",
             "dependencies": {
                 "@fluidframework/common-utils": "^3.0.0",
-                "@fluidframework/gitresources": "~2.0.1",
-                "@fluidframework/protocol-base": "~2.0.1",
+                "@fluidframework/gitresources": "~2.0.2",
+                "@fluidframework/protocol-base": "~2.0.2",
                 "@fluidframework/protocol-definitions": "^3.0.0",
                 "axios": "^0.26.0",
                 "crc-32": "1.2.0",
@@ -3077,21 +3077,21 @@
             }
         },
         "node_modules/@fluidframework/shared-object-base": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-SxvDleS9NhBIpEe0kFVuSOwABuUtxtEDqSTUZWu/4MEVUuaGE3/+NjYXIvJylNQIxtSiMmAg/1uIomi7UG/+HA==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-RCM+iQ1kFkSMiUyxe/v7VkLmpfsy6I8kULD7+vbv29ltKFM3YKio3DkmUvPIJICzAlj6QnFdthYS88NTdeyqOQ==",
             "dependencies": {
-                "@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/container-runtime": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/container-runtime": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/protocol-definitions": "^3.0.0",
-                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "uuid": "^9.0.0"
             }
         },
@@ -3108,21 +3108,21 @@
             }
         },
         "node_modules/@fluidframework/synthesize": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-48XxrYddsePCDA34w4YJhoSiNQ1c5QcgEV+LNmz7yvFXWlnWQGwxpvDoVFZnu5nDShVyrtfQVaOwuXe0bOEAVQ==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-kMrDLm8k8WmB3W3iEYxsYxfo0b5gHSFcZIfkNhP5QXenPAPbzCmvIaJg2Zo8rxY+grymfOpvlXW8bf9G/IBbVw==",
             "dependencies": {
-                "@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+                "@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
             }
         },
         "node_modules/@fluidframework/telemetry-utils": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-1oZhXUBA05i+OYD0huPYhmDxVE/P58HaKoaVundSu1zsu7h2sel+xPE7cUpKVl74PIu5gjDgQeVM6bClNjPlFw==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-0Din0dxWTBKXGRAvBuxPeV6t5yg3jTbCFWlv4o6tPRrqNRGuOrzvb7lrEoJ21kcTLQRdnGISefdO8LLJZ7zUeQ==",
             "dependencies": {
-                "@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/protocol-definitions": "^3.0.0",
                 "debug": "^4.1.1",
                 "events": "^3.1.0",
@@ -3142,22 +3142,22 @@
             }
         },
         "node_modules/@fluidframework/tinylicious-client": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-hmAt4z16KaYKHntM8BWpZdXV9B/sqJhgwUZnFVej17Lew6ZwagJ13OH5WUirdREW4O0ewzs9k8HEMMUZi1vReg==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-7S9Hn/JIlQ2sn8c/l194P1a1HIjNPO9M6p0WZbWtq+CSR0hNT4+MZSlvKfwbwO1x9toT3jO1Yn+XEOQWouYD3g==",
             "dependencies": {
-                "@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/fluid-static": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/fluid-static": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/protocol-definitions": "^3.0.0",
-                "@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/tinylicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/tinylicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "uuid": "^9.0.0"
             }
         },
@@ -3174,16 +3174,15 @@
             }
         },
         "node_modules/@fluidframework/tinylicious-driver": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-ILIi5Mt7e+PZTat5wFyT6acU4j8wfKcs+lyZakpzC5RA1TRcfgV7kYihsBcbiFUMRxPERawg9nSQcHwAeTqhPA==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-jjvk3f2NXimgKfZKlkAxZZdNhr4zMVF9ToF2PTO+9kXEco8hRdWMTKJUltQjbx+KJ0AFAA477v2H6IiCCFN2QA==",
             "dependencies": {
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "@fluidframework/protocol-definitions": "^3.0.0",
-                "@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/server-services-client": "^2.0.1",
+                "@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
                 "jsrsasign": "^10.5.25",
                 "uuid": "^9.0.0"
             }
@@ -3201,11 +3200,11 @@
             }
         },
         "node_modules/@fluidframework/view-interfaces": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-GyCbK0GUHOr5dAfPfW4DwUmLBlPmQ42gEf28i2s5iuIqFe0GApdxNd+Al0YGzRDsNB8JwRbHjFjwraV1ebgTUQ==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-St867vvX3iHKzZSrmbCCrDgWlP7VxWhTUzUcFA9/Xr404HWl1Zy88E9Rd2oxw3/ass2biyAuUPppElIFh+0MzQ==",
             "dependencies": {
-                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+                "@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
             }
         },
         "node_modules/@hapi/hoek": {
@@ -7503,16 +7502,16 @@
             }
         },
         "node_modules/fluid-framework": {
-            "version": "2.0.0-internal.7.0.0",
-            "resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-internal.7.0.0.tgz",
-            "integrity": "sha512-rlSS3mDBgal/TWyFLBQWTNyxxDGlJKxsx2BHAkp0ULQVYzldebRI8uIuYuwGDHG0f4/IFy2zjgrve1vzXN3pJQ==",
+            "version": "2.0.0-internal.7.1.0",
+            "resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-internal.7.1.0.tgz",
+            "integrity": "sha512-7gEXLH8CqirQlsbSo3AL33xB9PXOoEIzmntx5pDLfmoMaJigEewSOLBhviss3TSL8oJ7elM4DlkXxjqA6EGt0g==",
             "dependencies": {
-                "@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/fluid-static": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-                "@fluidframework/sequence": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+                "@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/fluid-static": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+                "@fluidframework/sequence": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
             }
         },
         "node_modules/fn.name": {

--- a/multi-framework-diceroller/package-lock.json
+++ b/multi-framework-diceroller/package-lock.json
@@ -19,7 +19,7 @@
             "devDependencies": {
                 "@babel/core": "^7.15.5",
                 "@babel/preset-env": "^7.15.0",
-                "@fluidframework/build-common": "^2.0.0-151899",
+                "@fluidframework/build-common": "^2.0.2",
                 "babel-loader": "^8.2.2",
                 "clean-webpack-plugin": "^3.0.0",
                 "html-webpack-plugin": "^4.3.0",
@@ -1842,9 +1842,9 @@
             }
         },
         "node_modules/@fluidframework/build-common": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.0.tgz",
-            "integrity": "sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.2.tgz",
+            "integrity": "sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==",
             "dev": true,
             "bin": {
                 "gen-version": "bin/gen-version"

--- a/multi-framework-diceroller/package.json
+++ b/multi-framework-diceroller/package.json
@@ -35,7 +35,7 @@
     "devDependencies": {
         "@babel/core": "^7.15.5",
         "@babel/preset-env": "^7.15.0",
-        "@fluidframework/build-common": "^2.0.0-151899",
+        "@fluidframework/build-common": "^2.0.2",
         "babel-loader": "^8.2.2",
         "clean-webpack-plugin": "^3.0.0",
         "html-webpack-plugin": "^4.3.0",

--- a/multi-framework-diceroller/package.json
+++ b/multi-framework-diceroller/package.json
@@ -26,8 +26,8 @@
     },
     "dependencies": {
         "@babel/preset-react": "^7.14.5",
-        "@fluidframework/tinylicious-client": "^2.0.0-internal.7.0.0",
-        "fluid-framework": "^2.0.0-internal.7.0.0",
+        "@fluidframework/tinylicious-client": "^2.0.0-internal.7.1.0",
+        "fluid-framework": "^2.0.0-internal.7.1.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "vue": "^3.2.11"

--- a/node-demo/package-lock.json
+++ b/node-demo/package-lock.json
@@ -15,7 +15,7 @@
 				"readline-sync": "^1.4.10"
 			},
 			"devDependencies": {
-				"@fluidframework/build-common": "^2.0.0-151899",
+				"@fluidframework/build-common": "^2.0.2",
 				"chai": "^4.3.7",
 				"mocha": "^10.1.0",
 				"mocha-junit-reporter": "^2.2.1",
@@ -65,9 +65,9 @@
 			}
 		},
 		"node_modules/@fluidframework/build-common": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.0.tgz",
-			"integrity": "sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.2.tgz",
+			"integrity": "sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==",
 			"dev": true,
 			"bin": {
 				"gen-version": "bin/gen-version"

--- a/node-demo/package-lock.json
+++ b/node-demo/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "0.1.0",
 			"license": "MIT",
 			"dependencies": {
-				"@fluidframework/tinylicious-client": "^2.0.0-internal.7.0.0",
-				"fluid-framework": "^2.0.0-internal.7.0.0",
+				"@fluidframework/tinylicious-client": "^2.0.0-internal.7.1.0",
+				"fluid-framework": "^2.0.0-internal.7.1.0",
 				"prettier": "^2.7.1",
 				"readline-sync": "^1.4.10"
 			},
@@ -28,12 +28,12 @@
 			}
 		},
 		"node_modules/@fluid-internal/client-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-N9NLm6+1pZ4u2kCMYsj0MbOvPhRWd2sWerdtJOVACICYNZjptiKGi9gU8Wf1vWliILKXC4gJmQUWXWOp+E4piQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-CUjL3pjmfpyZ2eRddgpE48b8wjIIDmKL5aiLw6eqoO0HWo2er3kV0nPX8rwMRNA+tuHahz14afLQ+nb0wA5V3A==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@types/events": "^3.0.0",
 				"base64-js": "^1.5.1",
 				"buffer": "^6.0.3",
@@ -43,24 +43,24 @@
 			}
 		},
 		"node_modules/@fluidframework/aqueduct": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-oz4JCEHpve0QyfD2+huzeOiGyOpfa+e7wiknQ03iHQPLKVFpiSz1cX5sbr6DFdCovz5Ub90Ot8rneuzMH8F9IA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-c9p0BFGnFwvCewBxjOLiFc1/zZ+ybMRUTij1BgkFuaP/fSnZamKSvecNdhfGvoDcWIDsQPb0gb/wppX3TU21vg==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/synthesize": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/request-handler": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/synthesize": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/view-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -93,30 +93,30 @@
 			}
 		},
 		"node_modules/@fluidframework/container-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-OWBJLiXkXZrB2kb9HNcj7BLSyEvzyALCVzZhtTVDd1LT5cUwPPx92fLfLHmLglhnJwW7UK+/UvggjAqNxAlbQA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-zUxrbGbbNwPdT+WDmXz7oeomZuqUzUQqDLAkgxO/qFnwdqh9pBI6nkzuXeGwQEOLScLkDUNRzJwimfKqFmBt2w==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/container-loader": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-lPJwdDR8ZCXRHiLhZzewWVr5jItlQ4MHrMa95wLdGxoPxpkkAMZBYLOLxmsIp7W1QQ6+mHZYw9ECv6B5TojroA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-EbHroDko65kyw92YprxMjBXi61vEVpL+uogZyQ0Jlkfvkor0xiVgtfgwKxFdUy+j6uElzYGonm6jRJMh+ga+6w==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
 				"events": "^3.1.0",
@@ -126,22 +126,22 @@
 			}
 		},
 		"node_modules/@fluidframework/container-runtime": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-Ju+58IfRVZeQS5zgk0u6QHq9av0GQABV33BAioKOqtB685a1fbVhgTTPX74KtQlB0MKaXyt0mZNW9oXUkoUSpA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-I1Lf53ZBZtnVpEbwSDaLVwoCGa/CX2vEbv5t/lHLFKrjGmNxzahx1ZWAw46jjg3ZBPEpdiYbwqKpCoRHg44a6A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"double-ended-queue": "^2.1.0-0",
 				"events": "^3.1.0",
 				"lz4js": "^0.2.0",
@@ -150,94 +150,94 @@
 			}
 		},
 		"node_modules/@fluidframework/container-runtime-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-ujWp607A5Lg2ZjN8QKYV28LstvGzGXFxXy/2phME4bPOQT9EtPD7uejLbAPVUg7LmJgDFOBQD1VuAI6Vlx92MQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-kC85xUSfrr03+JiUrnnjwJ2PVtcylGt/1UB/b8CWAC4T4P70roqEH48vZbnunjY5yJ7vmzHk7AThrsiGGhN6Sg==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/core-interfaces": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-znZqbn0ew7aqrnjFf+sfNsnajjZ9z9PHycrfzkVfo6YAW1WKuTi7VmZwUyLGVDIAJ86qlQW4/kI9WL4OypzSFA=="
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-HAqosUcAeyZWr1fQaE2CkR+0aMs3nHCQiDa+XhpQarJKNB6wMkscQ+AgzqxmAH6tX8R5Yz6gaPDEp/zScCepXQ=="
 		},
 		"node_modules/@fluidframework/core-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-nEs40QaYzCBlb0PVG2YFCQU++nsnpdHdkl83ilbtdGlYw37GUS+3vl5UbFqGv3EvRdjl4bu1nXi3Pve0AOESUA=="
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-R9fhUy0OPPFiCBEA+G2kPvKOD2YipkCbpRMNVLC1o0khaadcuB2Ji8xEy/1/bZAkjO+LiiZj49dxTqSxEuSDXA=="
 		},
 		"node_modules/@fluidframework/datastore": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-jpRJ9ArExfNvGcj+ymPq52jSd+KphExV6ryYXGr9T8K2+akSS4ap0G/zzgOSvnxDk69jUev38s9DISr3wLHCVg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-5Rxt2kwHiUv80OjksWVoXOqBfJc5gaRex4o4ALNL2BuTMnewQuQ4OJHzCvLIDGkDSgl0FgHXpoNac9HEAEEi8A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"lodash": "^4.17.21",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/datastore-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-PF/xp9c6C9o2fcmGTdBcfSCSJ6aOnYHdDtTYaFiGtWlFfLm0vfZo04NBkSsIUAvGE0UyOe8m40y6uYs1R5lJiA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-HkLqqhTD1pLEQ6uBgD6GpfQh0q+zbxVURLKIJ808PzUpXUWPK+c4R2+HA+sebQz/CcrO+VYlE+MO7TYct38eog==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-base": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-w0uGZGJOcDrjNQDHOs3GurcVak/Ssj9xlWiJZ8sx8U9aq84c+BvTbZpjUb9FViP0JQI6NWVnjIMTW4AqWeeDuw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-5hUfYI7tte0JL+UXADpU03W+k3BG5RPRDlvJCt+4pPMz9yrhtpjR5mHJL0M3WsuY/uACuCAN5Wfe9taHg4HhzA==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-yPsYKh7CPOaYrxmAMMDzKkiTRsy99XX97Wibjr4gjQ5rRgnE8wIMC0Y3PHvRgUwj1pPcZEArFTFnCIxUhs3lvw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-KnN+c3EWDP1jOlQU4horUbNNzfCDWUQdo3bxnYGy46Dfkag//OGUNF85JzHHeWKnPaB/YBcfWc8TuT/TBlcbsQ==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-dyKGoKk/4WFIEujmO+hZJIy8s6E6JV0mVUewkSY/LKdzJ6gZtjOKMyKhoR+jMPcvhq4CoMdSZz+lrh/fAf4sWg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-OnggpLFQBNFh0jLVHC3aZE1P13yat2+nKQlFnKD5gtmkBKbHKqWkrhdyX0xcfpsAHlD8NbStsscYfkz336NIQw==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/gitresources": "^2.0.1",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"axios": "^0.26.0",
 				"lz4js": "^0.2.0",
 				"url": "^0.11.0",
@@ -245,70 +245,70 @@
 			}
 		},
 		"node_modules/@fluidframework/fluid-static": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-MCWVw5Bbh1wMvyqolb2vrnRLAt6ETtc+OAhR3IH0VmID0JxG9PxNnAXo1iwj8YlZKMcLWHokcW1PA5wjyChMzw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-o90QGQoIyouZaBc74muLDG3Ny4O0fLZaLvkyA++nsB4lDAPFcsjjq+QQASPPCvwye591Z4jRcWV3ghDZsT6V6g==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/aqueduct": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/aqueduct": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/request-handler": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/gitresources": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-2.0.1.tgz",
-			"integrity": "sha512-N8lHCEkoEE7uLtjo7VMAl7psnuQDYSO2z61dbb4zUSWOVZ6E0cyhjR5N3dZtffhbTq0qPiYYN3Ss5M06Yri6OA=="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-2.0.2.tgz",
+			"integrity": "sha512-v9hI+uT8B5kwFAs+x6naqb7rOAX84r9ixjyIrE7Gqa9sBHIZ8pP9zKqNIdcS+Y14IqGiJYGDmwzM7Km6ThILCw=="
 		},
 		"node_modules/@fluidframework/map": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-ztuF8GgO2c/tZJwHHzbzXQ3UAhAfIQlIE4hW+wGy5txW6yqnvmUjpUDWqunnFp1h36DrNq9ro3RcB/labJf5bQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-OzoNKQ8ic/k+ZJSSieGtxeNLLbluu5H9wWr/6X/AZZV+WdaSAHNOlyD8hgh7Ae+7uRwx9ChfLuCBp1CgOcRS1A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"node_modules/@fluidframework/merge-tree": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-vnfR2ZgaImUvpfqkdyI+d6lEnrM+ioD2+tiHcBemii3q6PSK6+qbtwbFuslAUj/VVKjirIChPQCPwIHNH2nl0A==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-FamAnrAd8SHX2LKdjaKxoyvSX/w6hzoeSRtl9Oz8M89vrjGGT6Vz9s4D2gFaUY1rWhuYXW6aIAaOsmrgYekYoQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/protocol-base": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-2.0.1.tgz",
-			"integrity": "sha512-h/AiwgQhGFfKZaJLebEcvJ0G7j+6FOHwlEyd9nT7BfLp/zdwW63Jd4gA4PsQXmpzurRxskYuoYUKyWJGcO7E0Q==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-2.0.2.tgz",
+			"integrity": "sha512-9AbQ8FuZ5UNZgOWmNaWxs7CH08H9qRYX6OkTUbRXNjdJaFRSCBCkPSA23aHD85EN49UEkkpfoyH1SsQchHuR4Q==",
 			"dependencies": {
 				"@fluidframework/common-utils": "^3.0.0",
-				"@fluidframework/gitresources": "~2.0.1",
+				"@fluidframework/gitresources": "~2.0.2",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"events": "^3.1.0"
 			}
@@ -322,33 +322,33 @@
 			}
 		},
 		"node_modules/@fluidframework/request-handler": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-I7TZUmiAc0lhD6Y3AeHACXvS4GtIbK5xc+Ph042J7eWZPUgydD50AOH7bXBjuUXdRhF35i1X23vR+UEq0tp95Q==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-lMaxH2tjDT+MFKlatFBvmRbRxpmHgvSAwGXTUILxM5uOW32RURDu3GmgGb+BpGAmXyjKNwLaUgHBONCegK9sQQ==",
 			"dependencies": {
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/routerlicious-driver": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-+O1Omih8k3gLXfClw3A6CFlgNccBkujUBkeW/4t67LXVr2Z3/q4OOqfSmXVEFePyjiJZ0O6mErAXRRJ78euJVA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-NyciUkBlKNmMcy5yvilYsC6pyYExASrjx/3Pg8z5Df950hclLP4JNu1aJdraB9K7WUUuo50Pz75ZFEKHhvOu/g==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/gitresources": "^2.0.1",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"@fluidframework/server-services-client": "^2.0.1",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"socket.io-client": "^4.6.1",
@@ -357,59 +357,59 @@
 			}
 		},
 		"node_modules/@fluidframework/runtime-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-uIqvypcpfhBEwmAlKjCvofwsioeJvbo35umWqXsX6qOUp68xrbMsMwDB1C7o4gA6cjiicNTZH4lhbsOUJV67jA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-54g4ORqpZVoKlt2H74KJeDtsZWI2G2MSpUIExOOtPbTfgJYzA7cldCUwR8soAXMLEA+NreHycyR/cwzSJlT6nw==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0"
 			}
 		},
 		"node_modules/@fluidframework/runtime-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-E5oenqEdtNuO5FvbirN2dogltVofqhl9Cqu9d3wZnFonfczuMDgBX5rPcQFp+5B8E5t4YXlKe0V7MXx1j6o+Qw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-Rz/qG/N+GlW3jSfgw4WcVjiaT8sa6KNIgdS4oqcVAM+sLSnTA7SWtn7uga68wtg5J43Rzgb2e9iW39D1S0RofQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/sequence": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-c17zZQjevyoQD4YZFbBXnQSCC47ucsokYcj0NtPKFWj/weF/ha0ZZ4sgIaXNWOLN4WYgOpliGeyNMf33zp9Xog==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-9mnSQ+l6FNcfqIPbsrl1lJP7GiAnc5YwcdN4odRKBXaKRbLBJNS8WGAyYDNmAMHi+kVbGZ0F9eoYH1P6wtNMkQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/server-services-client": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-2.0.1.tgz",
-			"integrity": "sha512-VJrmSHYuvVXZ6VUi8rlSzAoQP7R2D8ohKBISLwD97VH1pyl7leuQ1cos7SFJRriIJySHyzveqrbNw8vYpeJXIg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-2.0.2.tgz",
+			"integrity": "sha512-YbK9Hz2URRJreK1IoZZCOCFrIPNxnayIT3xbu7SfeU8nG9ui6+QyjO1WS58/oTM9+raQCmgZaIfzfENXzpVqZA==",
 			"dependencies": {
 				"@fluidframework/common-utils": "^3.0.0",
-				"@fluidframework/gitresources": "~2.0.1",
-				"@fluidframework/protocol-base": "~2.0.1",
+				"@fluidframework/gitresources": "~2.0.2",
+				"@fluidframework/protocol-base": "~2.0.2",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -423,40 +423,40 @@
 			}
 		},
 		"node_modules/@fluidframework/shared-object-base": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-SxvDleS9NhBIpEe0kFVuSOwABuUtxtEDqSTUZWu/4MEVUuaGE3/+NjYXIvJylNQIxtSiMmAg/1uIomi7UG/+HA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-RCM+iQ1kFkSMiUyxe/v7VkLmpfsy6I8kULD7+vbv29ltKFM3YKio3DkmUvPIJICzAlj6QnFdthYS88NTdeyqOQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/synthesize": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-48XxrYddsePCDA34w4YJhoSiNQ1c5QcgEV+LNmz7yvFXWlnWQGwxpvDoVFZnu5nDShVyrtfQVaOwuXe0bOEAVQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-kMrDLm8k8WmB3W3iEYxsYxfo0b5gHSFcZIfkNhP5QXenPAPbzCmvIaJg2Zo8rxY+grymfOpvlXW8bf9G/IBbVw==",
 			"dependencies": {
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/telemetry-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-1oZhXUBA05i+OYD0huPYhmDxVE/P58HaKoaVundSu1zsu7h2sel+xPE7cUpKVl74PIu5gjDgQeVM6bClNjPlFw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-0Din0dxWTBKXGRAvBuxPeV6t5yg3jTbCFWlv4o6tPRrqNRGuOrzvb7lrEoJ21kcTLQRdnGISefdO8LLJZ7zUeQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"debug": "^4.1.1",
 				"events": "^3.1.0",
@@ -464,46 +464,45 @@
 			}
 		},
 		"node_modules/@fluidframework/tinylicious-client": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-hmAt4z16KaYKHntM8BWpZdXV9B/sqJhgwUZnFVej17Lew6ZwagJ13OH5WUirdREW4O0ewzs9k8HEMMUZi1vReg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-7S9Hn/JIlQ2sn8c/l194P1a1HIjNPO9M6p0WZbWtq+CSR0hNT4+MZSlvKfwbwO1x9toT3jO1Yn+XEOQWouYD3g==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/fluid-static": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/tinylicious-driver": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-ILIi5Mt7e+PZTat5wFyT6acU4j8wfKcs+lyZakpzC5RA1TRcfgV7kYihsBcbiFUMRxPERawg9nSQcHwAeTqhPA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-jjvk3f2NXimgKfZKlkAxZZdNhr4zMVF9ToF2PTO+9kXEco8hRdWMTKJUltQjbx+KJ0AFAA477v2H6IiCCFN2QA==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/server-services-client": "^2.0.1",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/view-interfaces": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-GyCbK0GUHOr5dAfPfW4DwUmLBlPmQ42gEf28i2s5iuIqFe0GApdxNd+Al0YGzRDsNB8JwRbHjFjwraV1ebgTUQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-St867vvX3iHKzZSrmbCCrDgWlP7VxWhTUzUcFA9/Xr404HWl1Zy88E9Rd2oxw3/ass2biyAuUPppElIFh+0MzQ==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@hapi/hoek": {
@@ -592,9 +591,9 @@
 			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
 		},
 		"node_modules/@types/events": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.1.tgz",
-			"integrity": "sha512-QfUFdKjGSc+iCf8OFZhqJKfDuqB6lP57kSMkPw8ba3yNDANicUwCdaPt5ytZ4nDXXVFxQkvT8v73I4stSVrCxA=="
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.2.tgz",
+			"integrity": "sha512-v4Mr60wJuF069iZZCdY5DKhfj0l6eXNJtbSM/oMDNdRLoBEUsktmKnswkz0X3OAic5W8Qy/YU6owKE4A66Y46A=="
 		},
 		"node_modules/ansi-colors": {
 			"version": "4.1.1",
@@ -1181,16 +1180,16 @@
 			}
 		},
 		"node_modules/fluid-framework": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-rlSS3mDBgal/TWyFLBQWTNyxxDGlJKxsx2BHAkp0ULQVYzldebRI8uIuYuwGDHG0f4/IFy2zjgrve1vzXN3pJQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-7gEXLH8CqirQlsbSo3AL33xB9PXOoEIzmntx5pDLfmoMaJigEewSOLBhviss3TSL8oJ7elM4DlkXxjqA6EGt0g==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/sequence": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/fluid-static": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/sequence": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/follow-redirects": {
@@ -1253,9 +1252,12 @@
 			}
 		},
 		"node_modules/function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
@@ -1925,9 +1927,9 @@
 			}
 		},
 		"node_modules/object-inspect": {
-			"version": "1.12.3",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-			"integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.0.tgz",
+			"integrity": "sha512-HQ4J+ic8hKrgIt3mqk6cVOVrW2ozL4KdvHlqpBv9vDYWx9ysAgENAdvy4FoGF+KFdhR7nQTNm5J0ctAeOwn+3g==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}

--- a/node-demo/package.json
+++ b/node-demo/package.json
@@ -23,8 +23,8 @@
 		"node": ">=18.0.0"
 	},
 	"dependencies": {
-		"@fluidframework/tinylicious-client": "^2.0.0-internal.7.0.0",
-		"fluid-framework": "^2.0.0-internal.7.0.0",
+		"@fluidframework/tinylicious-client": "^2.0.0-internal.7.1.0",
+		"fluid-framework": "^2.0.0-internal.7.1.0",
 		"readline-sync": "^1.4.10",
 		"prettier": "^2.7.1"
 	},

--- a/node-demo/package.json
+++ b/node-demo/package.json
@@ -29,7 +29,7 @@
 		"prettier": "^2.7.1"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0-151899",
+		"@fluidframework/build-common": "^2.0.2",
 		"chai": "^4.3.7",
 		"mocha": "^10.1.0",
 		"mocha-junit-reporter": "^2.2.1",

--- a/react-demo/package-lock.json
+++ b/react-demo/package-lock.json
@@ -15,7 +15,7 @@
 				"react-dom": "^16.10.2"
 			},
 			"devDependencies": {
-				"@fluidframework/build-common": "^2.0.0-151899",
+				"@fluidframework/build-common": "^2.0.2",
 				"@testing-library/jest-dom": "^5.11.4",
 				"@testing-library/react": "^11.1.0",
 				"@testing-library/user-event": "^12.1.10",
@@ -2546,9 +2546,9 @@
 			}
 		},
 		"node_modules/@fluidframework/build-common": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.0.tgz",
-			"integrity": "sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.2.tgz",
+			"integrity": "sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==",
 			"dev": true,
 			"bin": {
 				"gen-version": "bin/gen-version"

--- a/react-demo/package-lock.json
+++ b/react-demo/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "0.1.0",
 			"license": "MIT",
 			"dependencies": {
-				"@fluidframework/tinylicious-client": "^2.0.0-internal.7.0.0",
-				"fluid-framework": "^2.0.0-internal.7.0.0",
+				"@fluidframework/tinylicious-client": "^2.0.0-internal.7.1.0",
+				"fluid-framework": "^2.0.0-internal.7.1.0",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			},
@@ -2474,12 +2474,12 @@
 			}
 		},
 		"node_modules/@fluid-internal/client-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-N9NLm6+1pZ4u2kCMYsj0MbOvPhRWd2sWerdtJOVACICYNZjptiKGi9gU8Wf1vWliILKXC4gJmQUWXWOp+E4piQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-CUjL3pjmfpyZ2eRddgpE48b8wjIIDmKL5aiLw6eqoO0HWo2er3kV0nPX8rwMRNA+tuHahz14afLQ+nb0wA5V3A==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@types/events": "^3.0.0",
 				"base64-js": "^1.5.1",
 				"buffer": "^6.0.3",
@@ -2512,24 +2512,24 @@
 			}
 		},
 		"node_modules/@fluidframework/aqueduct": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-oz4JCEHpve0QyfD2+huzeOiGyOpfa+e7wiknQ03iHQPLKVFpiSz1cX5sbr6DFdCovz5Ub90Ot8rneuzMH8F9IA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-c9p0BFGnFwvCewBxjOLiFc1/zZ+ybMRUTij1BgkFuaP/fSnZamKSvecNdhfGvoDcWIDsQPb0gb/wppX3TU21vg==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/synthesize": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/request-handler": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/synthesize": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/view-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -2603,30 +2603,30 @@
 			}
 		},
 		"node_modules/@fluidframework/container-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-OWBJLiXkXZrB2kb9HNcj7BLSyEvzyALCVzZhtTVDd1LT5cUwPPx92fLfLHmLglhnJwW7UK+/UvggjAqNxAlbQA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-zUxrbGbbNwPdT+WDmXz7oeomZuqUzUQqDLAkgxO/qFnwdqh9pBI6nkzuXeGwQEOLScLkDUNRzJwimfKqFmBt2w==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/container-loader": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-lPJwdDR8ZCXRHiLhZzewWVr5jItlQ4MHrMa95wLdGxoPxpkkAMZBYLOLxmsIp7W1QQ6+mHZYw9ECv6B5TojroA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-EbHroDko65kyw92YprxMjBXi61vEVpL+uogZyQ0Jlkfvkor0xiVgtfgwKxFdUy+j6uElzYGonm6jRJMh+ga+6w==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
 				"events": "^3.1.0",
@@ -2648,22 +2648,22 @@
 			}
 		},
 		"node_modules/@fluidframework/container-runtime": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-Ju+58IfRVZeQS5zgk0u6QHq9av0GQABV33BAioKOqtB685a1fbVhgTTPX74KtQlB0MKaXyt0mZNW9oXUkoUSpA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-I1Lf53ZBZtnVpEbwSDaLVwoCGa/CX2vEbv5t/lHLFKrjGmNxzahx1ZWAw46jjg3ZBPEpdiYbwqKpCoRHg44a6A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"double-ended-queue": "^2.1.0-0",
 				"events": "^3.1.0",
 				"lz4js": "^0.2.0",
@@ -2672,15 +2672,15 @@
 			}
 		},
 		"node_modules/@fluidframework/container-runtime-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-ujWp607A5Lg2ZjN8QKYV28LstvGzGXFxXy/2phME4bPOQT9EtPD7uejLbAPVUg7LmJgDFOBQD1VuAI6Vlx92MQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-kC85xUSfrr03+JiUrnnjwJ2PVtcylGt/1UB/b8CWAC4T4P70roqEH48vZbnunjY5yJ7vmzHk7AThrsiGGhN6Sg==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/container-runtime/node_modules/uuid": {
@@ -2696,44 +2696,44 @@
 			}
 		},
 		"node_modules/@fluidframework/core-interfaces": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-znZqbn0ew7aqrnjFf+sfNsnajjZ9z9PHycrfzkVfo6YAW1WKuTi7VmZwUyLGVDIAJ86qlQW4/kI9WL4OypzSFA=="
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-HAqosUcAeyZWr1fQaE2CkR+0aMs3nHCQiDa+XhpQarJKNB6wMkscQ+AgzqxmAH6tX8R5Yz6gaPDEp/zScCepXQ=="
 		},
 		"node_modules/@fluidframework/core-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-nEs40QaYzCBlb0PVG2YFCQU++nsnpdHdkl83ilbtdGlYw37GUS+3vl5UbFqGv3EvRdjl4bu1nXi3Pve0AOESUA=="
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-R9fhUy0OPPFiCBEA+G2kPvKOD2YipkCbpRMNVLC1o0khaadcuB2Ji8xEy/1/bZAkjO+LiiZj49dxTqSxEuSDXA=="
 		},
 		"node_modules/@fluidframework/datastore": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-jpRJ9ArExfNvGcj+ymPq52jSd+KphExV6ryYXGr9T8K2+akSS4ap0G/zzgOSvnxDk69jUev38s9DISr3wLHCVg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-5Rxt2kwHiUv80OjksWVoXOqBfJc5gaRex4o4ALNL2BuTMnewQuQ4OJHzCvLIDGkDSgl0FgHXpoNac9HEAEEi8A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"lodash": "^4.17.21",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/datastore-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-PF/xp9c6C9o2fcmGTdBcfSCSJ6aOnYHdDtTYaFiGtWlFfLm0vfZo04NBkSsIUAvGE0UyOe8m40y6uYs1R5lJiA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-HkLqqhTD1pLEQ6uBgD6GpfQh0q+zbxVURLKIJ808PzUpXUWPK+c4R2+HA+sebQz/CcrO+VYlE+MO7TYct38eog==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/datastore/node_modules/uuid": {
@@ -2749,41 +2749,41 @@
 			}
 		},
 		"node_modules/@fluidframework/driver-base": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-w0uGZGJOcDrjNQDHOs3GurcVak/Ssj9xlWiJZ8sx8U9aq84c+BvTbZpjUb9FViP0JQI6NWVnjIMTW4AqWeeDuw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-5hUfYI7tte0JL+UXADpU03W+k3BG5RPRDlvJCt+4pPMz9yrhtpjR5mHJL0M3WsuY/uACuCAN5Wfe9taHg4HhzA==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-yPsYKh7CPOaYrxmAMMDzKkiTRsy99XX97Wibjr4gjQ5rRgnE8wIMC0Y3PHvRgUwj1pPcZEArFTFnCIxUhs3lvw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-KnN+c3EWDP1jOlQU4horUbNNzfCDWUQdo3bxnYGy46Dfkag//OGUNF85JzHHeWKnPaB/YBcfWc8TuT/TBlcbsQ==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-dyKGoKk/4WFIEujmO+hZJIy8s6E6JV0mVUewkSY/LKdzJ6gZtjOKMyKhoR+jMPcvhq4CoMdSZz+lrh/fAf4sWg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-OnggpLFQBNFh0jLVHC3aZE1P13yat2+nKQlFnKD5gtmkBKbHKqWkrhdyX0xcfpsAHlD8NbStsscYfkz336NIQw==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/gitresources": "^2.0.1",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"axios": "^0.26.0",
 				"lz4js": "^0.2.0",
 				"url": "^0.11.0",
@@ -2803,70 +2803,70 @@
 			}
 		},
 		"node_modules/@fluidframework/fluid-static": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-MCWVw5Bbh1wMvyqolb2vrnRLAt6ETtc+OAhR3IH0VmID0JxG9PxNnAXo1iwj8YlZKMcLWHokcW1PA5wjyChMzw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-o90QGQoIyouZaBc74muLDG3Ny4O0fLZaLvkyA++nsB4lDAPFcsjjq+QQASPPCvwye591Z4jRcWV3ghDZsT6V6g==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/aqueduct": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/aqueduct": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/request-handler": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/gitresources": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-2.0.1.tgz",
-			"integrity": "sha512-N8lHCEkoEE7uLtjo7VMAl7psnuQDYSO2z61dbb4zUSWOVZ6E0cyhjR5N3dZtffhbTq0qPiYYN3Ss5M06Yri6OA=="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-2.0.2.tgz",
+			"integrity": "sha512-v9hI+uT8B5kwFAs+x6naqb7rOAX84r9ixjyIrE7Gqa9sBHIZ8pP9zKqNIdcS+Y14IqGiJYGDmwzM7Km6ThILCw=="
 		},
 		"node_modules/@fluidframework/map": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-ztuF8GgO2c/tZJwHHzbzXQ3UAhAfIQlIE4hW+wGy5txW6yqnvmUjpUDWqunnFp1h36DrNq9ro3RcB/labJf5bQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-OzoNKQ8ic/k+ZJSSieGtxeNLLbluu5H9wWr/6X/AZZV+WdaSAHNOlyD8hgh7Ae+7uRwx9ChfLuCBp1CgOcRS1A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"node_modules/@fluidframework/merge-tree": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-vnfR2ZgaImUvpfqkdyI+d6lEnrM+ioD2+tiHcBemii3q6PSK6+qbtwbFuslAUj/VVKjirIChPQCPwIHNH2nl0A==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-FamAnrAd8SHX2LKdjaKxoyvSX/w6hzoeSRtl9Oz8M89vrjGGT6Vz9s4D2gFaUY1rWhuYXW6aIAaOsmrgYekYoQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/protocol-base": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-2.0.1.tgz",
-			"integrity": "sha512-h/AiwgQhGFfKZaJLebEcvJ0G7j+6FOHwlEyd9nT7BfLp/zdwW63Jd4gA4PsQXmpzurRxskYuoYUKyWJGcO7E0Q==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-2.0.2.tgz",
+			"integrity": "sha512-9AbQ8FuZ5UNZgOWmNaWxs7CH08H9qRYX6OkTUbRXNjdJaFRSCBCkPSA23aHD85EN49UEkkpfoyH1SsQchHuR4Q==",
 			"dependencies": {
 				"@fluidframework/common-utils": "^3.0.0",
-				"@fluidframework/gitresources": "~2.0.1",
+				"@fluidframework/gitresources": "~2.0.2",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"events": "^3.1.0"
 			}
@@ -2885,33 +2885,33 @@
 			"integrity": "sha512-t0jm6u4RX77Fn3rnoxDmavzo26y/JBsNIz5iptnamBgUTOo37i7wXr9VPB8+AjCEd3kcXPyFEoNa8zIEvgOekQ=="
 		},
 		"node_modules/@fluidframework/request-handler": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-I7TZUmiAc0lhD6Y3AeHACXvS4GtIbK5xc+Ph042J7eWZPUgydD50AOH7bXBjuUXdRhF35i1X23vR+UEq0tp95Q==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-lMaxH2tjDT+MFKlatFBvmRbRxpmHgvSAwGXTUILxM5uOW32RURDu3GmgGb+BpGAmXyjKNwLaUgHBONCegK9sQQ==",
 			"dependencies": {
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/routerlicious-driver": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-+O1Omih8k3gLXfClw3A6CFlgNccBkujUBkeW/4t67LXVr2Z3/q4OOqfSmXVEFePyjiJZ0O6mErAXRRJ78euJVA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-NyciUkBlKNmMcy5yvilYsC6pyYExASrjx/3Pg8z5Df950hclLP4JNu1aJdraB9K7WUUuo50Pz75ZFEKHhvOu/g==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/gitresources": "^2.0.1",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"@fluidframework/server-services-client": "^2.0.1",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"socket.io-client": "^4.6.1",
@@ -2932,48 +2932,48 @@
 			}
 		},
 		"node_modules/@fluidframework/runtime-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-uIqvypcpfhBEwmAlKjCvofwsioeJvbo35umWqXsX6qOUp68xrbMsMwDB1C7o4gA6cjiicNTZH4lhbsOUJV67jA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-54g4ORqpZVoKlt2H74KJeDtsZWI2G2MSpUIExOOtPbTfgJYzA7cldCUwR8soAXMLEA+NreHycyR/cwzSJlT6nw==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0"
 			}
 		},
 		"node_modules/@fluidframework/runtime-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-E5oenqEdtNuO5FvbirN2dogltVofqhl9Cqu9d3wZnFonfczuMDgBX5rPcQFp+5B8E5t4YXlKe0V7MXx1j6o+Qw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-Rz/qG/N+GlW3jSfgw4WcVjiaT8sa6KNIgdS4oqcVAM+sLSnTA7SWtn7uga68wtg5J43Rzgb2e9iW39D1S0RofQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/sequence": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-c17zZQjevyoQD4YZFbBXnQSCC47ucsokYcj0NtPKFWj/weF/ha0ZZ4sgIaXNWOLN4WYgOpliGeyNMf33zp9Xog==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-9mnSQ+l6FNcfqIPbsrl1lJP7GiAnc5YwcdN4odRKBXaKRbLBJNS8WGAyYDNmAMHi+kVbGZ0F9eoYH1P6wtNMkQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -3470,13 +3470,13 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-client": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-2.0.1.tgz",
-			"integrity": "sha512-VJrmSHYuvVXZ6VUi8rlSzAoQP7R2D8ohKBISLwD97VH1pyl7leuQ1cos7SFJRriIJySHyzveqrbNw8vYpeJXIg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-2.0.2.tgz",
+			"integrity": "sha512-YbK9Hz2URRJreK1IoZZCOCFrIPNxnayIT3xbu7SfeU8nG9ui6+QyjO1WS58/oTM9+raQCmgZaIfzfENXzpVqZA==",
 			"dependencies": {
 				"@fluidframework/common-utils": "^3.0.0",
-				"@fluidframework/gitresources": "~2.0.1",
-				"@fluidframework/protocol-base": "~2.0.1",
+				"@fluidframework/gitresources": "~2.0.2",
+				"@fluidframework/protocol-base": "~2.0.2",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -4008,21 +4008,21 @@
 			}
 		},
 		"node_modules/@fluidframework/shared-object-base": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-SxvDleS9NhBIpEe0kFVuSOwABuUtxtEDqSTUZWu/4MEVUuaGE3/+NjYXIvJylNQIxtSiMmAg/1uIomi7UG/+HA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-RCM+iQ1kFkSMiUyxe/v7VkLmpfsy6I8kULD7+vbv29ltKFM3YKio3DkmUvPIJICzAlj6QnFdthYS88NTdeyqOQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -4039,21 +4039,21 @@
 			}
 		},
 		"node_modules/@fluidframework/synthesize": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-48XxrYddsePCDA34w4YJhoSiNQ1c5QcgEV+LNmz7yvFXWlnWQGwxpvDoVFZnu5nDShVyrtfQVaOwuXe0bOEAVQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-kMrDLm8k8WmB3W3iEYxsYxfo0b5gHSFcZIfkNhP5QXenPAPbzCmvIaJg2Zo8rxY+grymfOpvlXW8bf9G/IBbVw==",
 			"dependencies": {
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/telemetry-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-1oZhXUBA05i+OYD0huPYhmDxVE/P58HaKoaVundSu1zsu7h2sel+xPE7cUpKVl74PIu5gjDgQeVM6bClNjPlFw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-0Din0dxWTBKXGRAvBuxPeV6t5yg3jTbCFWlv4o6tPRrqNRGuOrzvb7lrEoJ21kcTLQRdnGISefdO8LLJZ7zUeQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"debug": "^4.1.1",
 				"events": "^3.1.0",
@@ -4073,22 +4073,22 @@
 			}
 		},
 		"node_modules/@fluidframework/tinylicious-client": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-hmAt4z16KaYKHntM8BWpZdXV9B/sqJhgwUZnFVej17Lew6ZwagJ13OH5WUirdREW4O0ewzs9k8HEMMUZi1vReg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-7S9Hn/JIlQ2sn8c/l194P1a1HIjNPO9M6p0WZbWtq+CSR0hNT4+MZSlvKfwbwO1x9toT3jO1Yn+XEOQWouYD3g==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/fluid-static": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -4105,16 +4105,15 @@
 			}
 		},
 		"node_modules/@fluidframework/tinylicious-driver": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-ILIi5Mt7e+PZTat5wFyT6acU4j8wfKcs+lyZakpzC5RA1TRcfgV7kYihsBcbiFUMRxPERawg9nSQcHwAeTqhPA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-jjvk3f2NXimgKfZKlkAxZZdNhr4zMVF9ToF2PTO+9kXEco8hRdWMTKJUltQjbx+KJ0AFAA477v2H6IiCCFN2QA==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/server-services-client": "^2.0.1",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^9.0.0"
 			}
@@ -4132,11 +4131,11 @@
 			}
 		},
 		"node_modules/@fluidframework/view-interfaces": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-GyCbK0GUHOr5dAfPfW4DwUmLBlPmQ42gEf28i2s5iuIqFe0GApdxNd+Al0YGzRDsNB8JwRbHjFjwraV1ebgTUQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-St867vvX3iHKzZSrmbCCrDgWlP7VxWhTUzUcFA9/Xr404HWl1Zy88E9Rd2oxw3/ass2biyAuUPppElIFh+0MzQ==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@hapi/hoek": {
@@ -10982,16 +10981,16 @@
 			"dev": true
 		},
 		"node_modules/fluid-framework": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-rlSS3mDBgal/TWyFLBQWTNyxxDGlJKxsx2BHAkp0ULQVYzldebRI8uIuYuwGDHG0f4/IFy2zjgrve1vzXN3pJQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-7gEXLH8CqirQlsbSo3AL33xB9PXOoEIzmntx5pDLfmoMaJigEewSOLBhviss3TSL8oJ7elM4DlkXxjqA6EGt0g==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/sequence": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/fluid-static": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/sequence": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/fn.name": {

--- a/react-demo/package.json
+++ b/react-demo/package.json
@@ -42,8 +42,8 @@
 		"node": ">=18.0.0"
 	},
 	"dependencies": {
-		"@fluidframework/tinylicious-client": "^2.0.0-internal.7.0.0",
-		"fluid-framework": "^2.0.0-internal.7.0.0",
+		"@fluidframework/tinylicious-client": "^2.0.0-internal.7.1.0",
+		"fluid-framework": "^2.0.0-internal.7.1.0",
 		"react": "^16.10.2",
 		"react-dom": "^16.10.2"
 	},

--- a/react-demo/package.json
+++ b/react-demo/package.json
@@ -48,7 +48,7 @@
 		"react-dom": "^16.10.2"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0-151899",
+		"@fluidframework/build-common": "^2.0.2",
 		"@testing-library/jest-dom": "^5.11.4",
 		"@testing-library/react": "^11.1.0",
 		"@testing-library/user-event": "^12.1.10",

--- a/react-starter-template/package-lock.json
+++ b/react-starter-template/package-lock.json
@@ -10,8 +10,8 @@
 			"license": "MIT",
 			"dependencies": {
 				"@fluentui/react": "^8.17.1",
-				"@fluidframework/tinylicious-client": "^2.0.0-internal.7.0.0",
-				"fluid-framework": "^2.0.0-internal.7.0.0",
+				"@fluidframework/tinylicious-client": "^2.0.0-internal.7.1.0",
+				"fluid-framework": "^2.0.0-internal.7.1.0",
 				"immer": "^9.0.5",
 				"react": "^17.0.2",
 				"react-dom": "^17.0.2",
@@ -2775,12 +2775,12 @@
 			}
 		},
 		"node_modules/@fluid-internal/client-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-N9NLm6+1pZ4u2kCMYsj0MbOvPhRWd2sWerdtJOVACICYNZjptiKGi9gU8Wf1vWliILKXC4gJmQUWXWOp+E4piQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-CUjL3pjmfpyZ2eRddgpE48b8wjIIDmKL5aiLw6eqoO0HWo2er3kV0nPX8rwMRNA+tuHahz14afLQ+nb0wA5V3A==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@types/events": "^3.0.0",
 				"base64-js": "^1.5.1",
 				"buffer": "^6.0.3",
@@ -2790,24 +2790,24 @@
 			}
 		},
 		"node_modules/@fluidframework/aqueduct": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-oz4JCEHpve0QyfD2+huzeOiGyOpfa+e7wiknQ03iHQPLKVFpiSz1cX5sbr6DFdCovz5Ub90Ot8rneuzMH8F9IA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-c9p0BFGnFwvCewBxjOLiFc1/zZ+ybMRUTij1BgkFuaP/fSnZamKSvecNdhfGvoDcWIDsQPb0gb/wppX3TU21vg==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/synthesize": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/request-handler": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/synthesize": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/view-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -2858,30 +2858,30 @@
 			"integrity": "sha512-t0jm6u4RX77Fn3rnoxDmavzo26y/JBsNIz5iptnamBgUTOo37i7wXr9VPB8+AjCEd3kcXPyFEoNa8zIEvgOekQ=="
 		},
 		"node_modules/@fluidframework/container-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-OWBJLiXkXZrB2kb9HNcj7BLSyEvzyALCVzZhtTVDd1LT5cUwPPx92fLfLHmLglhnJwW7UK+/UvggjAqNxAlbQA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-zUxrbGbbNwPdT+WDmXz7oeomZuqUzUQqDLAkgxO/qFnwdqh9pBI6nkzuXeGwQEOLScLkDUNRzJwimfKqFmBt2w==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/container-loader": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-lPJwdDR8ZCXRHiLhZzewWVr5jItlQ4MHrMa95wLdGxoPxpkkAMZBYLOLxmsIp7W1QQ6+mHZYw9ECv6B5TojroA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-EbHroDko65kyw92YprxMjBXi61vEVpL+uogZyQ0Jlkfvkor0xiVgtfgwKxFdUy+j6uElzYGonm6jRJMh+ga+6w==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
 				"events": "^3.1.0",
@@ -2903,22 +2903,22 @@
 			}
 		},
 		"node_modules/@fluidframework/container-runtime": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-Ju+58IfRVZeQS5zgk0u6QHq9av0GQABV33BAioKOqtB685a1fbVhgTTPX74KtQlB0MKaXyt0mZNW9oXUkoUSpA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-I1Lf53ZBZtnVpEbwSDaLVwoCGa/CX2vEbv5t/lHLFKrjGmNxzahx1ZWAw46jjg3ZBPEpdiYbwqKpCoRHg44a6A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"double-ended-queue": "^2.1.0-0",
 				"events": "^3.1.0",
 				"lz4js": "^0.2.0",
@@ -2927,15 +2927,15 @@
 			}
 		},
 		"node_modules/@fluidframework/container-runtime-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-ujWp607A5Lg2ZjN8QKYV28LstvGzGXFxXy/2phME4bPOQT9EtPD7uejLbAPVUg7LmJgDFOBQD1VuAI6Vlx92MQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-kC85xUSfrr03+JiUrnnjwJ2PVtcylGt/1UB/b8CWAC4T4P70roqEH48vZbnunjY5yJ7vmzHk7AThrsiGGhN6Sg==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/container-runtime/node_modules/uuid": {
@@ -2951,44 +2951,44 @@
 			}
 		},
 		"node_modules/@fluidframework/core-interfaces": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-znZqbn0ew7aqrnjFf+sfNsnajjZ9z9PHycrfzkVfo6YAW1WKuTi7VmZwUyLGVDIAJ86qlQW4/kI9WL4OypzSFA=="
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-HAqosUcAeyZWr1fQaE2CkR+0aMs3nHCQiDa+XhpQarJKNB6wMkscQ+AgzqxmAH6tX8R5Yz6gaPDEp/zScCepXQ=="
 		},
 		"node_modules/@fluidframework/core-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-nEs40QaYzCBlb0PVG2YFCQU++nsnpdHdkl83ilbtdGlYw37GUS+3vl5UbFqGv3EvRdjl4bu1nXi3Pve0AOESUA=="
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-R9fhUy0OPPFiCBEA+G2kPvKOD2YipkCbpRMNVLC1o0khaadcuB2Ji8xEy/1/bZAkjO+LiiZj49dxTqSxEuSDXA=="
 		},
 		"node_modules/@fluidframework/datastore": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-jpRJ9ArExfNvGcj+ymPq52jSd+KphExV6ryYXGr9T8K2+akSS4ap0G/zzgOSvnxDk69jUev38s9DISr3wLHCVg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-5Rxt2kwHiUv80OjksWVoXOqBfJc5gaRex4o4ALNL2BuTMnewQuQ4OJHzCvLIDGkDSgl0FgHXpoNac9HEAEEi8A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"lodash": "^4.17.21",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/datastore-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-PF/xp9c6C9o2fcmGTdBcfSCSJ6aOnYHdDtTYaFiGtWlFfLm0vfZo04NBkSsIUAvGE0UyOe8m40y6uYs1R5lJiA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-HkLqqhTD1pLEQ6uBgD6GpfQh0q+zbxVURLKIJ808PzUpXUWPK+c4R2+HA+sebQz/CcrO+VYlE+MO7TYct38eog==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/datastore/node_modules/uuid": {
@@ -3004,41 +3004,41 @@
 			}
 		},
 		"node_modules/@fluidframework/driver-base": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-w0uGZGJOcDrjNQDHOs3GurcVak/Ssj9xlWiJZ8sx8U9aq84c+BvTbZpjUb9FViP0JQI6NWVnjIMTW4AqWeeDuw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-5hUfYI7tte0JL+UXADpU03W+k3BG5RPRDlvJCt+4pPMz9yrhtpjR5mHJL0M3WsuY/uACuCAN5Wfe9taHg4HhzA==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-yPsYKh7CPOaYrxmAMMDzKkiTRsy99XX97Wibjr4gjQ5rRgnE8wIMC0Y3PHvRgUwj1pPcZEArFTFnCIxUhs3lvw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-KnN+c3EWDP1jOlQU4horUbNNzfCDWUQdo3bxnYGy46Dfkag//OGUNF85JzHHeWKnPaB/YBcfWc8TuT/TBlcbsQ==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-dyKGoKk/4WFIEujmO+hZJIy8s6E6JV0mVUewkSY/LKdzJ6gZtjOKMyKhoR+jMPcvhq4CoMdSZz+lrh/fAf4sWg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-OnggpLFQBNFh0jLVHC3aZE1P13yat2+nKQlFnKD5gtmkBKbHKqWkrhdyX0xcfpsAHlD8NbStsscYfkz336NIQw==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/gitresources": "^2.0.1",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"axios": "^0.26.0",
 				"lz4js": "^0.2.0",
 				"url": "^0.11.0",
@@ -3058,70 +3058,70 @@
 			}
 		},
 		"node_modules/@fluidframework/fluid-static": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-MCWVw5Bbh1wMvyqolb2vrnRLAt6ETtc+OAhR3IH0VmID0JxG9PxNnAXo1iwj8YlZKMcLWHokcW1PA5wjyChMzw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-o90QGQoIyouZaBc74muLDG3Ny4O0fLZaLvkyA++nsB4lDAPFcsjjq+QQASPPCvwye591Z4jRcWV3ghDZsT6V6g==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/aqueduct": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/aqueduct": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/request-handler": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/gitresources": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-2.0.1.tgz",
-			"integrity": "sha512-N8lHCEkoEE7uLtjo7VMAl7psnuQDYSO2z61dbb4zUSWOVZ6E0cyhjR5N3dZtffhbTq0qPiYYN3Ss5M06Yri6OA=="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-2.0.2.tgz",
+			"integrity": "sha512-v9hI+uT8B5kwFAs+x6naqb7rOAX84r9ixjyIrE7Gqa9sBHIZ8pP9zKqNIdcS+Y14IqGiJYGDmwzM7Km6ThILCw=="
 		},
 		"node_modules/@fluidframework/map": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-ztuF8GgO2c/tZJwHHzbzXQ3UAhAfIQlIE4hW+wGy5txW6yqnvmUjpUDWqunnFp1h36DrNq9ro3RcB/labJf5bQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-OzoNKQ8ic/k+ZJSSieGtxeNLLbluu5H9wWr/6X/AZZV+WdaSAHNOlyD8hgh7Ae+7uRwx9ChfLuCBp1CgOcRS1A==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"node_modules/@fluidframework/merge-tree": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-vnfR2ZgaImUvpfqkdyI+d6lEnrM+ioD2+tiHcBemii3q6PSK6+qbtwbFuslAUj/VVKjirIChPQCPwIHNH2nl0A==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-FamAnrAd8SHX2LKdjaKxoyvSX/w6hzoeSRtl9Oz8M89vrjGGT6Vz9s4D2gFaUY1rWhuYXW6aIAaOsmrgYekYoQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/protocol-base": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-2.0.1.tgz",
-			"integrity": "sha512-h/AiwgQhGFfKZaJLebEcvJ0G7j+6FOHwlEyd9nT7BfLp/zdwW63Jd4gA4PsQXmpzurRxskYuoYUKyWJGcO7E0Q==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-2.0.2.tgz",
+			"integrity": "sha512-9AbQ8FuZ5UNZgOWmNaWxs7CH08H9qRYX6OkTUbRXNjdJaFRSCBCkPSA23aHD85EN49UEkkpfoyH1SsQchHuR4Q==",
 			"dependencies": {
 				"@fluidframework/common-utils": "^3.0.0",
-				"@fluidframework/gitresources": "~2.0.1",
+				"@fluidframework/gitresources": "~2.0.2",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"events": "^3.1.0"
 			}
@@ -3140,33 +3140,33 @@
 			"integrity": "sha512-t0jm6u4RX77Fn3rnoxDmavzo26y/JBsNIz5iptnamBgUTOo37i7wXr9VPB8+AjCEd3kcXPyFEoNa8zIEvgOekQ=="
 		},
 		"node_modules/@fluidframework/request-handler": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-I7TZUmiAc0lhD6Y3AeHACXvS4GtIbK5xc+Ph042J7eWZPUgydD50AOH7bXBjuUXdRhF35i1X23vR+UEq0tp95Q==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-lMaxH2tjDT+MFKlatFBvmRbRxpmHgvSAwGXTUILxM5uOW32RURDu3GmgGb+BpGAmXyjKNwLaUgHBONCegK9sQQ==",
 			"dependencies": {
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/routerlicious-driver": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-+O1Omih8k3gLXfClw3A6CFlgNccBkujUBkeW/4t67LXVr2Z3/q4OOqfSmXVEFePyjiJZ0O6mErAXRRJ78euJVA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-NyciUkBlKNmMcy5yvilYsC6pyYExASrjx/3Pg8z5Df950hclLP4JNu1aJdraB9K7WUUuo50Pz75ZFEKHhvOu/g==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/gitresources": "^2.0.1",
 				"@fluidframework/protocol-base": "^2.0.1",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"@fluidframework/server-services-client": "^2.0.1",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"socket.io-client": "^4.6.1",
@@ -3187,48 +3187,48 @@
 			}
 		},
 		"node_modules/@fluidframework/runtime-definitions": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-uIqvypcpfhBEwmAlKjCvofwsioeJvbo35umWqXsX6qOUp68xrbMsMwDB1C7o4gA6cjiicNTZH4lhbsOUJV67jA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-54g4ORqpZVoKlt2H74KJeDtsZWI2G2MSpUIExOOtPbTfgJYzA7cldCUwR8soAXMLEA+NreHycyR/cwzSJlT6nw==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0"
 			}
 		},
 		"node_modules/@fluidframework/runtime-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-E5oenqEdtNuO5FvbirN2dogltVofqhl9Cqu9d3wZnFonfczuMDgBX5rPcQFp+5B8E5t4YXlKe0V7MXx1j6o+Qw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-Rz/qG/N+GlW3jSfgw4WcVjiaT8sa6KNIgdS4oqcVAM+sLSnTA7SWtn7uga68wtg5J43Rzgb2e9iW39D1S0RofQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/sequence": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-c17zZQjevyoQD4YZFbBXnQSCC47ucsokYcj0NtPKFWj/weF/ha0ZZ4sgIaXNWOLN4WYgOpliGeyNMf33zp9Xog==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-9mnSQ+l6FNcfqIPbsrl1lJP7GiAnc5YwcdN4odRKBXaKRbLBJNS8WGAyYDNmAMHi+kVbGZ0F9eoYH1P6wtNMkQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -3620,13 +3620,13 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-client": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-2.0.1.tgz",
-			"integrity": "sha512-VJrmSHYuvVXZ6VUi8rlSzAoQP7R2D8ohKBISLwD97VH1pyl7leuQ1cos7SFJRriIJySHyzveqrbNw8vYpeJXIg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-2.0.2.tgz",
+			"integrity": "sha512-YbK9Hz2URRJreK1IoZZCOCFrIPNxnayIT3xbu7SfeU8nG9ui6+QyjO1WS58/oTM9+raQCmgZaIfzfENXzpVqZA==",
 			"dependencies": {
 				"@fluidframework/common-utils": "^3.0.0",
-				"@fluidframework/gitresources": "~2.0.1",
-				"@fluidframework/protocol-base": "~2.0.1",
+				"@fluidframework/gitresources": "~2.0.2",
+				"@fluidframework/protocol-base": "~2.0.2",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -4044,21 +4044,21 @@
 			}
 		},
 		"node_modules/@fluidframework/shared-object-base": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-SxvDleS9NhBIpEe0kFVuSOwABuUtxtEDqSTUZWu/4MEVUuaGE3/+NjYXIvJylNQIxtSiMmAg/1uIomi7UG/+HA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-RCM+iQ1kFkSMiUyxe/v7VkLmpfsy6I8kULD7+vbv29ltKFM3YKio3DkmUvPIJICzAlj6QnFdthYS88NTdeyqOQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -4075,21 +4075,21 @@
 			}
 		},
 		"node_modules/@fluidframework/synthesize": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-48XxrYddsePCDA34w4YJhoSiNQ1c5QcgEV+LNmz7yvFXWlnWQGwxpvDoVFZnu5nDShVyrtfQVaOwuXe0bOEAVQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-kMrDLm8k8WmB3W3iEYxsYxfo0b5gHSFcZIfkNhP5QXenPAPbzCmvIaJg2Zo8rxY+grymfOpvlXW8bf9G/IBbVw==",
 			"dependencies": {
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@fluidframework/telemetry-utils": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-1oZhXUBA05i+OYD0huPYhmDxVE/P58HaKoaVundSu1zsu7h2sel+xPE7cUpKVl74PIu5gjDgQeVM6bClNjPlFw==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-0Din0dxWTBKXGRAvBuxPeV6t5yg3jTbCFWlv4o6tPRrqNRGuOrzvb7lrEoJ21kcTLQRdnGISefdO8LLJZ7zUeQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
 				"debug": "^4.1.1",
 				"events": "^3.1.0",
@@ -4109,22 +4109,22 @@
 			}
 		},
 		"node_modules/@fluidframework/tinylicious-client": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-hmAt4z16KaYKHntM8BWpZdXV9B/sqJhgwUZnFVej17Lew6ZwagJ13OH5WUirdREW4O0ewzs9k8HEMMUZi1vReg==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-7S9Hn/JIlQ2sn8c/l194P1a1HIjNPO9M6p0WZbWtq+CSR0hNT4+MZSlvKfwbwO1x9toT3jO1Yn+XEOQWouYD3g==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/core-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/fluid-static": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
@@ -4141,16 +4141,15 @@
 			}
 		},
 		"node_modules/@fluidframework/tinylicious-driver": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-ILIi5Mt7e+PZTat5wFyT6acU4j8wfKcs+lyZakpzC5RA1TRcfgV7kYihsBcbiFUMRxPERawg9nSQcHwAeTqhPA==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-jjvk3f2NXimgKfZKlkAxZZdNhr4zMVF9ToF2PTO+9kXEco8hRdWMTKJUltQjbx+KJ0AFAA477v2H6IiCCFN2QA==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"@fluidframework/protocol-definitions": "^3.0.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/server-services-client": "^2.0.1",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^9.0.0"
 			}
@@ -4168,11 +4167,11 @@
 			}
 		},
 		"node_modules/@fluidframework/view-interfaces": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-GyCbK0GUHOr5dAfPfW4DwUmLBlPmQ42gEf28i2s5iuIqFe0GApdxNd+Al0YGzRDsNB8JwRbHjFjwraV1ebgTUQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-St867vvX3iHKzZSrmbCCrDgWlP7VxWhTUzUcFA9/Xr404HWl1Zy88E9Rd2oxw3/ass2biyAuUPppElIFh+0MzQ==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/@hapi/hoek": {
@@ -12630,16 +12629,16 @@
 			"dev": true
 		},
 		"node_modules/fluid-framework": {
-			"version": "2.0.0-internal.7.0.0",
-			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-internal.7.0.0.tgz",
-			"integrity": "sha512-rlSS3mDBgal/TWyFLBQWTNyxxDGlJKxsx2BHAkp0ULQVYzldebRI8uIuYuwGDHG0f4/IFy2zjgrve1vzXN3pJQ==",
+			"version": "2.0.0-internal.7.1.0",
+			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-internal.7.1.0.tgz",
+			"integrity": "sha512-7gEXLH8CqirQlsbSo3AL33xB9PXOoEIzmntx5pDLfmoMaJigEewSOLBhviss3TSL8oJ7elM4DlkXxjqA6EGt0g==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/map": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0",
-				"@fluidframework/sequence": ">=2.0.0-internal.7.0.0 <2.0.0-internal.7.1.0"
+				"@fluidframework/container-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/fluid-static": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/map": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0",
+				"@fluidframework/sequence": ">=2.0.0-internal.7.1.0 <2.0.0-internal.7.2.0"
 			}
 		},
 		"node_modules/fn.name": {

--- a/react-starter-template/package-lock.json
+++ b/react-starter-template/package-lock.json
@@ -20,7 +20,7 @@
 				"uuid": "^8.3.2"
 			},
 			"devDependencies": {
-				"@fluidframework/build-common": "^2.0.0-151899",
+				"@fluidframework/build-common": "^2.0.2",
 				"@testing-library/jest-dom": "^5.13.0",
 				"@testing-library/react": "^11.2.7",
 				"@testing-library/user-event": "^12.8.3",
@@ -2824,9 +2824,9 @@
 			}
 		},
 		"node_modules/@fluidframework/build-common": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.0.tgz",
-			"integrity": "sha512-oJsAczo32UpnM+/8LeE2KKOhr1KBxA48Y4umq/t9QfIFRiX0YtgyrLHRAtnGV6l/+4LX/Urmv6bbckeTFaPw7g==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.2.tgz",
+			"integrity": "sha512-lqAsi/EuncrcJVSP4mOlh+Aci9LAjHlvc2tkymidXXqMaJcATCyqUuaSXaZutgNkJ4wZZNZvWCQRJyqL4dtfWA==",
 			"dev": true,
 			"bin": {
 				"gen-version": "bin/gen-version"

--- a/react-starter-template/package.json
+++ b/react-starter-template/package.json
@@ -37,7 +37,7 @@
 		"uuid": "^8.3.2"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.0-151899",
+		"@fluidframework/build-common": "^2.0.2",
 		"@testing-library/jest-dom": "^5.13.0",
 		"@testing-library/react": "^11.2.7",
 		"@testing-library/user-event": "^12.8.3",

--- a/react-starter-template/package.json
+++ b/react-starter-template/package.json
@@ -27,8 +27,8 @@
 	},
 	"dependencies": {
 		"@fluentui/react": "^8.17.1",
-		"@fluidframework/tinylicious-client": "^2.0.0-internal.7.0.0",
-		"fluid-framework": "^2.0.0-internal.7.0.0",
+		"@fluidframework/tinylicious-client": "^2.0.0-internal.7.1.0",
+		"fluid-framework": "^2.0.0-internal.7.1.0",
 		"immer": "^9.0.5",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",


### PR DESCRIPTION
Also switches to test-runtime-utils in place of test-client-utils (which was discontinued a while back) and bumps build-common to 2.0.2.