### PR TITLE
Standardize examples to use @fluidframework/azure-local-service instead of tinylicious

### DIFF
--- a/angular-demo/README.md
+++ b/angular-demo/README.md
@@ -27,10 +27,10 @@ In this readme we'll walk you through the following topics:
 
 ### Run the app locally
 
-To run our local server, Tinylicious, on the default values of `localhost:7070`, enter the following into a terminal window:
+To run our local server, `@fluidframework/azure-local-service`, on the default values of `localhost:7070`, enter the following into a terminal window:
 
 ```bash
-npx tinylicious
+npx @fluidframework/azure-local-service
 ```
 
 Now, with our local service running in the background, we need to connect the application to it.

--- a/angular-demo/package-lock.json
+++ b/angular-demo/package-lock.json
@@ -26,6 +26,7 @@
 				"@angular-devkit/build-angular": "~13.3.9",
 				"@angular/cli": "~13.3.9",
 				"@angular/compiler-cli": "~13.3.11",
+				"@fluidframework/azure-local-service": "^1.1.0",
 				"@fluidframework/build-common": "^1.1.0",
 				"@types/debug": "^4.1.7",
 				"@types/node": "^18.0.0",
@@ -35,7 +36,6 @@
 				"prettier": "^2.7.1",
 				"puppeteer": "^19.2.2",
 				"start-server-and-test": "^1.14.0",
-				"tinylicious": "^1.0.0",
 				"typescript": "~4.5.5"
 			}
 		},
@@ -2553,6 +2553,469 @@
 				"uuid": "^8.3.1"
 			}
 		},
+		"node_modules/@fluidframework/azure-local-service": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-1.1.1.tgz",
+			"integrity": "sha512-gvk+qy8RytXBQaZ554OREszHGN73W3FmgpfwV+aXeOOP5RWLMPSvkPoac5K9gcUYN+nAFbRs517c055yucP9ug==",
+			"dev": true,
+			"dependencies": {
+				"tinylicious": "^0.4.89251"
+			},
+			"bin": {
+				"azure-local-service": "dist/index.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/common-utils": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@types/events": "^3.0.0",
+				"base64-js": "^1.5.1",
+				"buffer": "^6.0.3",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sha.js": "^2.4.11"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/gitresources": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
+			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-base": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
+			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-definitions": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.4001.tgz",
+			"integrity": "sha512-rERfgXK5DXGJvxADjotkAZssKgp3ZxW6u7yUekrDnFDkXtbCW1Gcq+EwvjHTEyhsOp30YBnD0Z39xnZy4zEZRw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas-driver": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/semver": "^6.0.1",
+				"assert": "^2.0.0",
+				"async": "^3.2.2",
+				"axios": "^0.26.0",
+				"buffer": "^6.0.3",
+				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
+				"json-stringify-safe": "^5.0.1",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"semver": "^6.3.0",
+				"sha.js": "^2.4.11",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas-driver": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.4001.tgz",
+			"integrity": "sha512-qRs+vMbSS9aPx7vr3XemvER5DeY/nsJ5ZkcL3UDjUOxvLZxbOAD6C6JeH3Zgzc/jc8bqshcxai/u7qso2zCsFw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"assert": "^2.0.0",
+				"async": "^3.2.2",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-local-server": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.4001.tgz",
+			"integrity": "sha512-FIlNUc9Ncul/5qzP+VyU53TJj8fxX7KZ1lweswZYalleRZwiqFA4Y+NbWRRWM0iJ1z8hvhyRZblG3iNrpGl04A==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^0.1038.4001",
+				"@fluidframework/server-memory-orderer": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@fluidframework/server-test-utils": "^0.1038.4001",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"jsrsasign": "^10.5.25",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-memory-orderer": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.4001.tgz",
+			"integrity": "sha512-fdzTCLFRh8QfyY17MnB22/o8x2XEX1+wZrm+dn+1Av+ZVe/+ZhfdX5LsQCMKYv+X5mgAauNmC/12mQE4H6jvsQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/debug": "^4.1.5",
+				"@types/double-ended-queue": "^2.1.0",
+				"@types/lodash": "^4.14.118",
+				"@types/node": "^14.18.0",
+				"@types/ws": "^6.0.1",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1",
+				"ws": "^7.4.6"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-client": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
+			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"axios": "^0.26.0",
+				"crc-32": "1.2.0",
+				"debug": "^4.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"jsrsasign": "^10.5.25",
+				"jwt-decode": "^3.0.0",
+				"querystring": "^0.2.0",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-core": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.4001.tgz",
+			"integrity": "sha512-nuZ9ebvyeIoRdlpQQpBNGkawKtc2/tHKbc8CHbMZRMh7F7kwYUtoHd/J8powb9eUcg5IHDmXx1l+PQRbQX4vCg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/nconf": "^0.10.2",
+				"@types/node": "^14.18.0",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"nconf": "^0.12.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-shared": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.4001.tgz",
+			"integrity": "sha512-vDRB2G/Xnuhan+Ri0Eg5JMKfsm7hxstCXdEyQhzJzC7+bw66wts+ZIsEsn4Ha/3KkxblF/RSW3lBhrYpxii3cQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@socket.io/redis-adapter": "^7.2.0",
+				"body-parser": "^1.17.1",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"ioredis": "^4.24.2",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"notepack.io": "^2.3.0",
+				"querystring": "^0.2.0",
+				"socket.io": "^4.5.3",
+				"socket.io-adapter": "^2.4.0",
+				"socket.io-parser": "^4.2.1",
+				"uuid": "^8.3.1",
+				"winston": "^3.6.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-telemetry": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.4001.tgz",
+			"integrity": "sha512-2leJhB04+71RTmC5ShRXm/4FWng9tLn9dlrUAjApZH4RlUJAx1JGsvo/5JU1tIbpUutMHUle2IpWyfu/RV+S5g==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"path-browserify": "^1.0.1",
+				"serialize-error": "^8.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-utils": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.4001.tgz",
+			"integrity": "sha512-K7X/0mlonDAu0pPIgTz8U9nLwRSbJY2oBpFPwpkp1UtE6SU02jx2ZzraT9epDmOl3EXeS1rHzA+mbvBSe1aFMg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"debug": "^4.1.1",
+				"express": "^4.17.3",
+				"ioredis": "^4.24.2",
+				"json-stringify-safe": "^5.0.1",
+				"jsonwebtoken": "^9.0.0",
+				"morgan": "^1.8.1",
+				"nconf": "^0.12.0",
+				"serialize-error": "^8.1.0",
+				"sillyname": "^0.1.0",
+				"split": "^1.0.0",
+				"uuid": "^8.3.1",
+				"winston": "^3.6.0",
+				"winston-transport": "^4.5.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-test-utils": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.4001.tgz",
+			"integrity": "sha512-qrLp5H1UUPIJSEHlzZ1iYlPFJCQrd2WnmoafxnQIg0mfU1ZE8XUlG5MKUg8bT9pWsCoEGJDiOkkRHaq+WXupjQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"string-hash": "^1.1.3",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@types/node": {
+			"version": "14.18.63",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@types/semver": {
+			"version": "6.2.5",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.5.tgz",
+			"integrity": "sha512-NAxro9/RqWXTqdSjccDZAjA4nXK+6zRun+HvibYJfGy8TQhpOC7Vv6v2rlHYKrT0Q8jGGoNRd/xVdHRIQRNlFQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@types/ws": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
+			"integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/async": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/denque": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/ioredis": {
+			"version": "4.28.5",
+			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
+			"integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+			"dev": true,
+			"dependencies": {
+				"cluster-key-slot": "^1.1.0",
+				"debug": "^4.3.1",
+				"denque": "^1.1.0",
+				"lodash.defaults": "^4.2.0",
+				"lodash.flatten": "^4.4.0",
+				"lodash.isarguments": "^3.1.0",
+				"p-map": "^2.1.0",
+				"redis-commands": "1.7.0",
+				"redis-errors": "^1.2.0",
+				"redis-parser": "^3.0.0",
+				"standard-as-callback": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ioredis"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/p-map": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/split": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"dev": true,
+			"dependencies": {
+				"through": "2"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/tinylicious": {
+			"version": "0.4.94771",
+			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
+			"integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.0.0",
+				"@fluidframework/gitresources": "^0.1038.1000",
+				"@fluidframework/protocol-base": "^0.1038.1000",
+				"@fluidframework/protocol-definitions": "^1.0.0",
+				"@fluidframework/server-lambdas": "^0.1038.1000",
+				"@fluidframework/server-local-server": "^0.1038.1000",
+				"@fluidframework/server-memory-orderer": "^0.1038.1000",
+				"@fluidframework/server-services-client": "^0.1038.1000",
+				"@fluidframework/server-services-core": "^0.1038.1000",
+				"@fluidframework/server-services-shared": "^0.1038.1000",
+				"@fluidframework/server-services-telemetry": "^0.1038.1000",
+				"@fluidframework/server-services-utils": "^0.1038.1000",
+				"@fluidframework/server-test-utils": "^0.1038.1000",
+				"agentkeepalive": "^4.2.1",
+				"axios": "^0.26.0",
+				"body-parser": "^1.17.1",
+				"charwise": "^3.0.1",
+				"compression": "^1.7.2",
+				"cookie-parser": "^1.4.3",
+				"cors": "^2.8.4",
+				"detect-port": "^1.3.0",
+				"express": "^4.16.3",
+				"isomorphic-git": "^1.8.2",
+				"json-stringify-safe": "^5.0.1",
+				"level": "^8.0.0",
+				"level-sublevel": "6.6.4",
+				"lodash": "^4.17.21",
+				"morgan": "^1.8.1",
+				"nconf": "^0.12.0",
+				"socket.io": "^4.5.0",
+				"split": "^1.0.0",
+				"uuid": "^8.3.2",
+				"winston": "^3.6.0"
+			},
+			"bin": {
+				"tinylicious": "dist/index.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/ws": {
+			"version": "7.5.9",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.3.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@fluidframework/build-common": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-1.1.0.tgz",
@@ -2938,513 +3401,6 @@
 				"uuid": "^8.3.1"
 			}
 		},
-		"node_modules/@fluidframework/server-lambdas": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-1.0.1.tgz",
-			"integrity": "sha512-lwVKg4dVDvbNH4ckj328z5cNu1plHhArzIMP3kpl8T94L6OubqsJ8vf3g46Wab/SjwltHC41p/wWigJapXZjqA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas-driver": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/semver": "^7.5.0",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"axios": "^0.26.0",
-				"buffer": "^6.0.3",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"semver": "^7.5.3",
-				"sha.js": "^2.4.11",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-1.0.1.tgz",
-			"integrity": "sha512-TfQ7rz2/6pW6Rq5CbGBu9ShiSKyOHg2pXX0cUVHtnuuUPsWTxQDWlVilYukyG0uxHJfE3ZDU3R1QgnWUQQmGgg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/async": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/async": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-1.0.1.tgz",
-			"integrity": "sha512-494H0PYNa6aqngyq/M46K7wlY7NHdIx1B4qcfRCRQmjJZrD9GPza3FHt2/426teBQ93F6SOKkBrMw2vbmoUUGg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.1",
-				"@fluidframework/server-memory-orderer": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@fluidframework/server-test-utils": "^1.0.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"jsrsasign": "^10.5.25",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-1.0.1.tgz",
-			"integrity": "sha512-zUuNICwyKC7OTSl/W9MSiwplSccnRHVmRpdxImCe5qVs+VSK1jHuIGiIzCkt6dlVNMu3WHyUXmrKCLmhJZmFeQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/debug": "^4.1.5",
-				"@types/double-ended-queue": "^2.1.0",
-				"@types/lodash": "^4.14.118",
-				"@types/node": "^16.18.16",
-				"@types/ws": "^6.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1",
-				"ws": "^7.4.6"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@types/node": {
-			"version": "16.18.59",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.59.tgz",
-			"integrity": "sha512-PJ1w2cNeKUEdey4LiPra0ZuxZFOGvetswE8qHRriV/sUkL5Al4tTmPV9D2+Y/TPIxTHHgxTfRjZVKWhPw/ORhQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@types/ws": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
-			"integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/ws": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@fluidframework/server-services-client": {
 			"version": "0.1036.5000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5000.tgz",
@@ -3463,518 +3419,6 @@
 				"querystring": "^0.2.0",
 				"sillyname": "^0.1.0",
 				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-1.0.1.tgz",
-			"integrity": "sha512-/Lb5ZZxb4aHtzLH3p+lrboi6TW/WD0I53di8FI4rMmn5AM7+h69BolPW7nume52t3HUi1I2Mnqhx1W8FKV8BbA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/nconf": "^0.10.2",
-				"@types/node": "^16.18.16",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"nconf": "^0.12.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@types/node": {
-			"version": "16.18.59",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.59.tgz",
-			"integrity": "sha512-PJ1w2cNeKUEdey4LiPra0ZuxZFOGvetswE8qHRriV/sUkL5Al4tTmPV9D2+Y/TPIxTHHgxTfRjZVKWhPw/ORhQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-1.0.1.tgz",
-			"integrity": "sha512-Z+IyqWHUk/y0aZ5cUXUoehcOiIr4qw1VkDR5i+1rnLntCRkPKk7h6FFXcWo+OBmI7D3AJOKZagMr6npezIPEmQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@socket.io/redis-adapter": "^7.2.0",
-				"body-parser": "^1.17.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"ioredis": "^5.2.3",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"notepack.io": "^2.3.0",
-				"querystring": "^0.2.0",
-				"serialize-error": "^8.1.0",
-				"socket.io": "^4.5.3",
-				"socket.io-adapter": "^2.4.0",
-				"socket.io-parser": "^4.2.1",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-telemetry": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-1.0.1.tgz",
-			"integrity": "sha512-qeNtIr5mnkDS5hwD9t+2kcmsRK4zxdAtR+F0j0/rZ/pBWuaVmJI6YiKC5HzWTuszW5F1VDpGnul0M8HEWyhrgQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"path-browserify": "^1.0.1",
-				"serialize-error": "^8.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-telemetry/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-telemetry/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-1.0.1.tgz",
-			"integrity": "sha512-MzoonbJ/EQMbPi+m7/TZxWqyYzs1wxOdtN/Fe4FkaKOcHJjXR1e33iBw3YTkMQR9W8Z8E3WfSe6UVmzNDNH1TQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"debug": "^4.1.1",
-				"express": "^4.17.3",
-				"ioredis": "^5.2.3",
-				"json-stringify-safe": "^5.0.1",
-				"jsonwebtoken": "^9.0.0",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0",
-				"sillyname": "^0.1.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0",
-				"winston-transport": "^4.5.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-1.0.1.tgz",
-			"integrity": "sha512-+2ZP2pU4eq3KY5EySJhcwyAZqy9WojPhirA+fNUPKblT0fmeAn2ks6mF3d98fcxwqjMPb+5UPLRWDf7/+i1/Aw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"string-hash": "^1.1.3",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
 			}
 		},
 		"node_modules/@fluidframework/shared-object-base": {
@@ -4080,12 +3524,6 @@
 			"dependencies": {
 				"@hapi/hoek": "^9.0.0"
 			}
-		},
-		"node_modules/@ioredis/commands": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-			"integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
-			"dev": true
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
@@ -5391,12 +4829,6 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
 			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-			"dev": true
-		},
-		"node_modules/@types/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==",
 			"dev": true
 		},
 		"node_modules/@types/serve-index": {
@@ -7866,15 +7298,6 @@
 			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
 			"dev": true
 		},
-		"node_modules/denque": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-			"integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
 		"node_modules/depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -10195,30 +9618,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/ioredis": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
-			"integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
-			"dev": true,
-			"dependencies": {
-				"@ioredis/commands": "^1.1.1",
-				"cluster-key-slot": "^1.1.0",
-				"debug": "^4.3.4",
-				"denque": "^2.1.0",
-				"lodash.defaults": "^4.2.0",
-				"lodash.isarguments": "^3.1.0",
-				"redis-errors": "^1.2.0",
-				"redis-parser": "^3.0.0",
-				"standard-as-callback": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=12.22.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ioredis"
 			}
 		},
 		"node_modules/ip": {
@@ -13468,6 +12867,12 @@
 			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
 			"dev": true
 		},
+		"node_modules/lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+			"dev": true
+		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -16549,6 +15954,12 @@
 				"node": ">=8.10.0"
 			}
 		},
+		"node_modules/redis-commands": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
+			"dev": true
+		},
 		"node_modules/redis-errors": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
@@ -18174,152 +17585,6 @@
 			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
 			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
 			"dev": true
-		},
-		"node_modules/tinylicious": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-1.0.0.tgz",
-			"integrity": "sha512-ACL8mEKT5LPbFyAXCDjYWqi3vcNef7y2ABMnU3O4jK1cRuEn0MywH7ppMM5ZrMgtSMMsJAINcWxZjpq3ndH8hg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.0",
-				"@fluidframework/protocol-base": "^1.0.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.0",
-				"@fluidframework/server-local-server": "^1.0.0",
-				"@fluidframework/server-memory-orderer": "^1.0.0",
-				"@fluidframework/server-services-client": "^1.0.0",
-				"@fluidframework/server-services-core": "^1.0.0",
-				"@fluidframework/server-services-shared": "^1.0.0",
-				"@fluidframework/server-services-telemetry": "^1.0.0",
-				"@fluidframework/server-services-utils": "^1.0.0",
-				"@fluidframework/server-test-utils": "^1.0.0",
-				"agentkeepalive": "^4.2.1",
-				"axios": "^0.26.0",
-				"body-parser": "^1.17.1",
-				"charwise": "^3.0.1",
-				"compression": "^1.7.2",
-				"cookie-parser": "^1.4.3",
-				"cors": "^2.8.4",
-				"detect-port": "^1.3.0",
-				"express": "^4.17.3",
-				"isomorphic-git": "^1.8.2",
-				"json-stringify-safe": "^5.0.1",
-				"level": "^8.0.0",
-				"level-sublevel": "6.6.4",
-				"lodash": "^4.17.21",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"socket.io": "^4.5.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.2",
-				"winston": "^3.6.0"
-			},
-			"bin": {
-				"tinylicious": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/tinylicious/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/tinylicious/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
 		},
 		"node_modules/tmp": {
 			"version": "0.0.33",

--- a/angular-demo/package-lock.json
+++ b/angular-demo/package-lock.json
@@ -35,7 +35,7 @@
 				"prettier": "^2.7.1",
 				"puppeteer": "^19.2.2",
 				"start-server-and-test": "^1.14.0",
-				"tinylicious": "^0.4.94771",
+				"tinylicious": "^1.0.0",
 				"typescript": "~4.5.5"
 			}
 		},
@@ -2470,9 +2470,9 @@
 			"dev": true
 		},
 		"node_modules/@colors/colors": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.1.90"
@@ -2939,51 +2939,57 @@
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.2000.tgz",
-			"integrity": "sha512-r3T2gix3IcsGNJCtzWef/8BHF1mwl32Zq8e3eWKmFFSnXYnsW0u1JUuozSXdRByi8P6py39yDK2CmfAnxwWnUg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-1.0.1.tgz",
+			"integrity": "sha512-lwVKg4dVDvbNH4ckj328z5cNu1plHhArzIMP3kpl8T94L6OubqsJ8vf3g46Wab/SjwltHC41p/wWigJapXZjqA==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas-driver": "^0.1038.2000",
-				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/server-services-core": "^0.1038.2000",
-				"@fluidframework/server-services-telemetry": "^0.1038.2000",
-				"@types/semver": "^6.0.1",
+				"@fluidframework/server-lambdas-driver": "^1.0.1",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"@types/semver": "^7.5.0",
+				"assert": "^2.0.0",
 				"async": "^3.2.2",
 				"axios": "^0.26.0",
 				"buffer": "^6.0.3",
 				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
 				"json-stringify-safe": "^5.0.1",
 				"lodash": "^4.17.21",
 				"nconf": "^0.12.0",
-				"semver": "^6.3.0",
+				"semver": "^7.5.3",
 				"sha.js": "^2.4.11",
 				"uuid": "^8.3.1"
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas-driver": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.2000.tgz",
-			"integrity": "sha512-uyk1hFfRHah8/iMxiuQw/xC10v5tmJKp4mA8+ombtLPWtWuVl6dzX3XIfrF1tIqjahzzWqMVuHWVMEAESOFblg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-1.0.1.tgz",
+			"integrity": "sha512-TfQ7rz2/6pW6Rq5CbGBu9ShiSKyOHg2pXX0cUVHtnuuUPsWTxQDWlVilYukyG0uxHJfE3ZDU3R1QgnWUQQmGgg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/server-services-core": "^0.1038.2000",
-				"@fluidframework/server-services-telemetry": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"assert": "^2.0.0",
 				"async": "^3.2.2",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"serialize-error": "^8.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/common-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.0.0.tgz",
-			"integrity": "sha512-O3UoZ2dQR/ZWMXTSbDcTH93WMqHmEKoYhYMn6cybESswmMOA2E9UF3B2TkJ+aofBLOLllDKXXGtuhPmu/9rTqQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
@@ -2996,41 +3002,41 @@
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.2000.tgz",
-			"integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.2000.tgz",
-			"integrity": "sha512-2yqIvtt3NBKWfZgQk/nxthf+evIZ0cOW4Klz/zgdIzSFSHLNjo1eItkQc+7wLG3F7v1tD5tn9AVOQsFrDWdvYg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.1.0.tgz",
-			"integrity": "sha512-Q4YA6FBlB2cHicgvfs9z3LPKnfZMdx5JrmIEGOmxFmom/l9EV1F43sXl6K9/j5se8tQ9V9L8drFbDzqVf37roQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1"
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.2000.tgz",
-			"integrity": "sha512-A8oB7jKUDCqlU1qFSc72o7zMcGAeo52WDWWhoSYgZzMV3ZHgaPjq+FYTTpGiJPACnYUhV644UPiFvGWriLIzDA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -3074,9 +3080,9 @@
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/common-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.0.0.tgz",
-			"integrity": "sha512-O3UoZ2dQR/ZWMXTSbDcTH93WMqHmEKoYhYMn6cybESswmMOA2E9UF3B2TkJ+aofBLOLllDKXXGtuhPmu/9rTqQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
@@ -3089,41 +3095,41 @@
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.2000.tgz",
-			"integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.2000.tgz",
-			"integrity": "sha512-2yqIvtt3NBKWfZgQk/nxthf+evIZ0cOW4Klz/zgdIzSFSHLNjo1eItkQc+7wLG3F7v1tD5tn9AVOQsFrDWdvYg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.1.0.tgz",
-			"integrity": "sha512-Q4YA6FBlB2cHicgvfs9z3LPKnfZMdx5JrmIEGOmxFmom/l9EV1F43sXl6K9/j5se8tQ9V9L8drFbDzqVf37roQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1"
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.2000.tgz",
-			"integrity": "sha512-A8oB7jKUDCqlU1qFSc72o7zMcGAeo52WDWWhoSYgZzMV3ZHgaPjq+FYTTpGiJPACnYUhV644UPiFvGWriLIzDA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -3167,37 +3173,44 @@
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
 			"bin": {
 				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/@fluidframework/server-local-server": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.2000.tgz",
-			"integrity": "sha512-kf+IsWeSiPiXT92h2Wexx2n4gVu+1eygYAc5KLVG/M6yyFqr8GYEHjluyjg2JMqaLh6vPGa44F0HzKIv3FppOw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-1.0.1.tgz",
+			"integrity": "sha512-494H0PYNa6aqngyq/M46K7wlY7NHdIx1B4qcfRCRQmjJZrD9GPza3FHt2/426teBQ93F6SOKkBrMw2vbmoUUGg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
+				"@fluidframework/common-utils": "^1.1.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.2000",
-				"@fluidframework/server-memory-orderer": "^0.1038.2000",
-				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/server-services-core": "^0.1038.2000",
-				"@fluidframework/server-services-telemetry": "^0.1038.2000",
-				"@fluidframework/server-test-utils": "^0.1038.2000",
+				"@fluidframework/server-lambdas": "^1.0.1",
+				"@fluidframework/server-memory-orderer": "^1.0.1",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"@fluidframework/server-test-utils": "^1.0.1",
 				"debug": "^4.1.1",
+				"events": "^3.1.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
 			}
 		},
 		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/common-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.0.0.tgz",
-			"integrity": "sha512-O3UoZ2dQR/ZWMXTSbDcTH93WMqHmEKoYhYMn6cybESswmMOA2E9UF3B2TkJ+aofBLOLllDKXXGtuhPmu/9rTqQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
@@ -3210,41 +3223,41 @@
 			}
 		},
 		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.2000.tgz",
-			"integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.2000.tgz",
-			"integrity": "sha512-2yqIvtt3NBKWfZgQk/nxthf+evIZ0cOW4Klz/zgdIzSFSHLNjo1eItkQc+7wLG3F7v1tD5tn9AVOQsFrDWdvYg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.1.0.tgz",
-			"integrity": "sha512-Q4YA6FBlB2cHicgvfs9z3LPKnfZMdx5JrmIEGOmxFmom/l9EV1F43sXl6K9/j5se8tQ9V9L8drFbDzqVf37roQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1"
 			}
 		},
 		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.2000.tgz",
-			"integrity": "sha512-A8oB7jKUDCqlU1qFSc72o7zMcGAeo52WDWWhoSYgZzMV3ZHgaPjq+FYTTpGiJPACnYUhV644UPiFvGWriLIzDA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -3282,25 +3295,27 @@
 			}
 		},
 		"node_modules/@fluidframework/server-memory-orderer": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.2000.tgz",
-			"integrity": "sha512-A+oIAJ5evNzEwEit5NBQSvOTQrzf6Zx+1yBES0v89ypjcIXYoT8oqJWvzuaFbxu4RH6w8JMFMkVZ1gnF1WGpog==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-1.0.1.tgz",
+			"integrity": "sha512-zUuNICwyKC7OTSl/W9MSiwplSccnRHVmRpdxImCe5qVs+VSK1jHuIGiIzCkt6dlVNMu3WHyUXmrKCLmhJZmFeQ==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.2000",
-				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/server-services-core": "^0.1038.2000",
-				"@fluidframework/server-services-telemetry": "^0.1038.2000",
+				"@fluidframework/server-lambdas": "^1.0.1",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/lodash": "^4.14.118",
-				"@types/node": "^14.18.0",
+				"@types/node": "^16.18.16",
 				"@types/ws": "^6.0.1",
+				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
 				"lodash": "^4.17.21",
 				"sillyname": "^0.1.0",
 				"uuid": "^8.3.1",
@@ -3308,9 +3323,9 @@
 			}
 		},
 		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/common-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.0.0.tgz",
-			"integrity": "sha512-O3UoZ2dQR/ZWMXTSbDcTH93WMqHmEKoYhYMn6cybESswmMOA2E9UF3B2TkJ+aofBLOLllDKXXGtuhPmu/9rTqQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
@@ -3323,41 +3338,41 @@
 			}
 		},
 		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.2000.tgz",
-			"integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.2000.tgz",
-			"integrity": "sha512-2yqIvtt3NBKWfZgQk/nxthf+evIZ0cOW4Klz/zgdIzSFSHLNjo1eItkQc+7wLG3F7v1tD5tn9AVOQsFrDWdvYg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.1.0.tgz",
-			"integrity": "sha512-Q4YA6FBlB2cHicgvfs9z3LPKnfZMdx5JrmIEGOmxFmom/l9EV1F43sXl6K9/j5se8tQ9V9L8drFbDzqVf37roQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1"
 			}
 		},
 		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.2000.tgz",
-			"integrity": "sha512-A8oB7jKUDCqlU1qFSc72o7zMcGAeo52WDWWhoSYgZzMV3ZHgaPjq+FYTTpGiJPACnYUhV644UPiFvGWriLIzDA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -3371,9 +3386,9 @@
 			}
 		},
 		"node_modules/@fluidframework/server-memory-orderer/node_modules/@types/node": {
-			"version": "14.18.56",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.56.tgz",
-			"integrity": "sha512-+k+57NVS9opgrEn5l9c0gvD1r6C+PtyhVE4BTnMMRwiEA8ZO8uFcs6Yy2sXIy0eC95ZurBtRSvhZiHXBysbl6w==",
+			"version": "16.18.59",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.59.tgz",
+			"integrity": "sha512-PJ1w2cNeKUEdey4LiPra0ZuxZFOGvetswE8qHRriV/sUkL5Al4tTmPV9D2+Y/TPIxTHHgxTfRjZVKWhPw/ORhQ==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-memory-orderer/node_modules/@types/ws": {
@@ -3451,26 +3466,27 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-core": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.2000.tgz",
-			"integrity": "sha512-kAYxPg1AAqRJxXzN7lXPlShSI31vr3MpDvBLeEQG4fcAWlZHcS5a0DtiA+kV8qKrhJCHfC+KyoS/UruJ4L2yxQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-1.0.1.tgz",
+			"integrity": "sha512-/Lb5ZZxb4aHtzLH3p+lrboi6TW/WD0I53di8FI4rMmn5AM7+h69BolPW7nume52t3HUi1I2Mnqhx1W8FKV8BbA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/server-services-telemetry": "^0.1038.2000",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
 				"@types/nconf": "^0.10.2",
-				"@types/node": "^14.18.0",
+				"@types/node": "^16.18.16",
 				"debug": "^4.1.1",
+				"events": "^3.1.0",
 				"nconf": "^0.12.0"
 			}
 		},
 		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/common-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.0.0.tgz",
-			"integrity": "sha512-O3UoZ2dQR/ZWMXTSbDcTH93WMqHmEKoYhYMn6cybESswmMOA2E9UF3B2TkJ+aofBLOLllDKXXGtuhPmu/9rTqQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
@@ -3483,41 +3499,41 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.2000.tgz",
-			"integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.2000.tgz",
-			"integrity": "sha512-2yqIvtt3NBKWfZgQk/nxthf+evIZ0cOW4Klz/zgdIzSFSHLNjo1eItkQc+7wLG3F7v1tD5tn9AVOQsFrDWdvYg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.1.0.tgz",
-			"integrity": "sha512-Q4YA6FBlB2cHicgvfs9z3LPKnfZMdx5JrmIEGOmxFmom/l9EV1F43sXl6K9/j5se8tQ9V9L8drFbDzqVf37roQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1"
 			}
 		},
 		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.2000.tgz",
-			"integrity": "sha512-A8oB7jKUDCqlU1qFSc72o7zMcGAeo52WDWWhoSYgZzMV3ZHgaPjq+FYTTpGiJPACnYUhV644UPiFvGWriLIzDA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -3531,9 +3547,9 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-core/node_modules/@types/node": {
-			"version": "14.18.56",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.56.tgz",
-			"integrity": "sha512-+k+57NVS9opgrEn5l9c0gvD1r6C+PtyhVE4BTnMMRwiEA8ZO8uFcs6Yy2sXIy0eC95ZurBtRSvhZiHXBysbl6w==",
+			"version": "16.18.59",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.59.tgz",
+			"integrity": "sha512-PJ1w2cNeKUEdey4LiPra0ZuxZFOGvetswE8qHRriV/sUkL5Al4tTmPV9D2+Y/TPIxTHHgxTfRjZVKWhPw/ORhQ==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-services-core/node_modules/buffer": {
@@ -3561,37 +3577,39 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-shared": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.2000.tgz",
-			"integrity": "sha512-Qh/ZN8E/LTLXsWkmU2zBhiTzrVy9+sL/Jf1+qyN2incu6R4lbB5zCQ9shDBuImboWFhD39yBBm/j5iDspOoOhQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-1.0.1.tgz",
+			"integrity": "sha512-Z+IyqWHUk/y0aZ5cUXUoehcOiIr4qw1VkDR5i+1rnLntCRkPKk7h6FFXcWo+OBmI7D3AJOKZagMr6npezIPEmQ==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/server-services-core": "^0.1038.2000",
-				"@fluidframework/server-services-telemetry": "^0.1038.2000",
-				"@socket.io/redis-adapter": "^7.0.0",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"@socket.io/redis-adapter": "^7.2.0",
 				"body-parser": "^1.17.1",
 				"debug": "^4.1.1",
-				"ioredis": "^4.24.2",
+				"events": "^3.1.0",
+				"ioredis": "^5.2.3",
 				"lodash": "^4.17.21",
 				"nconf": "^0.12.0",
 				"notepack.io": "^2.3.0",
 				"querystring": "^0.2.0",
-				"socket.io": "^4.5.0",
-				"socket.io-adapter": "^2.3.1",
-				"socket.io-parser": "^4.0.4",
+				"serialize-error": "^8.1.0",
+				"socket.io": "^4.5.3",
+				"socket.io-adapter": "^2.4.0",
+				"socket.io-parser": "^4.2.1",
 				"uuid": "^8.3.1",
 				"winston": "^3.6.0"
 			}
 		},
 		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/common-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.0.0.tgz",
-			"integrity": "sha512-O3UoZ2dQR/ZWMXTSbDcTH93WMqHmEKoYhYMn6cybESswmMOA2E9UF3B2TkJ+aofBLOLllDKXXGtuhPmu/9rTqQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
@@ -3604,41 +3622,41 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.2000.tgz",
-			"integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.2000.tgz",
-			"integrity": "sha512-2yqIvtt3NBKWfZgQk/nxthf+evIZ0cOW4Klz/zgdIzSFSHLNjo1eItkQc+7wLG3F7v1tD5tn9AVOQsFrDWdvYg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.1.0.tgz",
-			"integrity": "sha512-Q4YA6FBlB2cHicgvfs9z3LPKnfZMdx5JrmIEGOmxFmom/l9EV1F43sXl6K9/j5se8tQ9V9L8drFbDzqVf37roQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1"
 			}
 		},
 		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.2000.tgz",
-			"integrity": "sha512-A8oB7jKUDCqlU1qFSc72o7zMcGAeo52WDWWhoSYgZzMV3ZHgaPjq+FYTTpGiJPACnYUhV644UPiFvGWriLIzDA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -3676,12 +3694,12 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-telemetry": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.2000.tgz",
-			"integrity": "sha512-RBDh+uYZ53GfvXsH1XKDTAsCWpBIFZAl6IHaDZkLE11Zw4ZRk3Bz4063buuBklZ4K3HnLhv+p9Eu9jVsK+v3jA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-1.0.1.tgz",
+			"integrity": "sha512-qeNtIr5mnkDS5hwD9t+2kcmsRK4zxdAtR+F0j0/rZ/pBWuaVmJI6YiKC5HzWTuszW5F1VDpGnul0M8HEWyhrgQ==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
+				"@fluidframework/common-utils": "^1.1.1",
 				"json-stringify-safe": "^5.0.1",
 				"path-browserify": "^1.0.1",
 				"serialize-error": "^8.1.0",
@@ -3689,9 +3707,9 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-telemetry/node_modules/@fluidframework/common-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.0.0.tgz",
-			"integrity": "sha512-O3UoZ2dQR/ZWMXTSbDcTH93WMqHmEKoYhYMn6cybESswmMOA2E9UF3B2TkJ+aofBLOLllDKXXGtuhPmu/9rTqQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
@@ -3728,33 +3746,34 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-utils": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.2000.tgz",
-			"integrity": "sha512-NOfl50zlR8BWGYyxGUaJ+cg/5XbLDbLMcOtwKswK3jy8EQzv9sc7bc+Bt+5vZOgCvoFtUwwpeva8w9M7+vgkTg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-1.0.1.tgz",
+			"integrity": "sha512-MzoonbJ/EQMbPi+m7/TZxWqyYzs1wxOdtN/Fe4FkaKOcHJjXR1e33iBw3YTkMQR9W8Z8E3WfSe6UVmzNDNH1TQ==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/server-services-core": "^0.1038.2000",
-				"@fluidframework/server-services-telemetry": "^0.1038.2000",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
 				"debug": "^4.1.1",
-				"express": "^4.16.3",
-				"ioredis": "^4.24.2",
+				"express": "^4.17.3",
+				"ioredis": "^5.2.3",
 				"json-stringify-safe": "^5.0.1",
-				"jsonwebtoken": "^8.4.0",
+				"jsonwebtoken": "^9.0.0",
 				"morgan": "^1.8.1",
 				"nconf": "^0.12.0",
 				"serialize-error": "^8.1.0",
 				"sillyname": "^0.1.0",
 				"split": "^1.0.0",
 				"uuid": "^8.3.1",
-				"winston": "^3.6.0"
+				"winston": "^3.6.0",
+				"winston-transport": "^4.5.0"
 			}
 		},
 		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/common-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.0.0.tgz",
-			"integrity": "sha512-O3UoZ2dQR/ZWMXTSbDcTH93WMqHmEKoYhYMn6cybESswmMOA2E9UF3B2TkJ+aofBLOLllDKXXGtuhPmu/9rTqQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
@@ -3767,41 +3786,41 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.2000.tgz",
-			"integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.2000.tgz",
-			"integrity": "sha512-2yqIvtt3NBKWfZgQk/nxthf+evIZ0cOW4Klz/zgdIzSFSHLNjo1eItkQc+7wLG3F7v1tD5tn9AVOQsFrDWdvYg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.1.0.tgz",
-			"integrity": "sha512-Q4YA6FBlB2cHicgvfs9z3LPKnfZMdx5JrmIEGOmxFmom/l9EV1F43sXl6K9/j5se8tQ9V9L8drFbDzqVf37roQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1"
 			}
 		},
 		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.2000.tgz",
-			"integrity": "sha512-A8oB7jKUDCqlU1qFSc72o7zMcGAeo52WDWWhoSYgZzMV3ZHgaPjq+FYTTpGiJPACnYUhV644UPiFvGWriLIzDA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -3851,28 +3870,30 @@
 			}
 		},
 		"node_modules/@fluidframework/server-test-utils": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.2000.tgz",
-			"integrity": "sha512-w08VsOC+x0hzXZs5YIrmjFyG2gV+6bMXzMsxSeDuLPkwz1xQXNJxpVG1FM9hAJUke41kzxbRvielSdMfzp3N6A==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-1.0.1.tgz",
+			"integrity": "sha512-+2ZP2pU4eq3KY5EySJhcwyAZqy9WojPhirA+fNUPKblT0fmeAn2ks6mF3d98fcxwqjMPb+5UPLRWDf7/+i1/Aw==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/server-services-core": "^0.1038.2000",
-				"@fluidframework/server-services-telemetry": "^0.1038.2000",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"assert": "^2.0.0",
 				"debug": "^4.1.1",
+				"events": "^3.1.0",
 				"lodash": "^4.17.21",
 				"string-hash": "^1.1.3",
 				"uuid": "^8.3.1"
 			}
 		},
 		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/common-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.0.0.tgz",
-			"integrity": "sha512-O3UoZ2dQR/ZWMXTSbDcTH93WMqHmEKoYhYMn6cybESswmMOA2E9UF3B2TkJ+aofBLOLllDKXXGtuhPmu/9rTqQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
@@ -3885,41 +3906,41 @@
 			}
 		},
 		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.2000.tgz",
-			"integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.2000.tgz",
-			"integrity": "sha512-2yqIvtt3NBKWfZgQk/nxthf+evIZ0cOW4Klz/zgdIzSFSHLNjo1eItkQc+7wLG3F7v1tD5tn9AVOQsFrDWdvYg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.1.0.tgz",
-			"integrity": "sha512-Q4YA6FBlB2cHicgvfs9z3LPKnfZMdx5JrmIEGOmxFmom/l9EV1F43sXl6K9/j5se8tQ9V9L8drFbDzqVf37roQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1"
 			}
 		},
 		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.2000.tgz",
-			"integrity": "sha512-A8oB7jKUDCqlU1qFSc72o7zMcGAeo52WDWWhoSYgZzMV3ZHgaPjq+FYTTpGiJPACnYUhV644UPiFvGWriLIzDA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -4059,6 +4080,12 @@
 			"dependencies": {
 				"@hapi/hoek": "^9.0.0"
 			}
+		},
+		"node_modules/@ioredis/commands": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+			"integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+			"dev": true
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
@@ -5181,10 +5208,13 @@
 			"dev": true
 		},
 		"node_modules/@types/cors": {
-			"version": "2.8.12",
-			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
-			"integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
-			"dev": true
+			"version": "2.8.15",
+			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.15.tgz",
+			"integrity": "sha512-n91JxbNLD8eQIuXDIChAN1tCKNWCEgpceU9b7ZMbFA+P+Q4yIeh80jizFLEvolRPc1ES0VdwFlGv+kJTSirogw==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/debug": {
 			"version": "4.1.7",
@@ -5196,9 +5226,9 @@
 			}
 		},
 		"node_modules/@types/double-ended-queue": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@types/double-ended-queue/-/double-ended-queue-2.1.1.tgz",
-			"integrity": "sha512-O2+umEIlHBVyi+ePmucPjpINqTvSnsz+hAok0D4IpvrOsIsDr6c34B0AbNXW2UDVYuxbv51z5dxnrRt23ohgWg==",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@types/double-ended-queue/-/double-ended-queue-2.1.5.tgz",
+			"integrity": "sha512-Iyp30YLmx/PFvtmomdZq4i81N6uR/7Le+UFrUbnNVbHboRCcCuOKu64tPXlr2yFOb8Zh4t0SppDxRQ5DM/Hlhg==",
 			"dev": true
 		},
 		"node_modules/@types/eslint": {
@@ -5304,9 +5334,9 @@
 			"dev": true
 		},
 		"node_modules/@types/lodash": {
-			"version": "4.14.188",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.188.tgz",
-			"integrity": "sha512-zmEmF5OIM3rb7SbLCFYoQhO4dGt2FRM9AMkxvA3LaADOF1n8in/zGJlWji9fmafLoNyz+FoL6FE0SLtGIArD7w==",
+			"version": "4.14.200",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
+			"integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==",
 			"dev": true
 		},
 		"node_modules/@types/mime": {
@@ -5322,9 +5352,9 @@
 			"dev": true
 		},
 		"node_modules/@types/nconf": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.3.tgz",
-			"integrity": "sha512-leyIuBk/rMIp9114FlPRkc/cQG+/JzCz1Afx3BD+CwK2ep3ZRxoC843V1rqnE2pC/jRRjANWhuVBEn4clCwlug==",
+			"version": "0.10.5",
+			"resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.5.tgz",
+			"integrity": "sha512-Rig8+FAyg9twg01Ya+aVR+QAakMxcTiO3QcvhY41Rn/m1ZvFIU5fb+D3qxxqIHxrFacQqxeg8c8apzZYZ+dqLA==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -5364,9 +5394,9 @@
 			"dev": true
 		},
 		"node_modules/@types/semver": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.3.tgz",
-			"integrity": "sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==",
 			"dev": true
 		},
 		"node_modules/@types/serve-index": {
@@ -5401,6 +5431,12 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
 			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+			"dev": true
+		},
+		"node_modules/@types/triple-beam": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.4.tgz",
+			"integrity": "sha512-HlJjF3wxV4R2VQkFpKe0YqJLilYNgtRtsqqZtby7RkVsSs+i+vbyzjtUwpFEdUCKcrGzCiEJE7F/0mKjh0sunA==",
 			"dev": true
 		},
 		"node_modules/@types/ws": {
@@ -5996,6 +6032,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/assert": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+			"integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"is-nan": "^1.3.2",
+				"object-is": "^1.1.5",
+				"object.assign": "^4.1.4",
+				"util": "^0.12.5"
+			}
+		},
 		"node_modules/async": {
 			"version": "2.6.4",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
@@ -6054,6 +6103,18 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.1.0"
+			}
+		},
+		"node_modules/available-typed-arrays": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/axios": {
@@ -6662,13 +6723,14 @@
 			}
 		},
 		"node_modules/call-bind": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+			"integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
 			"dev": true,
 			"dependencies": {
-				"function-bind": "^1.1.1",
-				"get-intrinsic": "^1.0.2"
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.1",
+				"set-function-length": "^1.1.1"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -7699,6 +7761,20 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/define-data-property": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+			"integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.2.1",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/define-lazy-prop": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -7791,9 +7867,9 @@
 			"dev": true
 		},
 		"node_modules/denque": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+			"integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10"
@@ -8074,9 +8150,9 @@
 			}
 		},
 		"node_modules/engine.io": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.0.tgz",
-			"integrity": "sha512-4KzwW3F3bk+KlzSOY57fj/Jx6LyRQ1nbcyIadehl+AnXjKT7gDO0ORdRi/84ixvMKTym6ZKuxvbzN62HDDU1Lg==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.3.tgz",
+			"integrity": "sha512-IML/R4eG/pUS5w7OfcDE0jKrljWS9nwnEfsxWCIJF5eO6AHo6+Hlv+lQbdlAYsiJPHzUthLm1RUjnBzWOs45cw==",
 			"dev": true,
 			"dependencies": {
 				"@types/cookie": "^0.4.1",
@@ -8087,11 +8163,11 @@
 				"cookie": "~0.4.1",
 				"cors": "~2.8.5",
 				"debug": "~4.3.1",
-				"engine.io-parser": "~5.0.3",
-				"ws": "~8.2.3"
+				"engine.io-parser": "~5.2.1",
+				"ws": "~8.11.0"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=10.2.0"
 			}
 		},
 		"node_modules/engine.io-client": {
@@ -8121,6 +8197,36 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/engine.io/node_modules/engine.io-parser": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
+			"integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/engine.io/node_modules/ws": {
+			"version": "8.11.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/enhanced-resolve": {
@@ -9161,6 +9267,15 @@
 				}
 			}
 		},
+		"node_modules/for-each": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+			"dev": true,
+			"dependencies": {
+				"is-callable": "^1.1.3"
+			}
+		},
 		"node_modules/for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -9273,10 +9388,13 @@
 			}
 		},
 		"node_modules/function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/functions-have-names": {
 			"version": "1.2.3",
@@ -9325,14 +9443,15 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-			"integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+			"integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
 			"dev": true,
 			"dependencies": {
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.3"
+				"function-bind": "^1.1.2",
+				"has-proto": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -9472,6 +9591,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/gopd": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.1.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -9517,6 +9648,18 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/has-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+			"integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/has-symbols": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
@@ -9549,6 +9692,18 @@
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
 			"dev": true
+		},
+		"node_modules/hasown": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+			"integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/hdr-histogram-js": {
 			"version": "2.0.3",
@@ -10043,38 +10198,27 @@
 			}
 		},
 		"node_modules/ioredis": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
-			"integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
+			"integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
 			"dev": true,
 			"dependencies": {
+				"@ioredis/commands": "^1.1.1",
 				"cluster-key-slot": "^1.1.0",
-				"debug": "^4.3.1",
-				"denque": "^1.1.0",
+				"debug": "^4.3.4",
+				"denque": "^2.1.0",
 				"lodash.defaults": "^4.2.0",
-				"lodash.flatten": "^4.4.0",
 				"lodash.isarguments": "^3.1.0",
-				"p-map": "^2.1.0",
-				"redis-commands": "1.7.0",
 				"redis-errors": "^1.2.0",
 				"redis-parser": "^3.0.0",
 				"standard-as-callback": "^2.1.0"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=12.22.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/ioredis"
-			}
-		},
-		"node_modules/ioredis/node_modules/p-map": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/ip": {
@@ -10131,6 +10275,18 @@
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
+		},
+		"node_modules/is-callable": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/is-core-module": {
 			"version": "2.11.0",
@@ -10210,6 +10366,21 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/is-generator-function": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+			"integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -10236,6 +10407,22 @@
 			"resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
 			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
 			"dev": true
+		},
+		"node_modules/is-nan": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
@@ -10314,6 +10501,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-typed-array": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+			"integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+			"dev": true,
+			"dependencies": {
+				"which-typed-array": "^1.1.11"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-unicode-supported": {
@@ -12819,9 +13021,9 @@
 			]
 		},
 		"node_modules/jsonwebtoken": {
-			"version": "8.5.1",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-			"integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+			"integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
 			"dev": true,
 			"dependencies": {
 				"jws": "^3.2.2",
@@ -12833,20 +13035,26 @@
 				"lodash.isstring": "^4.0.1",
 				"lodash.once": "^4.0.0",
 				"ms": "^2.1.1",
-				"semver": "^5.6.0"
+				"semver": "^7.5.4"
 			},
 			"engines": {
-				"node": ">=4",
-				"npm": ">=1.4.28"
+				"node": ">=12",
+				"npm": ">=6"
 			}
 		},
 		"node_modules/jsonwebtoken/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
 			"bin": {
-				"semver": "bin/semver"
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/jsrsasign": {
@@ -13260,12 +13468,6 @@
 			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
 			"dev": true
 		},
-		"node_modules/lodash.flatten": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-			"dev": true
-		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -13401,16 +13603,20 @@
 			}
 		},
 		"node_modules/logform": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.4.2.tgz",
-			"integrity": "sha512-W4c9himeAwXEdZ05dQNerhFz2XG80P9Oj0loPUMV23VC2it0orMHQhJm4hdnnor3rd1HsGf6a2lPwBM1zeXHGw==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
+			"integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
 			"dev": true,
 			"dependencies": {
-				"@colors/colors": "1.5.0",
+				"@colors/colors": "1.6.0",
+				"@types/triple-beam": "^1.3.2",
 				"fecha": "^4.2.0",
 				"ms": "^2.1.1",
 				"safe-stable-stringify": "^2.3.1",
 				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/looper": {
@@ -14063,9 +14269,9 @@
 			"dev": true
 		},
 		"node_modules/nconf": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.0.tgz",
-			"integrity": "sha512-T3fZPw3c7Dfrz8JBQEbEcZJ2s8f7cUMpKuyBtsGQe0b71pcXx6gNh4oti2xh5dxB+gO9ufNfISBlGvvWtfyMcA==",
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.1.tgz",
+			"integrity": "sha512-p2cfF+B3XXacQdswUYWZ0w6Vld0832A/tuqjLBu3H1sfUcby4N2oVbGhyuCkZv+t3iY3aiFEj7gZGqax9Q2c1w==",
 			"dev": true,
 			"dependencies": {
 				"async": "^3.0.0",
@@ -14690,6 +14896,24 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/object.assign": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"has-symbols": "^1.0.3",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/obuf": {
@@ -16325,12 +16549,6 @@
 				"node": ">=8.10.0"
 			}
 		},
-		"node_modules/redis-commands": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
-			"dev": true
-		},
 		"node_modules/redis-errors": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
@@ -16718,9 +16936,9 @@
 			]
 		},
 		"node_modules/safe-stable-stringify": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
-			"integrity": "sha512-dVHE6bMtS/bnL2mwualjc6IxEv1F+OCUpA46pKUj6F8uDbUM0jCCulPqRNPSnWwGNKx5etqMjZYdXtrm5KJZGA==",
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
 			"dev": true,
 			"engines": {
 				"node": ">=10"
@@ -17026,6 +17244,21 @@
 			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
 			"dev": true
 		},
+		"node_modules/set-function-length": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
+			"integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.1.1",
+				"get-intrinsic": "^1.2.1",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/setprototypeof": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -17191,27 +17424,52 @@
 			}
 		},
 		"node_modules/socket.io": {
-			"version": "4.5.3",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.3.tgz",
-			"integrity": "sha512-zdpnnKU+H6mOp7nYRXH4GNv1ux6HL6+lHL8g7Ds7Lj8CkdK1jJK/dlwsKDculbyOHifcJ0Pr/yeXnZQ5GeFrcg==",
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.2.tgz",
+			"integrity": "sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==",
 			"dev": true,
 			"dependencies": {
 				"accepts": "~1.3.4",
 				"base64id": "~2.0.0",
+				"cors": "~2.8.5",
 				"debug": "~4.3.2",
-				"engine.io": "~6.2.0",
-				"socket.io-adapter": "~2.4.0",
-				"socket.io-parser": "~4.2.0"
+				"engine.io": "~6.5.2",
+				"socket.io-adapter": "~2.5.2",
+				"socket.io-parser": "~4.2.4"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=10.2.0"
 			}
 		},
 		"node_modules/socket.io-adapter": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
-			"integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==",
-			"dev": true
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+			"integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+			"dev": true,
+			"dependencies": {
+				"ws": "~8.11.0"
+			}
+		},
+		"node_modules/socket.io-adapter/node_modules/ws": {
+			"version": "8.11.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/socket.io-client": {
 			"version": "4.5.3",
@@ -17228,9 +17486,9 @@
 			}
 		},
 		"node_modules/socket.io-parser": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
-			"integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+			"integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
 			"dependencies": {
 				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.3.1"
@@ -17918,24 +18176,24 @@
 			"dev": true
 		},
 		"node_modules/tinylicious": {
-			"version": "0.4.94771",
-			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
-			"integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-1.0.0.tgz",
+			"integrity": "sha512-ACL8mEKT5LPbFyAXCDjYWqi3vcNef7y2ABMnU3O4jK1cRuEn0MywH7ppMM5ZrMgtSMMsJAINcWxZjpq3ndH8hg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.1000",
-				"@fluidframework/protocol-base": "^0.1038.1000",
-				"@fluidframework/protocol-definitions": "^1.0.0",
-				"@fluidframework/server-lambdas": "^0.1038.1000",
-				"@fluidframework/server-local-server": "^0.1038.1000",
-				"@fluidframework/server-memory-orderer": "^0.1038.1000",
-				"@fluidframework/server-services-client": "^0.1038.1000",
-				"@fluidframework/server-services-core": "^0.1038.1000",
-				"@fluidframework/server-services-shared": "^0.1038.1000",
-				"@fluidframework/server-services-telemetry": "^0.1038.1000",
-				"@fluidframework/server-services-utils": "^0.1038.1000",
-				"@fluidframework/server-test-utils": "^0.1038.1000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.0",
+				"@fluidframework/protocol-base": "^1.0.0",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^1.0.0",
+				"@fluidframework/server-local-server": "^1.0.0",
+				"@fluidframework/server-memory-orderer": "^1.0.0",
+				"@fluidframework/server-services-client": "^1.0.0",
+				"@fluidframework/server-services-core": "^1.0.0",
+				"@fluidframework/server-services-shared": "^1.0.0",
+				"@fluidframework/server-services-telemetry": "^1.0.0",
+				"@fluidframework/server-services-utils": "^1.0.0",
+				"@fluidframework/server-test-utils": "^1.0.0",
 				"agentkeepalive": "^4.2.1",
 				"axios": "^0.26.0",
 				"body-parser": "^1.17.1",
@@ -17944,7 +18202,7 @@
 				"cookie-parser": "^1.4.3",
 				"cors": "^2.8.4",
 				"detect-port": "^1.3.0",
-				"express": "^4.16.3",
+				"express": "^4.17.3",
 				"isomorphic-git": "^1.8.2",
 				"json-stringify-safe": "^5.0.1",
 				"level": "^8.0.0",
@@ -17965,9 +18223,9 @@
 			}
 		},
 		"node_modules/tinylicious/node_modules/@fluidframework/common-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.0.0.tgz",
-			"integrity": "sha512-O3UoZ2dQR/ZWMXTSbDcTH93WMqHmEKoYhYMn6cybESswmMOA2E9UF3B2TkJ+aofBLOLllDKXXGtuhPmu/9rTqQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
@@ -17980,41 +18238,41 @@
 			}
 		},
 		"node_modules/tinylicious/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.2000.tgz",
-			"integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/tinylicious/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.2000.tgz",
-			"integrity": "sha512-2yqIvtt3NBKWfZgQk/nxthf+evIZ0cOW4Klz/zgdIzSFSHLNjo1eItkQc+7wLG3F7v1tD5tn9AVOQsFrDWdvYg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/tinylicious/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.1.0.tgz",
-			"integrity": "sha512-Q4YA6FBlB2cHicgvfs9z3LPKnfZMdx5JrmIEGOmxFmom/l9EV1F43sXl6K9/j5se8tQ9V9L8drFbDzqVf37roQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1"
 			}
 		},
 		"node_modules/tinylicious/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.2000.tgz",
-			"integrity": "sha512-A8oB7jKUDCqlU1qFSc72o7zMcGAeo52WDWWhoSYgZzMV3ZHgaPjq+FYTTpGiJPACnYUhV644UPiFvGWriLIzDA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -18126,10 +18384,13 @@
 			}
 		},
 		"node_modules/triple-beam": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
-			"integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==",
-			"dev": true
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 14.0.0"
+			}
 		},
 		"node_modules/tslib": {
 			"version": "2.4.1",
@@ -18353,6 +18614,19 @@
 			"dependencies": {
 				"querystringify": "^2.1.1",
 				"requires-port": "^1.0.0"
+			}
+		},
+		"node_modules/util": {
+			"version": "0.12.5",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"is-arguments": "^1.0.4",
+				"is-generator-function": "^1.0.7",
+				"is-typed-array": "^1.1.3",
+				"which-typed-array": "^1.1.2"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -18854,6 +19128,25 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/which-typed-array": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
+			"integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
+			"dev": true,
+			"dependencies": {
+				"available-typed-arrays": "^1.0.5",
+				"call-bind": "^1.0.4",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/wide-align": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -18870,12 +19163,12 @@
 			"dev": true
 		},
 		"node_modules/winston": {
-			"version": "3.8.2",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.8.2.tgz",
-			"integrity": "sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==",
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
+			"integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
 			"dev": true,
 			"dependencies": {
-				"@colors/colors": "1.5.0",
+				"@colors/colors": "^1.6.0",
 				"@dabh/diagnostics": "^2.0.2",
 				"async": "^3.2.3",
 				"is-stream": "^2.0.0",
@@ -18892,9 +19185,9 @@
 			}
 		},
 		"node_modules/winston-transport": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
-			"integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.6.0.tgz",
+			"integrity": "sha512-wbBA9PbPAHxKiygo7ub7BYRiKxms0tpfU2ljtWzb3SjRjv5yl6Ozuy/TkXf00HTAt+Uylo3gSkNwzc4ME0wiIg==",
 			"dev": true,
 			"dependencies": {
 				"logform": "^2.3.2",
@@ -18902,7 +19195,7 @@
 				"triple-beam": "^1.3.0"
 			},
 			"engines": {
-				"node": ">= 6.4.0"
+				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/winston/node_modules/async": {

--- a/angular-demo/package-lock.json
+++ b/angular-demo/package-lock.json
@@ -26,7 +26,6 @@
 				"@angular-devkit/build-angular": "~13.3.9",
 				"@angular/cli": "~13.3.9",
 				"@angular/compiler-cli": "~13.3.11",
-				"@fluidframework/azure-local-service": "^1.1.0",
 				"@fluidframework/build-common": "^1.1.0",
 				"@types/debug": "^4.1.7",
 				"@types/node": "^18.0.0",
@@ -2469,15 +2468,6 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
 		},
-		"node_modules/@colors/colors": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
-			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.1.90"
-			}
-		},
 		"node_modules/@csstools/postcss-progressive-custom-properties": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-1.3.0.tgz",
@@ -2510,17 +2500,6 @@
 				"postcss-selector-parser": "^6.0.10"
 			}
 		},
-		"node_modules/@dabh/diagnostics": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-			"integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
-			"dev": true,
-			"dependencies": {
-				"colorspace": "1.1.x",
-				"enabled": "2.0.x",
-				"kuler": "^2.0.0"
-			}
-		},
 		"node_modules/@discoveryjs/json-ext": {
 			"version": "0.5.6",
 			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
@@ -2551,469 +2530,6 @@
 				"@fluidframework/synthesize": "^1.3.0",
 				"@fluidframework/view-interfaces": "^1.3.0",
 				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-1.1.1.tgz",
-			"integrity": "sha512-gvk+qy8RytXBQaZ554OREszHGN73W3FmgpfwV+aXeOOP5RWLMPSvkPoac5K9gcUYN+nAFbRs517c055yucP9ug==",
-			"dev": true,
-			"dependencies": {
-				"tinylicious": "^0.4.89251"
-			},
-			"bin": {
-				"azure-local-service": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
-			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
-			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.4001.tgz",
-			"integrity": "sha512-rERfgXK5DXGJvxADjotkAZssKgp3ZxW6u7yUekrDnFDkXtbCW1Gcq+EwvjHTEyhsOp30YBnD0Z39xnZy4zEZRw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas-driver": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/semver": "^6.0.1",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"axios": "^0.26.0",
-				"buffer": "^6.0.3",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"semver": "^6.3.0",
-				"sha.js": "^2.4.11",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas-driver": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.4001.tgz",
-			"integrity": "sha512-qRs+vMbSS9aPx7vr3XemvER5DeY/nsJ5ZkcL3UDjUOxvLZxbOAD6C6JeH3Zgzc/jc8bqshcxai/u7qso2zCsFw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-local-server": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.4001.tgz",
-			"integrity": "sha512-FIlNUc9Ncul/5qzP+VyU53TJj8fxX7KZ1lweswZYalleRZwiqFA4Y+NbWRRWM0iJ1z8hvhyRZblG3iNrpGl04A==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.4001",
-				"@fluidframework/server-memory-orderer": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@fluidframework/server-test-utils": "^0.1038.4001",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"jsrsasign": "^10.5.25",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-memory-orderer": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.4001.tgz",
-			"integrity": "sha512-fdzTCLFRh8QfyY17MnB22/o8x2XEX1+wZrm+dn+1Av+ZVe/+ZhfdX5LsQCMKYv+X5mgAauNmC/12mQE4H6jvsQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/debug": "^4.1.5",
-				"@types/double-ended-queue": "^2.1.0",
-				"@types/lodash": "^4.14.118",
-				"@types/node": "^14.18.0",
-				"@types/ws": "^6.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1",
-				"ws": "^7.4.6"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
-			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-core": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.4001.tgz",
-			"integrity": "sha512-nuZ9ebvyeIoRdlpQQpBNGkawKtc2/tHKbc8CHbMZRMh7F7kwYUtoHd/J8powb9eUcg5IHDmXx1l+PQRbQX4vCg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/nconf": "^0.10.2",
-				"@types/node": "^14.18.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"nconf": "^0.12.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-shared": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.4001.tgz",
-			"integrity": "sha512-vDRB2G/Xnuhan+Ri0Eg5JMKfsm7hxstCXdEyQhzJzC7+bw66wts+ZIsEsn4Ha/3KkxblF/RSW3lBhrYpxii3cQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@socket.io/redis-adapter": "^7.2.0",
-				"body-parser": "^1.17.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"ioredis": "^4.24.2",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"notepack.io": "^2.3.0",
-				"querystring": "^0.2.0",
-				"socket.io": "^4.5.3",
-				"socket.io-adapter": "^2.4.0",
-				"socket.io-parser": "^4.2.1",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-telemetry": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.4001.tgz",
-			"integrity": "sha512-2leJhB04+71RTmC5ShRXm/4FWng9tLn9dlrUAjApZH4RlUJAx1JGsvo/5JU1tIbpUutMHUle2IpWyfu/RV+S5g==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"path-browserify": "^1.0.1",
-				"serialize-error": "^8.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-utils": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.4001.tgz",
-			"integrity": "sha512-K7X/0mlonDAu0pPIgTz8U9nLwRSbJY2oBpFPwpkp1UtE6SU02jx2ZzraT9epDmOl3EXeS1rHzA+mbvBSe1aFMg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"debug": "^4.1.1",
-				"express": "^4.17.3",
-				"ioredis": "^4.24.2",
-				"json-stringify-safe": "^5.0.1",
-				"jsonwebtoken": "^9.0.0",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0",
-				"sillyname": "^0.1.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0",
-				"winston-transport": "^4.5.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-test-utils": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.4001.tgz",
-			"integrity": "sha512-qrLp5H1UUPIJSEHlzZ1iYlPFJCQrd2WnmoafxnQIg0mfU1ZE8XUlG5MKUg8bT9pWsCoEGJDiOkkRHaq+WXupjQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"string-hash": "^1.1.3",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@types/node": {
-			"version": "14.18.63",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@types/semver": {
-			"version": "6.2.5",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.5.tgz",
-			"integrity": "sha512-NAxro9/RqWXTqdSjccDZAjA4nXK+6zRun+HvibYJfGy8TQhpOC7Vv6v2rlHYKrT0Q8jGGoNRd/xVdHRIQRNlFQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@types/ws": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
-			"integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/async": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/denque": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/ioredis": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
-			"integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
-			"dev": true,
-			"dependencies": {
-				"cluster-key-slot": "^1.1.0",
-				"debug": "^4.3.1",
-				"denque": "^1.1.0",
-				"lodash.defaults": "^4.2.0",
-				"lodash.flatten": "^4.4.0",
-				"lodash.isarguments": "^3.1.0",
-				"p-map": "^2.1.0",
-				"redis-commands": "1.7.0",
-				"redis-errors": "^1.2.0",
-				"redis-parser": "^3.0.0",
-				"standard-as-callback": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ioredis"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/p-map": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/tinylicious": {
-			"version": "0.4.94771",
-			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
-			"integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.1000",
-				"@fluidframework/protocol-base": "^0.1038.1000",
-				"@fluidframework/protocol-definitions": "^1.0.0",
-				"@fluidframework/server-lambdas": "^0.1038.1000",
-				"@fluidframework/server-local-server": "^0.1038.1000",
-				"@fluidframework/server-memory-orderer": "^0.1038.1000",
-				"@fluidframework/server-services-client": "^0.1038.1000",
-				"@fluidframework/server-services-core": "^0.1038.1000",
-				"@fluidframework/server-services-shared": "^0.1038.1000",
-				"@fluidframework/server-services-telemetry": "^0.1038.1000",
-				"@fluidframework/server-services-utils": "^0.1038.1000",
-				"@fluidframework/server-test-utils": "^0.1038.1000",
-				"agentkeepalive": "^4.2.1",
-				"axios": "^0.26.0",
-				"body-parser": "^1.17.1",
-				"charwise": "^3.0.1",
-				"compression": "^1.7.2",
-				"cookie-parser": "^1.4.3",
-				"cors": "^2.8.4",
-				"detect-port": "^1.3.0",
-				"express": "^4.16.3",
-				"isomorphic-git": "^1.8.2",
-				"json-stringify-safe": "^5.0.1",
-				"level": "^8.0.0",
-				"level-sublevel": "6.6.4",
-				"lodash": "^4.17.21",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"socket.io": "^4.5.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.2",
-				"winston": "^3.6.0"
-			},
-			"bin": {
-				"tinylicious": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/ws": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@fluidframework/build-common": {
@@ -4530,27 +4046,6 @@
 			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
 			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
 		},
-		"node_modules/@socket.io/redis-adapter": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-7.2.0.tgz",
-			"integrity": "sha512-/r6oF6Myz0K9uatB/pfCi0BhKg/KRMh1OokrqcjlNz6aq40WiXdFLRbHJQuwGHq/KvB+D6141K+IynbVxZGvhw==",
-			"dev": true,
-			"dependencies": {
-				"debug": "~4.3.1",
-				"notepack.io": "~2.2.0",
-				"socket.io-adapter": "^2.4.0",
-				"uid2": "0.0.3"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/@socket.io/redis-adapter/node_modules/notepack.io": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.2.0.tgz",
-			"integrity": "sha512-9b5w3t5VSH6ZPosoYnyDONnUTF8o0UkBw7JLA6eBlYJWyGT1Q3vQa8Hmuj1/X6RYvHjjygBDgw6fJhe0JEojfw==",
-			"dev": true
-		},
 		"node_modules/@tootallnate/once": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -4639,21 +4134,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/cookie": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-			"integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-			"dev": true
-		},
-		"node_modules/@types/cors": {
-			"version": "2.8.15",
-			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.15.tgz",
-			"integrity": "sha512-n91JxbNLD8eQIuXDIChAN1tCKNWCEgpceU9b7ZMbFA+P+Q4yIeh80jizFLEvolRPc1ES0VdwFlGv+kJTSirogw==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/@types/debug": {
 			"version": "4.1.7",
 			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
@@ -4662,12 +4142,6 @@
 			"dependencies": {
 				"@types/ms": "*"
 			}
-		},
-		"node_modules/@types/double-ended-queue": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@types/double-ended-queue/-/double-ended-queue-2.1.5.tgz",
-			"integrity": "sha512-Iyp30YLmx/PFvtmomdZq4i81N6uR/7Le+UFrUbnNVbHboRCcCuOKu64tPXlr2yFOb8Zh4t0SppDxRQ5DM/Hlhg==",
-			"dev": true
 		},
 		"node_modules/@types/eslint": {
 			"version": "8.4.9",
@@ -4771,12 +4245,6 @@
 			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
 			"dev": true
 		},
-		"node_modules/@types/lodash": {
-			"version": "4.14.200",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
-			"integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==",
-			"dev": true
-		},
 		"node_modules/@types/mime": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
@@ -4787,12 +4255,6 @@
 			"version": "0.7.31",
 			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
 			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
-			"dev": true
-		},
-		"node_modules/@types/nconf": {
-			"version": "0.10.5",
-			"resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.5.tgz",
-			"integrity": "sha512-Rig8+FAyg9twg01Ya+aVR+QAakMxcTiO3QcvhY41Rn/m1ZvFIU5fb+D3qxxqIHxrFacQqxeg8c8apzZYZ+dqLA==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -4863,12 +4325,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
 			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-			"dev": true
-		},
-		"node_modules/@types/triple-beam": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.4.tgz",
-			"integrity": "sha512-HlJjF3wxV4R2VQkFpKe0YqJLilYNgtRtsqqZtby7RkVsSs+i+vbyzjtUwpFEdUCKcrGzCiEJE7F/0mKjh0sunA==",
 			"dev": true
 		},
 		"node_modules/@types/ws": {
@@ -5092,71 +4548,6 @@
 				"node": ">=6.5"
 			}
 		},
-		"node_modules/abstract-level": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
-			"integrity": "sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^6.0.3",
-				"catering": "^2.1.0",
-				"is-buffer": "^2.0.5",
-				"level-supports": "^4.0.0",
-				"level-transcoder": "^1.0.1",
-				"module-error": "^1.0.1",
-				"queue-microtask": "^1.2.3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/abstract-level/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/abstract-level/node_modules/is-buffer": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -5189,15 +4580,6 @@
 			"dev": true,
 			"peerDependencies": {
 				"acorn": "^8"
-			}
-		},
-		"node_modules/address": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/address/-/address-1.2.1.tgz",
-			"integrity": "sha512-B+6bi5D34+fDYENiH5qOlA0cV2rAGKuWZ9LeyUUehbXy8e0VS9e498yO0Jeeh+iM+6KbfudHTFjXw2MmJD4QRA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/adjust-sourcemap-loader": {
@@ -5464,19 +4846,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/assert": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
-			"integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"is-nan": "^1.3.2",
-				"object-is": "^1.1.5",
-				"object.assign": "^4.1.4",
-				"util": "^0.12.5"
-			}
-		},
 		"node_modules/async": {
 			"version": "2.6.4",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
@@ -5485,12 +4854,6 @@
 			"dependencies": {
 				"lodash": "^4.17.14"
 			}
-		},
-		"node_modules/async-lock": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz",
-			"integrity": "sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ==",
-			"dev": true
 		},
 		"node_modules/atob": {
 			"version": "2.1.2",
@@ -5535,18 +4898,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.1.0"
-			}
-		},
-		"node_modules/available-typed-arrays": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/axios": {
@@ -5833,33 +5184,6 @@
 				}
 			]
 		},
-		"node_modules/base64id": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-			"integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-			"dev": true,
-			"engines": {
-				"node": "^4.5.0 || >= 5.9"
-			}
-		},
-		"node_modules/basic-auth": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-			"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "5.1.2"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/basic-auth/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
 		"node_modules/batch": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -5991,18 +5315,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/browser-level": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
-			"integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
-			"dev": true,
-			"dependencies": {
-				"abstract-level": "^1.0.2",
-				"catering": "^2.1.1",
-				"module-error": "^1.0.2",
-				"run-parallel-limit": "^1.1.0"
-			}
-		},
 		"node_modules/browserslist": {
 			"version": "4.21.4",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
@@ -6073,12 +5385,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/buffer-equal-constant-time": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-			"dev": true
-		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -6104,25 +5410,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/bytewise": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-			"integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
-			"dev": true,
-			"dependencies": {
-				"bytewise-core": "^1.2.2",
-				"typewise": "^1.0.3"
-			}
-		},
-		"node_modules/bytewise-core": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-			"integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
-			"dev": true,
-			"dependencies": {
-				"typewise-core": "^1.2"
 			}
 		},
 		"node_modules/cacache": {
@@ -6202,15 +5489,6 @@
 				}
 			]
 		},
-		"node_modules/catering": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
-			"integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -6238,12 +5516,6 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-			"dev": true
-		},
-		"node_modules/charwise": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz",
-			"integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw==",
 			"dev": true
 		},
 		"node_modules/check-more-types": {
@@ -6336,29 +5608,6 @@
 			"integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
 			"dev": true
 		},
-		"node_modules/classic-level": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.2.0.tgz",
-			"integrity": "sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"dependencies": {
-				"abstract-level": "^1.0.2",
-				"catering": "^2.1.0",
-				"module-error": "^1.0.1",
-				"napi-macros": "~2.0.0",
-				"node-gyp-build": "^4.3.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/clean-git-ref": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
-			"integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
-			"dev": true
-		},
 		"node_modules/clean-stack": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -6438,15 +5687,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/cluster-key-slot": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
-			"integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6463,16 +5703,6 @@
 			"integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
 			"dev": true
 		},
-		"node_modules/color": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^1.9.3",
-				"color-string": "^1.6.0"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -6488,16 +5718,6 @@
 			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
 			"dev": true
 		},
-		"node_modules/color-string": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
-		},
 		"node_modules/color-support": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
@@ -6512,16 +5732,6 @@
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
 			"integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
 			"dev": true
-		},
-		"node_modules/colorspace": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-			"integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-			"dev": true,
-			"dependencies": {
-				"color": "^3.1.3",
-				"text-hex": "1.0.x"
-			}
 		},
 		"node_modules/commander": {
 			"version": "2.20.3",
@@ -6638,28 +5848,6 @@
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
 			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/cookie-parser": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-			"integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
-			"dev": true,
-			"dependencies": {
-				"cookie": "0.4.1",
-				"cookie-signature": "1.0.6"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/cookie-parser/node_modules/cookie": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-			"integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
@@ -6790,19 +5978,6 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"dev": true
-		},
-		"node_modules/cors": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-			"dev": true,
-			"dependencies": {
-				"object-assign": "^4",
-				"vary": "^1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
 		},
 		"node_modules/cosmiconfig": {
 			"version": "7.0.1",
@@ -7122,21 +6297,6 @@
 				"node": ">=0.10"
 			}
 		},
-		"node_modules/decompress-response": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-			"dev": true,
-			"dependencies": {
-				"mimic-response": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -7341,20 +6501,6 @@
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
 		},
-		"node_modules/detect-port": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
-			"integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
-			"dev": true,
-			"dependencies": {
-				"address": "^1.0.1",
-				"debug": "4"
-			},
-			"bin": {
-				"detect": "bin/detect-port.js",
-				"detect-port": "bin/detect-port.js"
-			}
-		},
 		"node_modules/devtools-protocol": {
 			"version": "0.0.1056733",
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1056733.tgz",
@@ -7369,12 +6515,6 @@
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
-		},
-		"node_modules/diff3": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
-			"dev": true
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
@@ -7479,15 +6619,6 @@
 			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
 			"dev": true
 		},
-		"node_modules/ecdsa-sig-formatter": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"node_modules/ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -7526,12 +6657,6 @@
 			"engines": {
 				"node": ">= 4"
 			}
-		},
-		"node_modules/enabled": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
-			"dev": true
 		},
 		"node_modules/encodeurl": {
 			"version": "1.0.2",
@@ -7572,27 +6697,6 @@
 				"once": "^1.4.0"
 			}
 		},
-		"node_modules/engine.io": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.3.tgz",
-			"integrity": "sha512-IML/R4eG/pUS5w7OfcDE0jKrljWS9nwnEfsxWCIJF5eO6AHo6+Hlv+lQbdlAYsiJPHzUthLm1RUjnBzWOs45cw==",
-			"dev": true,
-			"dependencies": {
-				"@types/cookie": "^0.4.1",
-				"@types/cors": "^2.8.12",
-				"@types/node": ">=10.0.0",
-				"accepts": "~1.3.4",
-				"base64id": "2.0.0",
-				"cookie": "~0.4.1",
-				"cors": "~2.8.5",
-				"debug": "~4.3.1",
-				"engine.io-parser": "~5.2.1",
-				"ws": "~8.11.0"
-			},
-			"engines": {
-				"node": ">=10.2.0"
-			}
-		},
 		"node_modules/engine.io-client": {
 			"version": "6.2.3",
 			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.3.tgz",
@@ -7611,45 +6715,6 @@
 			"integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==",
 			"engines": {
 				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/engine.io/node_modules/cookie": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/engine.io/node_modules/engine.io-parser": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
-			"integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/engine.io/node_modules/ws": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/enhanced-resolve": {
@@ -7694,6 +6759,7 @@
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
 			"integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
 			"dev": true,
+			"optional": true,
 			"dependencies": {
 				"prr": "~1.0.1"
 			},
@@ -8438,12 +7504,6 @@
 				"pend": "~1.2.0"
 			}
 		},
-		"node_modules/fecha": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
-			"dev": true
-		},
 		"node_modules/figures": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -8665,12 +7725,6 @@
 				"@fluidframework/sequence": "^1.3.0"
 			}
 		},
-		"node_modules/fn.name": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-			"dev": true
-		},
 		"node_modules/follow-redirects": {
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
@@ -8688,15 +7742,6 @@
 				"debug": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/for-each": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-			"dev": true,
-			"dependencies": {
-				"is-callable": "^1.1.3"
 			}
 		},
 		"node_modules/for-in": {
@@ -9675,18 +8720,6 @@
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
 		},
-		"node_modules/is-callable": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-core-module": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
@@ -9765,21 +8798,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/is-generator-function": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-			"integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-			"dev": true,
-			"dependencies": {
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -9806,22 +8824,6 @@
 			"resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
 			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
 			"dev": true
-		},
-		"node_modules/is-nan": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
@@ -9902,21 +8904,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-typed-array": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
-			"integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
-			"dev": true,
-			"dependencies": {
-				"which-typed-array": "^1.1.11"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-unicode-supported": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -9975,31 +8962,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/isomorphic-git": {
-			"version": "1.21.0",
-			"resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.21.0.tgz",
-			"integrity": "sha512-ZqCAUM63CYepA3fB8H7NVyPSiOkgzIbQ7T+QPrm9xtYgQypN9JUJ5uLMjB5iTfomdJf3mdm6aSxjZwnT6ubvEA==",
-			"dev": true,
-			"dependencies": {
-				"async-lock": "^1.1.0",
-				"clean-git-ref": "^2.0.1",
-				"crc-32": "^1.2.0",
-				"diff3": "0.0.3",
-				"ignore": "^5.1.4",
-				"minimisted": "^2.0.0",
-				"pako": "^1.0.10",
-				"pify": "^4.0.1",
-				"readable-stream": "^3.4.0",
-				"sha.js": "^2.4.9",
-				"simple-get": "^4.0.1"
-			},
-			"bin": {
-				"isogit": "cli.cjs"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/istanbul-lib-coverage": {
@@ -12419,70 +11381,12 @@
 				"node >= 0.2.0"
 			]
 		},
-		"node_modules/jsonwebtoken": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-			"integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-			"dev": true,
-			"dependencies": {
-				"jws": "^3.2.2",
-				"lodash.includes": "^4.3.0",
-				"lodash.isboolean": "^3.0.3",
-				"lodash.isinteger": "^4.0.4",
-				"lodash.isnumber": "^3.0.3",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.isstring": "^4.0.1",
-				"lodash.once": "^4.0.0",
-				"ms": "^2.1.1",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": ">=12",
-				"npm": ">=6"
-			}
-		},
-		"node_modules/jsonwebtoken/node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/jsrsasign": {
 			"version": "10.5.27",
 			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.27.tgz",
 			"integrity": "sha512-1F4LmDeJZHYwoVvB44jEo2uZL3XuwYNzXCDOu53Ui6vqofGQ/gCYDmaxfVZtN0TGd92UKXr/BONcfrPonUIcQQ==",
 			"funding": {
 				"url": "https://github.com/kjur/jsrsasign#donations"
-			}
-		},
-		"node_modules/jwa": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-			"dev": true,
-			"dependencies": {
-				"buffer-equal-constant-time": "1.0.1",
-				"ecdsa-sig-formatter": "1.0.11",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"node_modules/jws": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-			"dev": true,
-			"dependencies": {
-				"jwa": "^1.4.1",
-				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/jwt-decode": {
@@ -12525,12 +11429,6 @@
 			"engines": {
 				"node": ">= 8"
 			}
-		},
-		"node_modules/kuler": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-			"dev": true
 		},
 		"node_modules/lazy-ass": {
 			"version": "1.6.0",
@@ -12630,164 +11528,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/level": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/level/-/level-8.0.0.tgz",
-			"integrity": "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==",
-			"dev": true,
-			"dependencies": {
-				"browser-level": "^1.0.1",
-				"classic-level": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/level"
-			}
-		},
-		"node_modules/level-codec": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
-			"integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^5.6.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/level-errors": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-			"integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-			"dev": true,
-			"dependencies": {
-				"errno": "~0.1.1"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/level-iterator-stream": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
-			"integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.5",
-				"xtend": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/level-iterator-stream/node_modules/readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/level-iterator-stream/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"node_modules/level-iterator-stream/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"node_modules/level-post": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
-			"integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
-			"dev": true,
-			"dependencies": {
-				"ltgt": "^2.1.2"
-			}
-		},
-		"node_modules/level-sublevel": {
-			"version": "6.6.4",
-			"resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.4.tgz",
-			"integrity": "sha512-pcCrTUOiO48+Kp6F1+UAzF/OtWqLcQVTVF39HLdZ3RO8XBoXt+XVPKZO1vVr1aUoxHZA9OtD2e1v7G+3S5KFDA==",
-			"dev": true,
-			"dependencies": {
-				"bytewise": "~1.1.0",
-				"level-codec": "^9.0.0",
-				"level-errors": "^2.0.0",
-				"level-iterator-stream": "^2.0.3",
-				"ltgt": "~2.1.1",
-				"pull-defer": "^0.2.2",
-				"pull-level": "^2.0.3",
-				"pull-stream": "^3.6.8",
-				"typewiselite": "~1.0.0",
-				"xtend": "~4.0.0"
-			}
-		},
-		"node_modules/level-supports": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
-			"integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/level-transcoder": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
-			"integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^6.0.3",
-				"module-error": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/level-transcoder/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
 		"node_modules/leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -12859,66 +11599,6 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-			"dev": true
-		},
-		"node_modules/lodash.defaults": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-			"dev": true
-		},
-		"node_modules/lodash.flatten": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-			"dev": true
-		},
-		"node_modules/lodash.includes": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-			"dev": true
-		},
-		"node_modules/lodash.isarguments": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-			"dev": true
-		},
-		"node_modules/lodash.isboolean": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-			"dev": true
-		},
-		"node_modules/lodash.isinteger": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-			"dev": true
-		},
-		"node_modules/lodash.isnumber": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-			"dev": true
-		},
-		"node_modules/lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-			"dev": true
-		},
-		"node_modules/lodash.isstring": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-			"dev": true
-		},
-		"node_modules/lodash.once": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
 			"dev": true
 		},
 		"node_modules/log-symbols": {
@@ -13007,29 +11687,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/logform": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
-			"integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
-			"dev": true,
-			"dependencies": {
-				"@colors/colors": "1.6.0",
-				"@types/triple-beam": "^1.3.2",
-				"fecha": "^4.2.0",
-				"ms": "^2.1.1",
-				"safe-stable-stringify": "^2.3.1",
-				"triple-beam": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/looper": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
-			"integrity": "sha512-6DzMHJcjbQX/UPHc1rRCBfKlLwDkvuGZ715cIR36wSdYqWXFT35uLXq5P/2orl3tz+t+VOVPxw4yPinQlUDGDQ==",
-			"dev": true
-		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -13041,12 +11698,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/ltgt": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
-			"integrity": "sha512-5VjHC5GsENtIi5rbJd+feEpDKhfr7j0odoUR2Uh978g+2p93nd5o34cTjQWohXsPsCZeqoDnIqEf88mPCe0Pfw==",
-			"dev": true
 		},
 		"node_modules/magic-string": {
 			"version": "0.25.7",
@@ -13307,18 +11958,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/mimic-response": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/mini-css-extract-plugin": {
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.5.3.tgz",
@@ -13416,15 +12055,6 @@
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/minimisted": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
-			"integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
-			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.5"
 			}
 		},
 		"node_modules/minipass": {
@@ -13567,58 +12197,6 @@
 			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
 			"dev": true
 		},
-		"node_modules/module-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
-			"integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/morgan": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-			"integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
-			"dev": true,
-			"dependencies": {
-				"basic-auth": "~2.0.1",
-				"debug": "2.6.9",
-				"depd": "~2.0.0",
-				"on-finished": "~2.3.0",
-				"on-headers": "~1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/morgan/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/morgan/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true
-		},
-		"node_modules/morgan/node_modules/on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-			"dev": true,
-			"dependencies": {
-				"ee-first": "1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -13661,76 +12239,11 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
-		"node_modules/napi-macros": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
-			"integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
-			"dev": true
-		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
-		},
-		"node_modules/nconf": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.1.tgz",
-			"integrity": "sha512-p2cfF+B3XXacQdswUYWZ0w6Vld0832A/tuqjLBu3H1sfUcby4N2oVbGhyuCkZv+t3iY3aiFEj7gZGqax9Q2c1w==",
-			"dev": true,
-			"dependencies": {
-				"async": "^3.0.0",
-				"ini": "^2.0.0",
-				"secure-keys": "^1.0.0",
-				"yargs": "^16.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
-		"node_modules/nconf/node_modules/async": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-			"dev": true
-		},
-		"node_modules/nconf/node_modules/cliui": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-			"dev": true,
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0",
-				"wrap-ansi": "^7.0.0"
-			}
-		},
-		"node_modules/nconf/node_modules/yargs": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-			"dev": true,
-			"dependencies": {
-				"cliui": "^7.0.2",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.0",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^20.2.2"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/nconf/node_modules/yargs-parser": {
-			"version": "20.2.9",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"node_modules/needle": {
 			"version": "2.9.1",
@@ -13854,6 +12367,7 @@
 			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
 			"integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
 			"dev": true,
+			"optional": true,
 			"bin": {
 				"node-gyp-build": "bin.js",
 				"node-gyp-build-optional": "optional.js",
@@ -13904,12 +12418,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/notepack.io": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.3.0.tgz",
-			"integrity": "sha512-9RiFDxeydHsWOqdthRUck2Kd4UW2NzVd2xxOulZiQ9mvge6ElsHXLpwD3HEJyql6sFEnEn/eMO7HSdS0M5mWkA==",
-			"dev": true
 		},
 		"node_modules/npm-bundled": {
 			"version": "1.1.2",
@@ -14260,15 +12768,6 @@
 				"url": "https://github.com/fb55/nth-check?sponsor=1"
 			}
 		},
-		"node_modules/object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/object-inspect": {
 			"version": "1.12.2",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
@@ -14301,24 +12800,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/object.assign": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"has-symbols": "^1.0.3",
-				"object-keys": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/obuf": {
@@ -14355,15 +12836,6 @@
 			"dev": true,
 			"dependencies": {
 				"wrappy": "1"
-			}
-		},
-		"node_modules/one-time": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-			"dev": true,
-			"dependencies": {
-				"fn.name": "1.x.x"
 			}
 		},
 		"node_modules/onetime": {
@@ -14794,6 +13266,7 @@
 			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
 			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 			"dev": true,
+			"optional": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -15623,7 +14096,8 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
 			"integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"node_modules/ps-tree": {
 			"version": "1.2.0",
@@ -15638,64 +14112,6 @@
 			},
 			"engines": {
 				"node": ">= 0.10"
-			}
-		},
-		"node_modules/pull-cat": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
-			"integrity": "sha512-i3w+xZ3DCtTVz8S62hBOuNLRHqVDsHMNZmgrZsjPnsxXUgbWtXEee84lo1XswE7W2a3WHyqsNuDJTjVLAQR8xg==",
-			"dev": true
-		},
-		"node_modules/pull-defer": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
-			"integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA==",
-			"dev": true
-		},
-		"node_modules/pull-level": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
-			"integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
-			"dev": true,
-			"dependencies": {
-				"level-post": "^1.0.7",
-				"pull-cat": "^1.1.9",
-				"pull-live": "^1.0.1",
-				"pull-pushable": "^2.0.0",
-				"pull-stream": "^3.4.0",
-				"pull-window": "^2.1.4",
-				"stream-to-pull-stream": "^1.7.1"
-			}
-		},
-		"node_modules/pull-live": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
-			"integrity": "sha512-tkNz1QT5gId8aPhV5+dmwoIiA1nmfDOzJDlOOUpU5DNusj6neNd3EePybJ5+sITr2FwyCs/FVpx74YMCfc8YeA==",
-			"dev": true,
-			"dependencies": {
-				"pull-cat": "^1.1.9",
-				"pull-stream": "^3.4.0"
-			}
-		},
-		"node_modules/pull-pushable": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
-			"integrity": "sha512-M7dp95enQ2kaHvfCt2+DJfyzgCSpWVR2h2kWYnVsW6ZpxQBx5wOu0QWOvQPVoPnBLUZYitYP2y7HyHkLQNeGXg==",
-			"dev": true
-		},
-		"node_modules/pull-stream": {
-			"version": "3.6.14",
-			"resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
-			"integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew==",
-			"dev": true
-		},
-		"node_modules/pull-window": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
-			"integrity": "sha512-cbDzN76BMlcGG46OImrgpkMf/VkCnupj8JhsrpBw3aWBM9ye345aYnqitmZCgauBkc0HbbRRn9hCnsa3k2FNUg==",
-			"dev": true,
-			"dependencies": {
-				"looper": "^2.0.0"
 			}
 		},
 		"node_modules/pump": {
@@ -15952,33 +14368,6 @@
 			},
 			"engines": {
 				"node": ">=8.10.0"
-			}
-		},
-		"node_modules/redis-commands": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
-			"dev": true
-		},
-		"node_modules/redis-errors": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-			"integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/redis-parser": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-			"integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-			"dev": true,
-			"dependencies": {
-				"redis-errors": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/reflect-metadata": {
@@ -16288,29 +14677,6 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
-		"node_modules/run-parallel-limit": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
-			"integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"queue-microtask": "^1.2.2"
-			}
-		},
 		"node_modules/rxjs": {
 			"version": "6.6.7",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
@@ -16345,15 +14711,6 @@
 					"url": "https://feross.org/support"
 				}
 			]
-		},
-		"node_modules/safe-stable-stringify": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
@@ -16436,12 +14793,6 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
-		"node_modules/secure-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
-			"integrity": "sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg==",
-			"dev": true
-		},
 		"node_modules/select-hose": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -16519,33 +14870,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true
-		},
-		"node_modules/serialize-error": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
-			"integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
-			"dev": true,
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/serialize-error/node_modules/type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.0",
@@ -16746,66 +15070,6 @@
 			"resolved": "https://registry.npmjs.org/sillyname/-/sillyname-0.1.0.tgz",
 			"integrity": "sha512-GWA0Zont13ov+cMNw4T7nU4SCyW8jdhD3vjA5+qs8jr+09sCPxOf+FPS5zE0c9pYlCwD+NU/CiMimY462lgG9g=="
 		},
-		"node_modules/simple-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/simple-get": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"decompress-response": "^6.0.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
-			}
-		},
-		"node_modules/simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-			"dev": true,
-			"dependencies": {
-				"is-arrayish": "^0.3.1"
-			}
-		},
-		"node_modules/simple-swizzle/node_modules/is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-			"dev": true
-		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -16832,54 +15096,6 @@
 			"engines": {
 				"node": ">= 6.0.0",
 				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/socket.io": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.2.tgz",
-			"integrity": "sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==",
-			"dev": true,
-			"dependencies": {
-				"accepts": "~1.3.4",
-				"base64id": "~2.0.0",
-				"cors": "~2.8.5",
-				"debug": "~4.3.2",
-				"engine.io": "~6.5.2",
-				"socket.io-adapter": "~2.5.2",
-				"socket.io-parser": "~4.2.4"
-			},
-			"engines": {
-				"node": ">=10.2.0"
-			}
-		},
-		"node_modules/socket.io-adapter": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
-			"integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
-			"dev": true,
-			"dependencies": {
-				"ws": "~8.11.0"
-			}
-		},
-		"node_modules/socket.io-adapter/node_modules/ws": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/socket.io-client": {
@@ -17112,15 +15328,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/stack-trace": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-			"integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/stack-utils": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -17141,12 +15348,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/standard-as-callback": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-			"integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
-			"dev": true
 		},
 		"node_modules/start-server-and-test": {
 			"version": "1.14.0",
@@ -17243,22 +15444,6 @@
 				"duplexer": "~0.1.1"
 			}
 		},
-		"node_modules/stream-to-pull-stream": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
-			"integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
-			"dev": true,
-			"dependencies": {
-				"looper": "^3.0.0",
-				"pull-stream": "^3.2.3"
-			}
-		},
-		"node_modules/stream-to-pull-stream/node_modules/looper": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-			"integrity": "sha512-LJ9wplN/uSn72oJRsXTx+snxPet5c8XiZmOKCm906NVYu+ag6SB6vUcnJcWxgnl2NfbIyeobAn7Bwv6xRj2XJg==",
-			"dev": true
-		},
 		"node_modules/string_decoder": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -17267,12 +15452,6 @@
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
 			}
-		},
-		"node_modules/string-hash": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-			"integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
-			"dev": true
 		},
 		"node_modules/string-length": {
 			"version": "4.0.2",
@@ -17562,12 +15741,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/text-hex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-			"dev": true
-		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -17648,15 +15821,6 @@
 				"tree-kill": "cli.js"
 			}
 		},
-		"node_modules/triple-beam": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
-			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 14.0.0"
-			}
-		},
 		"node_modules/tslib": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -17714,33 +15878,6 @@
 			"engines": {
 				"node": ">=4.2.0"
 			}
-		},
-		"node_modules/typewise": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-			"integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
-			"dev": true,
-			"dependencies": {
-				"typewise-core": "^1.2.0"
-			}
-		},
-		"node_modules/typewise-core": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-			"integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
-			"dev": true
-		},
-		"node_modules/typewiselite": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
-			"integrity": "sha512-J9alhjVHupW3Wfz6qFRGgQw0N3gr8hOkw6zm7FZ6UR1Cse/oD9/JVok7DNE9TT9IbciDHX2Ex9+ksE6cRmtymw==",
-			"dev": true
-		},
-		"node_modules/uid2": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-			"integrity": "sha512-5gSP1liv10Gjp8cMEnFd6shzkL/D6W1uhXSFNCxDC+YI8+L8wkCYCbJ7n77Ezb4wE/xzMogecE+DtamEe9PZjg==",
-			"dev": true
 		},
 		"node_modules/unbzip2-stream": {
 			"version": "1.4.3",
@@ -17879,19 +16016,6 @@
 			"dependencies": {
 				"querystringify": "^2.1.1",
 				"requires-port": "^1.0.0"
-			}
-		},
-		"node_modules/util": {
-			"version": "0.12.5",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"is-arguments": "^1.0.4",
-				"is-generator-function": "^1.0.7",
-				"is-typed-array": "^1.1.3",
-				"which-typed-array": "^1.1.2"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -18393,25 +16517,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/which-typed-array": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
-			"integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
-			"dev": true,
-			"dependencies": {
-				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.4",
-				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/wide-align": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -18425,48 +16530,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
 			"integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
-			"dev": true
-		},
-		"node_modules/winston": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
-			"integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
-			"dev": true,
-			"dependencies": {
-				"@colors/colors": "^1.6.0",
-				"@dabh/diagnostics": "^2.0.2",
-				"async": "^3.2.3",
-				"is-stream": "^2.0.0",
-				"logform": "^2.4.0",
-				"one-time": "^1.0.0",
-				"readable-stream": "^3.4.0",
-				"safe-stable-stringify": "^2.3.1",
-				"stack-trace": "0.0.x",
-				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.5.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/winston-transport": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.6.0.tgz",
-			"integrity": "sha512-wbBA9PbPAHxKiygo7ub7BYRiKxms0tpfU2ljtWzb3SjRjv5yl6Ozuy/TkXf00HTAt+Uylo3gSkNwzc4ME0wiIg==",
-			"dev": true,
-			"dependencies": {
-				"logform": "^2.3.2",
-				"readable-stream": "^3.6.0",
-				"triple-beam": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/winston/node_modules/async": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
 			"dev": true
 		},
 		"node_modules/wrap-ansi": {
@@ -18570,15 +16633,6 @@
 			"integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.4"
 			}
 		},
 		"node_modules/y18n": {

--- a/angular-demo/package.json
+++ b/angular-demo/package.json
@@ -11,7 +11,7 @@
 		"ci:test:jest": "jest --ci --reporters=default --reporters=jest-junit",
 		"ng": "ng",
 		"start": "ng serve",
-		"start:server": "npx tinylicious",
+		"start:server": "npx @fluidframework/azure-local-service",
 		"build": "ng build",
 		"watch": "ng build --watch --configuration development",
 		"test": "start-server-and-test start:server 7070 test:jest",
@@ -40,6 +40,7 @@
 		"@angular-devkit/build-angular": "~13.3.9",
 		"@angular/cli": "~13.3.9",
 		"@angular/compiler-cli": "~13.3.11",
+		"@fluidframework/azure-local-service": "^1.1.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@types/debug": "^4.1.7",
 		"@types/node": "^18.0.0",
@@ -49,7 +50,6 @@
 		"prettier": "^2.7.1",
 		"puppeteer": "^19.2.2",
 		"start-server-and-test": "^1.14.0",
-		"tinylicious": "^1.0.0",
 		"typescript": "~4.5.5"
 	},
 	"jest-junit": {

--- a/angular-demo/package.json
+++ b/angular-demo/package.json
@@ -49,7 +49,7 @@
 		"prettier": "^2.7.1",
 		"puppeteer": "^19.2.2",
 		"start-server-and-test": "^1.14.0",
-		"tinylicious": "^0.4.94771",
+		"tinylicious": "^1.0.0",
 		"typescript": "~4.5.5"
 	},
 	"jest-junit": {

--- a/angular-demo/package.json
+++ b/angular-demo/package.json
@@ -40,7 +40,6 @@
 		"@angular-devkit/build-angular": "~13.3.9",
 		"@angular/cli": "~13.3.9",
 		"@angular/compiler-cli": "~13.3.11",
-		"@fluidframework/azure-local-service": "^1.1.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@types/debug": "^4.1.7",
 		"@types/node": "^18.0.0",

--- a/audience-demo/README.md
+++ b/audience-demo/README.md
@@ -8,7 +8,7 @@ The React client will display all users connected to a Fluid Container.
 To run an Azure Client service locally, on the default values of `localhost:7070`, enter the following into a terminal window:
 
 ```bash
-npx tinylicious
+npx @fluidframework/azure-local-service
 ```
 
 With the local service running in the background, we need to connect the application to it.

--- a/audience-demo/package-lock.json
+++ b/audience-demo/package-lock.json
@@ -15,7 +15,6 @@
 				"react-dom": "^18.2.0"
 			},
 			"devDependencies": {
-				"@fluidframework/azure-local-service": "^1.1.0",
 				"@fluidframework/build-common": "^2.0.0",
 				"@testing-library/jest-dom": "^6.1.3",
 				"@testing-library/react": "^14.0.0",
@@ -28,6 +27,7 @@
 				"puppeteer": "^21.1.1",
 				"react-scripts": "^5.0.1",
 				"start-server-and-test": "^2.0.0",
+				"tinylicious": "^1.0.0",
 				"url": "^0.11.2"
 			}
 		},
@@ -2241,9 +2241,9 @@
 			"dev": true
 		},
 		"node_modules/@colors/colors": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.1.90"
@@ -2707,21 +2707,6 @@
 			},
 			"peerDependencies": {
 				"fluid-framework": "^1.3.3"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-1.1.1.tgz",
-			"integrity": "sha512-gvk+qy8RytXBQaZ554OREszHGN73W3FmgpfwV+aXeOOP5RWLMPSvkPoac5K9gcUYN+nAFbRs517c055yucP9ug==",
-			"dev": true,
-			"dependencies": {
-				"tinylicious": "^0.4.89251"
-			},
-			"bin": {
-				"azure-local-service": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@fluidframework/build-common": {
@@ -3483,21 +3468,21 @@
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.4001.tgz",
-			"integrity": "sha512-rERfgXK5DXGJvxADjotkAZssKgp3ZxW6u7yUekrDnFDkXtbCW1Gcq+EwvjHTEyhsOp30YBnD0Z39xnZy4zEZRw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-1.0.1.tgz",
+			"integrity": "sha512-lwVKg4dVDvbNH4ckj328z5cNu1plHhArzIMP3kpl8T94L6OubqsJ8vf3g46Wab/SjwltHC41p/wWigJapXZjqA==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas-driver": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/semver": "^6.0.1",
+				"@fluidframework/server-lambdas-driver": "^1.0.1",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"@types/semver": "^7.5.0",
 				"assert": "^2.0.0",
 				"async": "^3.2.2",
 				"axios": "^0.26.0",
@@ -3507,55 +3492,56 @@
 				"json-stringify-safe": "^5.0.1",
 				"lodash": "^4.17.21",
 				"nconf": "^0.12.0",
-				"semver": "^6.3.0",
+				"semver": "^7.5.3",
 				"sha.js": "^2.4.11",
 				"uuid": "^8.3.1"
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas-driver": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.4001.tgz",
-			"integrity": "sha512-qRs+vMbSS9aPx7vr3XemvER5DeY/nsJ5ZkcL3UDjUOxvLZxbOAD6C6JeH3Zgzc/jc8bqshcxai/u7qso2zCsFw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-1.0.1.tgz",
+			"integrity": "sha512-TfQ7rz2/6pW6Rq5CbGBu9ShiSKyOHg2pXX0cUVHtnuuUPsWTxQDWlVilYukyG0uxHJfE3ZDU3R1QgnWUQQmGgg==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
 				"assert": "^2.0.0",
 				"async": "^3.2.2",
 				"events": "^3.1.0",
-				"lodash": "^4.17.21"
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"serialize-error": "^8.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
-			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
-			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
-			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -3578,33 +3564,32 @@
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
-			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
-			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
-			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -3617,12 +3602,6 @@
 				"uuid": "^8.3.1"
 			}
 		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@types/semver": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.3.tgz",
-			"integrity": "sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==",
-			"dev": true
-		},
 		"node_modules/@fluidframework/server-lambdas/node_modules/axios": {
 			"version": "0.26.1",
 			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
@@ -3632,20 +3611,53 @@
 				"follow-redirects": "^1.14.8"
 			}
 		},
+		"node_modules/@fluidframework/server-lambdas/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@fluidframework/server-lambdas/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@fluidframework/server-lambdas/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
 		"node_modules/@fluidframework/server-local-server": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.4001.tgz",
-			"integrity": "sha512-FIlNUc9Ncul/5qzP+VyU53TJj8fxX7KZ1lweswZYalleRZwiqFA4Y+NbWRRWM0iJ1z8hvhyRZblG3iNrpGl04A==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-1.0.1.tgz",
+			"integrity": "sha512-494H0PYNa6aqngyq/M46K7wlY7NHdIx1B4qcfRCRQmjJZrD9GPza3FHt2/426teBQ93F6SOKkBrMw2vbmoUUGg==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.4001",
-				"@fluidframework/server-memory-orderer": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@fluidframework/server-test-utils": "^0.1038.4001",
+				"@fluidframework/server-lambdas": "^1.0.1",
+				"@fluidframework/server-memory-orderer": "^1.0.1",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"@fluidframework/server-test-utils": "^1.0.1",
 				"debug": "^4.1.1",
 				"events": "^3.1.0",
 				"jsrsasign": "^10.5.25",
@@ -3653,33 +3665,32 @@
 			}
 		},
 		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
-			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
-			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
-			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -3702,22 +3713,22 @@
 			}
 		},
 		"node_modules/@fluidframework/server-memory-orderer": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.4001.tgz",
-			"integrity": "sha512-fdzTCLFRh8QfyY17MnB22/o8x2XEX1+wZrm+dn+1Av+ZVe/+ZhfdX5LsQCMKYv+X5mgAauNmC/12mQE4H6jvsQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-1.0.1.tgz",
+			"integrity": "sha512-zUuNICwyKC7OTSl/W9MSiwplSccnRHVmRpdxImCe5qVs+VSK1jHuIGiIzCkt6dlVNMu3WHyUXmrKCLmhJZmFeQ==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@fluidframework/server-lambdas": "^1.0.1",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/lodash": "^4.14.118",
-				"@types/node": "^14.18.0",
+				"@types/node": "^16.18.16",
 				"@types/ws": "^6.0.1",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
@@ -3730,33 +3741,32 @@
 			}
 		},
 		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
-			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
-			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
-			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -3850,51 +3860,50 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-core": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.4001.tgz",
-			"integrity": "sha512-nuZ9ebvyeIoRdlpQQpBNGkawKtc2/tHKbc8CHbMZRMh7F7kwYUtoHd/J8powb9eUcg5IHDmXx1l+PQRbQX4vCg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-1.0.1.tgz",
+			"integrity": "sha512-/Lb5ZZxb4aHtzLH3p+lrboi6TW/WD0I53di8FI4rMmn5AM7+h69BolPW7nume52t3HUi1I2Mnqhx1W8FKV8BbA==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
 				"@types/nconf": "^0.10.2",
-				"@types/node": "^14.18.0",
+				"@types/node": "^16.18.16",
 				"debug": "^4.1.1",
 				"events": "^3.1.0",
 				"nconf": "^0.12.0"
 			}
 		},
 		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
-			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
-			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
-			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -3917,27 +3926,28 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-shared": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.4001.tgz",
-			"integrity": "sha512-vDRB2G/Xnuhan+Ri0Eg5JMKfsm7hxstCXdEyQhzJzC7+bw66wts+ZIsEsn4Ha/3KkxblF/RSW3lBhrYpxii3cQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-1.0.1.tgz",
+			"integrity": "sha512-Z+IyqWHUk/y0aZ5cUXUoehcOiIr4qw1VkDR5i+1rnLntCRkPKk7h6FFXcWo+OBmI7D3AJOKZagMr6npezIPEmQ==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
 				"@socket.io/redis-adapter": "^7.2.0",
 				"body-parser": "^1.17.1",
 				"debug": "^4.1.1",
 				"events": "^3.1.0",
-				"ioredis": "^4.24.2",
+				"ioredis": "^5.2.3",
 				"lodash": "^4.17.21",
 				"nconf": "^0.12.0",
 				"notepack.io": "^2.3.0",
 				"querystring": "^0.2.0",
+				"serialize-error": "^8.1.0",
 				"socket.io": "^4.5.3",
 				"socket.io-adapter": "^2.4.0",
 				"socket.io-parser": "^4.2.1",
@@ -3946,33 +3956,32 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
-			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
-			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
-			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -3995,9 +4004,9 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-telemetry": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.4001.tgz",
-			"integrity": "sha512-2leJhB04+71RTmC5ShRXm/4FWng9tLn9dlrUAjApZH4RlUJAx1JGsvo/5JU1tIbpUutMHUle2IpWyfu/RV+S5g==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-1.0.1.tgz",
+			"integrity": "sha512-qeNtIr5mnkDS5hwD9t+2kcmsRK4zxdAtR+F0j0/rZ/pBWuaVmJI6YiKC5HzWTuszW5F1VDpGnul0M8HEWyhrgQ==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
@@ -4008,18 +4017,18 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-utils": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.4001.tgz",
-			"integrity": "sha512-K7X/0mlonDAu0pPIgTz8U9nLwRSbJY2oBpFPwpkp1UtE6SU02jx2ZzraT9epDmOl3EXeS1rHzA+mbvBSe1aFMg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-1.0.1.tgz",
+			"integrity": "sha512-MzoonbJ/EQMbPi+m7/TZxWqyYzs1wxOdtN/Fe4FkaKOcHJjXR1e33iBw3YTkMQR9W8Z8E3WfSe6UVmzNDNH1TQ==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
 				"debug": "^4.1.1",
 				"express": "^4.17.3",
-				"ioredis": "^4.24.2",
+				"ioredis": "^5.2.3",
 				"json-stringify-safe": "^5.0.1",
 				"jsonwebtoken": "^9.0.0",
 				"morgan": "^1.8.1",
@@ -4033,33 +4042,32 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
-			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
-			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
-			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -4094,18 +4102,18 @@
 			}
 		},
 		"node_modules/@fluidframework/server-test-utils": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.4001.tgz",
-			"integrity": "sha512-qrLp5H1UUPIJSEHlzZ1iYlPFJCQrd2WnmoafxnQIg0mfU1ZE8XUlG5MKUg8bT9pWsCoEGJDiOkkRHaq+WXupjQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-1.0.1.tgz",
+			"integrity": "sha512-+2ZP2pU4eq3KY5EySJhcwyAZqy9WojPhirA+fNUPKblT0fmeAn2ks6mF3d98fcxwqjMPb+5UPLRWDf7/+i1/Aw==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"events": "^3.1.0",
@@ -4115,33 +4123,32 @@
 			}
 		},
 		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
-			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
-			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
-			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -4361,6 +4368,12 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+			"dev": true
+		},
+		"node_modules/@ioredis/commands": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+			"integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
 			"dev": true
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
@@ -5610,27 +5623,27 @@
 			"dev": true
 		},
 		"node_modules/@types/cors": {
-			"version": "2.8.14",
-			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.14.tgz",
-			"integrity": "sha512-RXHUvNWYICtbP6s18PnOCaqToK8y14DnLd75c6HfyKf228dxy7pHNOQkxPtvXKp/hINFMDjbYzsj63nnpPMSRQ==",
+			"version": "2.8.15",
+			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.15.tgz",
+			"integrity": "sha512-n91JxbNLD8eQIuXDIChAN1tCKNWCEgpceU9b7ZMbFA+P+Q4yIeh80jizFLEvolRPc1ES0VdwFlGv+kJTSirogw==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/debug": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
-			"integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.10.tgz",
+			"integrity": "sha512-tOSCru6s732pofZ+sMv9o4o3Zc+Sa8l3bxd/tweTQudFn06vAzb13ZX46Zi6m6EJ+RUbRTHvgQJ1gBtSgkaUYA==",
 			"dev": true,
 			"dependencies": {
 				"@types/ms": "*"
 			}
 		},
 		"node_modules/@types/double-ended-queue": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@types/double-ended-queue/-/double-ended-queue-2.1.3.tgz",
-			"integrity": "sha512-PWBSlai2jeSM3xOlr4JPI0oDiGFLVkVvylJ1nK1+oK9V/RiBIqDy8vCtsk+gOQN/I1gU6O1cR1OHheBanFdbCQ==",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@types/double-ended-queue/-/double-ended-queue-2.1.5.tgz",
+			"integrity": "sha512-Iyp30YLmx/PFvtmomdZq4i81N6uR/7Le+UFrUbnNVbHboRCcCuOKu64tPXlr2yFOb8Zh4t0SppDxRQ5DM/Hlhg==",
 			"dev": true
 		},
 		"node_modules/@types/eslint": {
@@ -5755,9 +5768,9 @@
 			"dev": true
 		},
 		"node_modules/@types/lodash": {
-			"version": "4.14.198",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.198.tgz",
-			"integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg==",
+			"version": "4.14.200",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
+			"integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==",
 			"dev": true
 		},
 		"node_modules/@types/mime": {
@@ -5767,21 +5780,21 @@
 			"dev": true
 		},
 		"node_modules/@types/ms": {
-			"version": "0.7.31",
-			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+			"version": "0.7.33",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.33.tgz",
+			"integrity": "sha512-AuHIyzR5Hea7ij0P9q7vx7xu4z0C28ucwjAZC0ja7JhINyCnOw8/DnvAPQQ9TfOlCtZAmCERKQX9+o1mgQhuOQ==",
 			"dev": true
 		},
 		"node_modules/@types/nconf": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.3.tgz",
-			"integrity": "sha512-leyIuBk/rMIp9114FlPRkc/cQG+/JzCz1Afx3BD+CwK2ep3ZRxoC843V1rqnE2pC/jRRjANWhuVBEn4clCwlug==",
+			"version": "0.10.5",
+			"resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.5.tgz",
+			"integrity": "sha512-Rig8+FAyg9twg01Ya+aVR+QAakMxcTiO3QcvhY41Rn/m1ZvFIU5fb+D3qxxqIHxrFacQqxeg8c8apzZYZ+dqLA==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "14.18.59",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.59.tgz",
-			"integrity": "sha512-NWJMpBL2Xs3MY93yrD6YrrTKep8eIA6iMnfG4oIc6LrTRlBZgiSCGiY3V/Owlp6umIBLyKb4F8Q7hxWatjYH5A==",
+			"version": "16.18.59",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.59.tgz",
+			"integrity": "sha512-PJ1w2cNeKUEdey4LiPra0ZuxZFOGvetswE8qHRriV/sUkL5Al4tTmPV9D2+Y/TPIxTHHgxTfRjZVKWhPw/ORhQ==",
 			"dev": true
 		},
 		"node_modules/@types/parse-json": {
@@ -5913,9 +5926,9 @@
 			"dev": true
 		},
 		"node_modules/@types/triple-beam": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.3.tgz",
-			"integrity": "sha512-6tOUG+nVHn0cJbVp25JFayS5UE6+xlbcNF9Lo9mU7U0zk3zeUShZied4YEQZjy1JBF043FSkdXw8YkUJuVtB5g==",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.4.tgz",
+			"integrity": "sha512-HlJjF3wxV4R2VQkFpKe0YqJLilYNgtRtsqqZtby7RkVsSs+i+vbyzjtUwpFEdUCKcrGzCiEJE7F/0mKjh0sunA==",
 			"dev": true
 		},
 		"node_modules/@types/trusted-types": {
@@ -9169,9 +9182,9 @@
 			}
 		},
 		"node_modules/denque": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+			"integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10"
@@ -9556,9 +9569,9 @@
 			}
 		},
 		"node_modules/engine.io": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.2.tgz",
-			"integrity": "sha512-IXsMcGpw/xRfjra46sVZVHiSWo/nJ/3g1337q9KNXtS6YRzbW5yIzTCb9DjhrBe7r3GZQR0I4+nq+4ODk5g/cA==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.3.tgz",
+			"integrity": "sha512-IML/R4eG/pUS5w7OfcDE0jKrljWS9nwnEfsxWCIJF5eO6AHo6+Hlv+lQbdlAYsiJPHzUthLm1RUjnBzWOs45cw==",
 			"dev": true,
 			"dependencies": {
 				"@types/cookie": "^0.4.1",
@@ -12199,25 +12212,23 @@
 			}
 		},
 		"node_modules/ioredis": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
-			"integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
+			"integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
 			"dev": true,
 			"dependencies": {
+				"@ioredis/commands": "^1.1.1",
 				"cluster-key-slot": "^1.1.0",
-				"debug": "^4.3.1",
-				"denque": "^1.1.0",
+				"debug": "^4.3.4",
+				"denque": "^2.1.0",
 				"lodash.defaults": "^4.2.0",
-				"lodash.flatten": "^4.4.0",
 				"lodash.isarguments": "^3.1.0",
-				"p-map": "^2.1.0",
-				"redis-commands": "1.7.0",
 				"redis-errors": "^1.2.0",
 				"redis-parser": "^3.0.0",
 				"standard-as-callback": "^2.1.0"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=12.22.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -15285,12 +15296,6 @@
 			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
 			"dev": true
 		},
-		"node_modules/lodash.flatten": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-			"dev": true
-		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -15364,17 +15369,20 @@
 			"dev": true
 		},
 		"node_modules/logform": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.5.1.tgz",
-			"integrity": "sha512-9FyqAm9o9NKKfiAKfZoYo9bGXXuwMkxQiQttkT4YjjVtQVIQtK6LmVtlxmCaFswo6N4AfEkHqZTV0taDtPotNg==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
+			"integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
 			"dev": true,
 			"dependencies": {
-				"@colors/colors": "1.5.0",
+				"@colors/colors": "1.6.0",
 				"@types/triple-beam": "^1.3.2",
 				"fecha": "^4.2.0",
 				"ms": "^2.1.1",
 				"safe-stable-stringify": "^2.3.1",
 				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/looper": {
@@ -15882,9 +15890,9 @@
 			"dev": true
 		},
 		"node_modules/nconf": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.0.tgz",
-			"integrity": "sha512-T3fZPw3c7Dfrz8JBQEbEcZJ2s8f7cUMpKuyBtsGQe0b71pcXx6gNh4oti2xh5dxB+gO9ufNfISBlGvvWtfyMcA==",
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.1.tgz",
+			"integrity": "sha512-p2cfF+B3XXacQdswUYWZ0w6Vld0832A/tuqjLBu3H1sfUcby4N2oVbGhyuCkZv+t3iY3aiFEj7gZGqax9Q2c1w==",
 			"dev": true,
 			"dependencies": {
 				"async": "^3.0.0",
@@ -16398,15 +16406,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/p-map": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/p-retry": {
@@ -20183,12 +20182,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/redis-commands": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
-			"dev": true
-		},
 		"node_modules/redis-errors": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
@@ -22430,24 +22423,24 @@
 			"dev": true
 		},
 		"node_modules/tinylicious": {
-			"version": "0.4.94771",
-			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
-			"integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-1.0.0.tgz",
+			"integrity": "sha512-ACL8mEKT5LPbFyAXCDjYWqi3vcNef7y2ABMnU3O4jK1cRuEn0MywH7ppMM5ZrMgtSMMsJAINcWxZjpq3ndH8hg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.1000",
-				"@fluidframework/protocol-base": "^0.1038.1000",
-				"@fluidframework/protocol-definitions": "^1.0.0",
-				"@fluidframework/server-lambdas": "^0.1038.1000",
-				"@fluidframework/server-local-server": "^0.1038.1000",
-				"@fluidframework/server-memory-orderer": "^0.1038.1000",
-				"@fluidframework/server-services-client": "^0.1038.1000",
-				"@fluidframework/server-services-core": "^0.1038.1000",
-				"@fluidframework/server-services-shared": "^0.1038.1000",
-				"@fluidframework/server-services-telemetry": "^0.1038.1000",
-				"@fluidframework/server-services-utils": "^0.1038.1000",
-				"@fluidframework/server-test-utils": "^0.1038.1000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.0",
+				"@fluidframework/protocol-base": "^1.0.0",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^1.0.0",
+				"@fluidframework/server-local-server": "^1.0.0",
+				"@fluidframework/server-memory-orderer": "^1.0.0",
+				"@fluidframework/server-services-client": "^1.0.0",
+				"@fluidframework/server-services-core": "^1.0.0",
+				"@fluidframework/server-services-shared": "^1.0.0",
+				"@fluidframework/server-services-telemetry": "^1.0.0",
+				"@fluidframework/server-services-utils": "^1.0.0",
+				"@fluidframework/server-test-utils": "^1.0.0",
 				"agentkeepalive": "^4.2.1",
 				"axios": "^0.26.0",
 				"body-parser": "^1.17.1",
@@ -22456,7 +22449,7 @@
 				"cookie-parser": "^1.4.3",
 				"cors": "^2.8.4",
 				"detect-port": "^1.3.0",
-				"express": "^4.16.3",
+				"express": "^4.17.3",
 				"isomorphic-git": "^1.8.2",
 				"json-stringify-safe": "^5.0.1",
 				"level": "^8.0.0",
@@ -22477,33 +22470,32 @@
 			}
 		},
 		"node_modules/tinylicious/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
-			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/tinylicious/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
-			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/tinylicious/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
-			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -23727,12 +23719,12 @@
 			}
 		},
 		"node_modules/winston": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.10.0.tgz",
-			"integrity": "sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==",
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
+			"integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
 			"dev": true,
 			"dependencies": {
-				"@colors/colors": "1.5.0",
+				"@colors/colors": "^1.6.0",
 				"@dabh/diagnostics": "^2.0.2",
 				"async": "^3.2.3",
 				"is-stream": "^2.0.0",
@@ -23749,9 +23741,9 @@
 			}
 		},
 		"node_modules/winston-transport": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
-			"integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.6.0.tgz",
+			"integrity": "sha512-wbBA9PbPAHxKiygo7ub7BYRiKxms0tpfU2ljtWzb3SjRjv5yl6Ozuy/TkXf00HTAt+Uylo3gSkNwzc4ME0wiIg==",
 			"dev": true,
 			"dependencies": {
 				"logform": "^2.3.2",
@@ -23759,7 +23751,7 @@
 				"triple-beam": "^1.3.0"
 			},
 			"engines": {
-				"node": ">= 6.4.0"
+				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/word-wrap": {

--- a/audience-demo/package-lock.json
+++ b/audience-demo/package-lock.json
@@ -15,6 +15,7 @@
 				"react-dom": "^18.2.0"
 			},
 			"devDependencies": {
+				"@fluidframework/azure-local-service": "^1.1.0",
 				"@fluidframework/build-common": "^2.0.0",
 				"@testing-library/jest-dom": "^6.1.3",
 				"@testing-library/react": "^14.0.0",
@@ -27,7 +28,6 @@
 				"puppeteer": "^21.1.1",
 				"react-scripts": "^5.0.1",
 				"start-server-and-test": "^2.0.0",
-				"tinylicious": "^1.0.0",
 				"url": "^0.11.2"
 			}
 		},
@@ -2709,6 +2709,397 @@
 				"fluid-framework": "^1.3.3"
 			}
 		},
+		"node_modules/@fluidframework/azure-local-service": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-1.1.1.tgz",
+			"integrity": "sha512-gvk+qy8RytXBQaZ554OREszHGN73W3FmgpfwV+aXeOOP5RWLMPSvkPoac5K9gcUYN+nAFbRs517c055yucP9ug==",
+			"dev": true,
+			"dependencies": {
+				"tinylicious": "^0.4.89251"
+			},
+			"bin": {
+				"azure-local-service": "dist/index.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/gitresources": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
+			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-base": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
+			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.4001.tgz",
+			"integrity": "sha512-rERfgXK5DXGJvxADjotkAZssKgp3ZxW6u7yUekrDnFDkXtbCW1Gcq+EwvjHTEyhsOp30YBnD0Z39xnZy4zEZRw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas-driver": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/semver": "^6.0.1",
+				"assert": "^2.0.0",
+				"async": "^3.2.2",
+				"axios": "^0.26.0",
+				"buffer": "^6.0.3",
+				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
+				"json-stringify-safe": "^5.0.1",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"semver": "^6.3.0",
+				"sha.js": "^2.4.11",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas-driver": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.4001.tgz",
+			"integrity": "sha512-qRs+vMbSS9aPx7vr3XemvER5DeY/nsJ5ZkcL3UDjUOxvLZxbOAD6C6JeH3Zgzc/jc8bqshcxai/u7qso2zCsFw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"assert": "^2.0.0",
+				"async": "^3.2.2",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-local-server": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.4001.tgz",
+			"integrity": "sha512-FIlNUc9Ncul/5qzP+VyU53TJj8fxX7KZ1lweswZYalleRZwiqFA4Y+NbWRRWM0iJ1z8hvhyRZblG3iNrpGl04A==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^0.1038.4001",
+				"@fluidframework/server-memory-orderer": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@fluidframework/server-test-utils": "^0.1038.4001",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"jsrsasign": "^10.5.25",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-memory-orderer": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.4001.tgz",
+			"integrity": "sha512-fdzTCLFRh8QfyY17MnB22/o8x2XEX1+wZrm+dn+1Av+ZVe/+ZhfdX5LsQCMKYv+X5mgAauNmC/12mQE4H6jvsQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/debug": "^4.1.5",
+				"@types/double-ended-queue": "^2.1.0",
+				"@types/lodash": "^4.14.118",
+				"@types/node": "^14.18.0",
+				"@types/ws": "^6.0.1",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1",
+				"ws": "^7.4.6"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-client": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
+			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"axios": "^0.26.0",
+				"crc-32": "1.2.0",
+				"debug": "^4.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"jsrsasign": "^10.5.25",
+				"jwt-decode": "^3.0.0",
+				"querystring": "^0.2.0",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-core": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.4001.tgz",
+			"integrity": "sha512-nuZ9ebvyeIoRdlpQQpBNGkawKtc2/tHKbc8CHbMZRMh7F7kwYUtoHd/J8powb9eUcg5IHDmXx1l+PQRbQX4vCg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/nconf": "^0.10.2",
+				"@types/node": "^14.18.0",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"nconf": "^0.12.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-shared": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.4001.tgz",
+			"integrity": "sha512-vDRB2G/Xnuhan+Ri0Eg5JMKfsm7hxstCXdEyQhzJzC7+bw66wts+ZIsEsn4Ha/3KkxblF/RSW3lBhrYpxii3cQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@socket.io/redis-adapter": "^7.2.0",
+				"body-parser": "^1.17.1",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"ioredis": "^4.24.2",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"notepack.io": "^2.3.0",
+				"querystring": "^0.2.0",
+				"socket.io": "^4.5.3",
+				"socket.io-adapter": "^2.4.0",
+				"socket.io-parser": "^4.2.1",
+				"uuid": "^8.3.1",
+				"winston": "^3.6.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-telemetry": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.4001.tgz",
+			"integrity": "sha512-2leJhB04+71RTmC5ShRXm/4FWng9tLn9dlrUAjApZH4RlUJAx1JGsvo/5JU1tIbpUutMHUle2IpWyfu/RV+S5g==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"path-browserify": "^1.0.1",
+				"serialize-error": "^8.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-utils": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.4001.tgz",
+			"integrity": "sha512-K7X/0mlonDAu0pPIgTz8U9nLwRSbJY2oBpFPwpkp1UtE6SU02jx2ZzraT9epDmOl3EXeS1rHzA+mbvBSe1aFMg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"debug": "^4.1.1",
+				"express": "^4.17.3",
+				"ioredis": "^4.24.2",
+				"json-stringify-safe": "^5.0.1",
+				"jsonwebtoken": "^9.0.0",
+				"morgan": "^1.8.1",
+				"nconf": "^0.12.0",
+				"serialize-error": "^8.1.0",
+				"sillyname": "^0.1.0",
+				"split": "^1.0.0",
+				"uuid": "^8.3.1",
+				"winston": "^3.6.0",
+				"winston-transport": "^4.5.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-test-utils": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.4001.tgz",
+			"integrity": "sha512-qrLp5H1UUPIJSEHlzZ1iYlPFJCQrd2WnmoafxnQIg0mfU1ZE8XUlG5MKUg8bT9pWsCoEGJDiOkkRHaq+WXupjQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"string-hash": "^1.1.3",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@types/node": {
+			"version": "14.18.63",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@types/semver": {
+			"version": "6.2.5",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.5.tgz",
+			"integrity": "sha512-NAxro9/RqWXTqdSjccDZAjA4nXK+6zRun+HvibYJfGy8TQhpOC7Vv6v2rlHYKrT0Q8jGGoNRd/xVdHRIQRNlFQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/axios": {
+			"version": "0.26.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+			"dev": true,
+			"dependencies": {
+				"follow-redirects": "^1.14.8"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/denque": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/ioredis": {
+			"version": "4.28.5",
+			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
+			"integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+			"dev": true,
+			"dependencies": {
+				"cluster-key-slot": "^1.1.0",
+				"debug": "^4.3.1",
+				"denque": "^1.1.0",
+				"lodash.defaults": "^4.2.0",
+				"lodash.flatten": "^4.4.0",
+				"lodash.isarguments": "^3.1.0",
+				"p-map": "^2.1.0",
+				"redis-commands": "1.7.0",
+				"redis-errors": "^1.2.0",
+				"redis-parser": "^3.0.0",
+				"standard-as-callback": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ioredis"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/split": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"dev": true,
+			"dependencies": {
+				"through": "2"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/tinylicious": {
+			"version": "0.4.94771",
+			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
+			"integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.0.0",
+				"@fluidframework/gitresources": "^0.1038.1000",
+				"@fluidframework/protocol-base": "^0.1038.1000",
+				"@fluidframework/protocol-definitions": "^1.0.0",
+				"@fluidframework/server-lambdas": "^0.1038.1000",
+				"@fluidframework/server-local-server": "^0.1038.1000",
+				"@fluidframework/server-memory-orderer": "^0.1038.1000",
+				"@fluidframework/server-services-client": "^0.1038.1000",
+				"@fluidframework/server-services-core": "^0.1038.1000",
+				"@fluidframework/server-services-shared": "^0.1038.1000",
+				"@fluidframework/server-services-telemetry": "^0.1038.1000",
+				"@fluidframework/server-services-utils": "^0.1038.1000",
+				"@fluidframework/server-test-utils": "^0.1038.1000",
+				"agentkeepalive": "^4.2.1",
+				"axios": "^0.26.0",
+				"body-parser": "^1.17.1",
+				"charwise": "^3.0.1",
+				"compression": "^1.7.2",
+				"cookie-parser": "^1.4.3",
+				"cors": "^2.8.4",
+				"detect-port": "^1.3.0",
+				"express": "^4.16.3",
+				"isomorphic-git": "^1.8.2",
+				"json-stringify-safe": "^5.0.1",
+				"level": "^8.0.0",
+				"level-sublevel": "6.6.4",
+				"lodash": "^4.17.21",
+				"morgan": "^1.8.1",
+				"nconf": "^0.12.0",
+				"socket.io": "^4.5.0",
+				"split": "^1.0.0",
+				"uuid": "^8.3.2",
+				"winston": "^3.6.0"
+			},
+			"bin": {
+				"tinylicious": "dist/index.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/ws": {
+			"version": "7.5.9",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.3.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@fluidframework/build-common": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.0.tgz",
@@ -3467,348 +3858,6 @@
 				"@fluidframework/common-definitions": "^0.20.1"
 			}
 		},
-		"node_modules/@fluidframework/server-lambdas": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-1.0.1.tgz",
-			"integrity": "sha512-lwVKg4dVDvbNH4ckj328z5cNu1plHhArzIMP3kpl8T94L6OubqsJ8vf3g46Wab/SjwltHC41p/wWigJapXZjqA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas-driver": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/semver": "^7.5.0",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"axios": "^0.26.0",
-				"buffer": "^6.0.3",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"semver": "^7.5.3",
-				"sha.js": "^2.4.11",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-1.0.1.tgz",
-			"integrity": "sha512-TfQ7rz2/6pW6Rq5CbGBu9ShiSKyOHg2pXX0cUVHtnuuUPsWTxQDWlVilYukyG0uxHJfE3ZDU3R1QgnWUQQmGgg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-local-server": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-1.0.1.tgz",
-			"integrity": "sha512-494H0PYNa6aqngyq/M46K7wlY7NHdIx1B4qcfRCRQmjJZrD9GPza3FHt2/426teBQ93F6SOKkBrMw2vbmoUUGg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.1",
-				"@fluidframework/server-memory-orderer": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@fluidframework/server-test-utils": "^1.0.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"jsrsasign": "^10.5.25",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-1.0.1.tgz",
-			"integrity": "sha512-zUuNICwyKC7OTSl/W9MSiwplSccnRHVmRpdxImCe5qVs+VSK1jHuIGiIzCkt6dlVNMu3WHyUXmrKCLmhJZmFeQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/debug": "^4.1.5",
-				"@types/double-ended-queue": "^2.1.0",
-				"@types/lodash": "^4.14.118",
-				"@types/node": "^16.18.16",
-				"@types/ws": "^6.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1",
-				"ws": "^7.4.6"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/ws": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@fluidframework/server-services-client": {
 			"version": "0.1036.5001",
 			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5001.tgz",
@@ -3855,317 +3904,6 @@
 			"version": "0.26.1",
 			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
 			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-1.0.1.tgz",
-			"integrity": "sha512-/Lb5ZZxb4aHtzLH3p+lrboi6TW/WD0I53di8FI4rMmn5AM7+h69BolPW7nume52t3HUi1I2Mnqhx1W8FKV8BbA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/nconf": "^0.10.2",
-				"@types/node": "^16.18.16",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"nconf": "^0.12.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-1.0.1.tgz",
-			"integrity": "sha512-Z+IyqWHUk/y0aZ5cUXUoehcOiIr4qw1VkDR5i+1rnLntCRkPKk7h6FFXcWo+OBmI7D3AJOKZagMr6npezIPEmQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@socket.io/redis-adapter": "^7.2.0",
-				"body-parser": "^1.17.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"ioredis": "^5.2.3",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"notepack.io": "^2.3.0",
-				"querystring": "^0.2.0",
-				"serialize-error": "^8.1.0",
-				"socket.io": "^4.5.3",
-				"socket.io-adapter": "^2.4.0",
-				"socket.io-parser": "^4.2.1",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/@fluidframework/server-services-telemetry": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-1.0.1.tgz",
-			"integrity": "sha512-qeNtIr5mnkDS5hwD9t+2kcmsRK4zxdAtR+F0j0/rZ/pBWuaVmJI6YiKC5HzWTuszW5F1VDpGnul0M8HEWyhrgQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"path-browserify": "^1.0.1",
-				"serialize-error": "^8.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-1.0.1.tgz",
-			"integrity": "sha512-MzoonbJ/EQMbPi+m7/TZxWqyYzs1wxOdtN/Fe4FkaKOcHJjXR1e33iBw3YTkMQR9W8Z8E3WfSe6UVmzNDNH1TQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"debug": "^4.1.1",
-				"express": "^4.17.3",
-				"ioredis": "^5.2.3",
-				"json-stringify-safe": "^5.0.1",
-				"jsonwebtoken": "^9.0.0",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0",
-				"sillyname": "^0.1.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0",
-				"winston-transport": "^4.5.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-1.0.1.tgz",
-			"integrity": "sha512-+2ZP2pU4eq3KY5EySJhcwyAZqy9WojPhirA+fNUPKblT0fmeAn2ks6mF3d98fcxwqjMPb+5UPLRWDf7/+i1/Aw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"string-hash": "^1.1.3",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
 			"dependencies": {
 				"follow-redirects": "^1.14.8"
 			}
@@ -4368,12 +4106,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-			"dev": true
-		},
-		"node_modules/@ioredis/commands": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-			"integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
 			"dev": true
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
@@ -9181,15 +8913,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/denque": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-			"integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
 		"node_modules/depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -12209,30 +11932,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/ioredis": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
-			"integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
-			"dev": true,
-			"dependencies": {
-				"@ioredis/commands": "^1.1.1",
-				"cluster-key-slot": "^1.1.0",
-				"debug": "^4.3.4",
-				"denque": "^2.1.0",
-				"lodash.defaults": "^4.2.0",
-				"lodash.isarguments": "^3.1.0",
-				"redis-errors": "^1.2.0",
-				"redis-parser": "^3.0.0",
-				"standard-as-callback": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=12.22.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ioredis"
 			}
 		},
 		"node_modules/ip": {
@@ -15296,6 +14995,12 @@
 			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
 			"dev": true
 		},
+		"node_modules/lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+			"dev": true
+		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -16406,6 +16111,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-map": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/p-retry": {
@@ -20182,6 +19896,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/redis-commands": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
+			"dev": true
+		},
 		"node_modules/redis-errors": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
@@ -22421,113 +22141,6 @@
 			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
 			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
 			"dev": true
-		},
-		"node_modules/tinylicious": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-1.0.0.tgz",
-			"integrity": "sha512-ACL8mEKT5LPbFyAXCDjYWqi3vcNef7y2ABMnU3O4jK1cRuEn0MywH7ppMM5ZrMgtSMMsJAINcWxZjpq3ndH8hg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.0",
-				"@fluidframework/protocol-base": "^1.0.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.0",
-				"@fluidframework/server-local-server": "^1.0.0",
-				"@fluidframework/server-memory-orderer": "^1.0.0",
-				"@fluidframework/server-services-client": "^1.0.0",
-				"@fluidframework/server-services-core": "^1.0.0",
-				"@fluidframework/server-services-shared": "^1.0.0",
-				"@fluidframework/server-services-telemetry": "^1.0.0",
-				"@fluidframework/server-services-utils": "^1.0.0",
-				"@fluidframework/server-test-utils": "^1.0.0",
-				"agentkeepalive": "^4.2.1",
-				"axios": "^0.26.0",
-				"body-parser": "^1.17.1",
-				"charwise": "^3.0.1",
-				"compression": "^1.7.2",
-				"cookie-parser": "^1.4.3",
-				"cors": "^2.8.4",
-				"detect-port": "^1.3.0",
-				"express": "^4.17.3",
-				"isomorphic-git": "^1.8.2",
-				"json-stringify-safe": "^5.0.1",
-				"level": "^8.0.0",
-				"level-sublevel": "6.6.4",
-				"lodash": "^4.17.21",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"socket.io": "^4.5.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.2",
-				"winston": "^3.6.0"
-			},
-			"bin": {
-				"tinylicious": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/tinylicious/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/tinylicious/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
 		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",

--- a/audience-demo/package-lock.json
+++ b/audience-demo/package-lock.json
@@ -15,7 +15,6 @@
 				"react-dom": "^18.2.0"
 			},
 			"devDependencies": {
-				"@fluidframework/azure-local-service": "^1.1.0",
 				"@fluidframework/build-common": "^2.0.0",
 				"@testing-library/jest-dom": "^6.1.3",
 				"@testing-library/react": "^14.0.0",
@@ -2240,15 +2239,6 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
 		},
-		"node_modules/@colors/colors": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
-			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.1.90"
-			}
-		},
 		"node_modules/@csstools/normalize.css": {
 			"version": "12.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
@@ -2535,17 +2525,6 @@
 				"postcss-selector-parser": "^6.0.10"
 			}
 		},
-		"node_modules/@dabh/diagnostics": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-			"integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
-			"dev": true,
-			"dependencies": {
-				"colorspace": "1.1.x",
-				"enabled": "2.0.x",
-				"kuler": "^2.0.0"
-			}
-		},
 		"node_modules/@eslint-community/eslint-utils": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -2707,397 +2686,6 @@
 			},
 			"peerDependencies": {
 				"fluid-framework": "^1.3.3"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-1.1.1.tgz",
-			"integrity": "sha512-gvk+qy8RytXBQaZ554OREszHGN73W3FmgpfwV+aXeOOP5RWLMPSvkPoac5K9gcUYN+nAFbRs517c055yucP9ug==",
-			"dev": true,
-			"dependencies": {
-				"tinylicious": "^0.4.89251"
-			},
-			"bin": {
-				"azure-local-service": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
-			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
-			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.4001.tgz",
-			"integrity": "sha512-rERfgXK5DXGJvxADjotkAZssKgp3ZxW6u7yUekrDnFDkXtbCW1Gcq+EwvjHTEyhsOp30YBnD0Z39xnZy4zEZRw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas-driver": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/semver": "^6.0.1",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"axios": "^0.26.0",
-				"buffer": "^6.0.3",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"semver": "^6.3.0",
-				"sha.js": "^2.4.11",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas-driver": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.4001.tgz",
-			"integrity": "sha512-qRs+vMbSS9aPx7vr3XemvER5DeY/nsJ5ZkcL3UDjUOxvLZxbOAD6C6JeH3Zgzc/jc8bqshcxai/u7qso2zCsFw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-local-server": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.4001.tgz",
-			"integrity": "sha512-FIlNUc9Ncul/5qzP+VyU53TJj8fxX7KZ1lweswZYalleRZwiqFA4Y+NbWRRWM0iJ1z8hvhyRZblG3iNrpGl04A==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.4001",
-				"@fluidframework/server-memory-orderer": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@fluidframework/server-test-utils": "^0.1038.4001",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"jsrsasign": "^10.5.25",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-memory-orderer": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.4001.tgz",
-			"integrity": "sha512-fdzTCLFRh8QfyY17MnB22/o8x2XEX1+wZrm+dn+1Av+ZVe/+ZhfdX5LsQCMKYv+X5mgAauNmC/12mQE4H6jvsQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/debug": "^4.1.5",
-				"@types/double-ended-queue": "^2.1.0",
-				"@types/lodash": "^4.14.118",
-				"@types/node": "^14.18.0",
-				"@types/ws": "^6.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1",
-				"ws": "^7.4.6"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
-			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-core": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.4001.tgz",
-			"integrity": "sha512-nuZ9ebvyeIoRdlpQQpBNGkawKtc2/tHKbc8CHbMZRMh7F7kwYUtoHd/J8powb9eUcg5IHDmXx1l+PQRbQX4vCg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/nconf": "^0.10.2",
-				"@types/node": "^14.18.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"nconf": "^0.12.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-shared": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.4001.tgz",
-			"integrity": "sha512-vDRB2G/Xnuhan+Ri0Eg5JMKfsm7hxstCXdEyQhzJzC7+bw66wts+ZIsEsn4Ha/3KkxblF/RSW3lBhrYpxii3cQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@socket.io/redis-adapter": "^7.2.0",
-				"body-parser": "^1.17.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"ioredis": "^4.24.2",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"notepack.io": "^2.3.0",
-				"querystring": "^0.2.0",
-				"socket.io": "^4.5.3",
-				"socket.io-adapter": "^2.4.0",
-				"socket.io-parser": "^4.2.1",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-telemetry": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.4001.tgz",
-			"integrity": "sha512-2leJhB04+71RTmC5ShRXm/4FWng9tLn9dlrUAjApZH4RlUJAx1JGsvo/5JU1tIbpUutMHUle2IpWyfu/RV+S5g==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"path-browserify": "^1.0.1",
-				"serialize-error": "^8.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-utils": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.4001.tgz",
-			"integrity": "sha512-K7X/0mlonDAu0pPIgTz8U9nLwRSbJY2oBpFPwpkp1UtE6SU02jx2ZzraT9epDmOl3EXeS1rHzA+mbvBSe1aFMg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"debug": "^4.1.1",
-				"express": "^4.17.3",
-				"ioredis": "^4.24.2",
-				"json-stringify-safe": "^5.0.1",
-				"jsonwebtoken": "^9.0.0",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0",
-				"sillyname": "^0.1.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0",
-				"winston-transport": "^4.5.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-test-utils": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.4001.tgz",
-			"integrity": "sha512-qrLp5H1UUPIJSEHlzZ1iYlPFJCQrd2WnmoafxnQIg0mfU1ZE8XUlG5MKUg8bT9pWsCoEGJDiOkkRHaq+WXupjQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"string-hash": "^1.1.3",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@types/node": {
-			"version": "14.18.63",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@types/semver": {
-			"version": "6.2.5",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.5.tgz",
-			"integrity": "sha512-NAxro9/RqWXTqdSjccDZAjA4nXK+6zRun+HvibYJfGy8TQhpOC7Vv6v2rlHYKrT0Q8jGGoNRd/xVdHRIQRNlFQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/denque": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/ioredis": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
-			"integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
-			"dev": true,
-			"dependencies": {
-				"cluster-key-slot": "^1.1.0",
-				"debug": "^4.3.1",
-				"denque": "^1.1.0",
-				"lodash.defaults": "^4.2.0",
-				"lodash.flatten": "^4.4.0",
-				"lodash.isarguments": "^3.1.0",
-				"p-map": "^2.1.0",
-				"redis-commands": "1.7.0",
-				"redis-errors": "^1.2.0",
-				"redis-parser": "^3.0.0",
-				"standard-as-callback": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ioredis"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/tinylicious": {
-			"version": "0.4.94771",
-			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
-			"integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.1000",
-				"@fluidframework/protocol-base": "^0.1038.1000",
-				"@fluidframework/protocol-definitions": "^1.0.0",
-				"@fluidframework/server-lambdas": "^0.1038.1000",
-				"@fluidframework/server-local-server": "^0.1038.1000",
-				"@fluidframework/server-memory-orderer": "^0.1038.1000",
-				"@fluidframework/server-services-client": "^0.1038.1000",
-				"@fluidframework/server-services-core": "^0.1038.1000",
-				"@fluidframework/server-services-shared": "^0.1038.1000",
-				"@fluidframework/server-services-telemetry": "^0.1038.1000",
-				"@fluidframework/server-services-utils": "^0.1038.1000",
-				"@fluidframework/server-test-utils": "^0.1038.1000",
-				"agentkeepalive": "^4.2.1",
-				"axios": "^0.26.0",
-				"body-parser": "^1.17.1",
-				"charwise": "^3.0.1",
-				"compression": "^1.7.2",
-				"cookie-parser": "^1.4.3",
-				"cors": "^2.8.4",
-				"detect-port": "^1.3.0",
-				"express": "^4.16.3",
-				"isomorphic-git": "^1.8.2",
-				"json-stringify-safe": "^5.0.1",
-				"level": "^8.0.0",
-				"level-sublevel": "6.6.4",
-				"lodash": "^4.17.21",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"socket.io": "^4.5.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.2",
-				"winston": "^3.6.0"
-			},
-			"bin": {
-				"tinylicious": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/ws": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@fluidframework/build-common": {
@@ -4834,27 +4422,6 @@
 			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
 			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
 		},
-		"node_modules/@socket.io/redis-adapter": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-7.2.0.tgz",
-			"integrity": "sha512-/r6oF6Myz0K9uatB/pfCi0BhKg/KRMh1OokrqcjlNz6aq40WiXdFLRbHJQuwGHq/KvB+D6141K+IynbVxZGvhw==",
-			"dev": true,
-			"dependencies": {
-				"debug": "~4.3.1",
-				"notepack.io": "~2.2.0",
-				"socket.io-adapter": "^2.4.0",
-				"uid2": "0.0.3"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/@socket.io/redis-adapter/node_modules/notepack.io": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.2.0.tgz",
-			"integrity": "sha512-9b5w3t5VSH6ZPosoYnyDONnUTF8o0UkBw7JLA6eBlYJWyGT1Q3vQa8Hmuj1/X6RYvHjjygBDgw6fJhe0JEojfw==",
-			"dev": true
-		},
 		"node_modules/@surma/rollup-plugin-off-main-thread": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -5348,36 +4915,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/cookie": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-			"integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-			"dev": true
-		},
-		"node_modules/@types/cors": {
-			"version": "2.8.15",
-			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.15.tgz",
-			"integrity": "sha512-n91JxbNLD8eQIuXDIChAN1tCKNWCEgpceU9b7ZMbFA+P+Q4yIeh80jizFLEvolRPc1ES0VdwFlGv+kJTSirogw==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@types/debug": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.10.tgz",
-			"integrity": "sha512-tOSCru6s732pofZ+sMv9o4o3Zc+Sa8l3bxd/tweTQudFn06vAzb13ZX46Zi6m6EJ+RUbRTHvgQJ1gBtSgkaUYA==",
-			"dev": true,
-			"dependencies": {
-				"@types/ms": "*"
-			}
-		},
-		"node_modules/@types/double-ended-queue": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@types/double-ended-queue/-/double-ended-queue-2.1.5.tgz",
-			"integrity": "sha512-Iyp30YLmx/PFvtmomdZq4i81N6uR/7Le+UFrUbnNVbHboRCcCuOKu64tPXlr2yFOb8Zh4t0SppDxRQ5DM/Hlhg==",
-			"dev": true
-		},
 		"node_modules/@types/eslint": {
 			"version": "8.44.2",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.2.tgz",
@@ -5499,28 +5036,10 @@
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
 		},
-		"node_modules/@types/lodash": {
-			"version": "4.14.200",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
-			"integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==",
-			"dev": true
-		},
 		"node_modules/@types/mime": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
 			"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-			"dev": true
-		},
-		"node_modules/@types/ms": {
-			"version": "0.7.33",
-			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.33.tgz",
-			"integrity": "sha512-AuHIyzR5Hea7ij0P9q7vx7xu4z0C28ucwjAZC0ja7JhINyCnOw8/DnvAPQQ9TfOlCtZAmCERKQX9+o1mgQhuOQ==",
-			"dev": true
-		},
-		"node_modules/@types/nconf": {
-			"version": "0.10.5",
-			"resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.5.tgz",
-			"integrity": "sha512-Rig8+FAyg9twg01Ya+aVR+QAakMxcTiO3QcvhY41Rn/m1ZvFIU5fb+D3qxxqIHxrFacQqxeg8c8apzZYZ+dqLA==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -5657,26 +5176,11 @@
 			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
 			"dev": true
 		},
-		"node_modules/@types/triple-beam": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.4.tgz",
-			"integrity": "sha512-HlJjF3wxV4R2VQkFpKe0YqJLilYNgtRtsqqZtby7RkVsSs+i+vbyzjtUwpFEdUCKcrGzCiEJE7F/0mKjh0sunA==",
-			"dev": true
-		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.4.tgz",
 			"integrity": "sha512-IDaobHimLQhjwsQ/NMwRVfa/yL7L/wriQPMhw1ZJall0KX6E1oxk29XMDeilW5qTIg5aoiqf5Udy8U/51aNoQQ==",
 			"dev": true
-		},
-		"node_modules/@types/ws": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
-			"integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
 		},
 		"node_modules/@types/yargs": {
 			"version": "17.0.24",
@@ -6206,24 +5710,6 @@
 				"node": ">=6.5"
 			}
 		},
-		"node_modules/abstract-level": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
-			"integrity": "sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^6.0.3",
-				"catering": "^2.1.0",
-				"is-buffer": "^2.0.5",
-				"level-supports": "^4.0.0",
-				"level-transcoder": "^1.0.1",
-				"module-error": "^1.0.1",
-				"queue-microtask": "^1.2.3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -6330,18 +5816,6 @@
 			},
 			"engines": {
 				"node": ">= 14"
-			}
-		},
-		"node_modules/agentkeepalive": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
-			"integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
-			"dev": true,
-			"dependencies": {
-				"humanize-ms": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 8.0.0"
 			}
 		},
 		"node_modules/ajv": {
@@ -6663,19 +6137,6 @@
 			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
 			"dev": true
 		},
-		"node_modules/assert": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
-			"integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"is-nan": "^1.3.2",
-				"object-is": "^1.1.5",
-				"object.assign": "^4.1.4",
-				"util": "^0.12.5"
-			}
-		},
 		"node_modules/ast-types": {
 			"version": "0.13.4",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -6698,12 +6159,6 @@
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
 			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-			"dev": true
-		},
-		"node_modules/async-lock": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz",
-			"integrity": "sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ==",
 			"dev": true
 		},
 		"node_modules/asynciterator.prototype": {
@@ -7104,33 +6559,6 @@
 				}
 			]
 		},
-		"node_modules/base64id": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-			"integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-			"dev": true,
-			"engines": {
-				"node": "^4.5.0 || >= 5.9"
-			}
-		},
-		"node_modules/basic-auth": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-			"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "5.1.2"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/basic-auth/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
 		"node_modules/basic-ftp": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
@@ -7283,18 +6711,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/browser-level": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
-			"integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
-			"dev": true,
-			"dependencies": {
-				"abstract-level": "^1.0.2",
-				"catering": "^2.1.1",
-				"module-error": "^1.0.2",
-				"run-parallel-limit": "^1.1.0"
-			}
-		},
 		"node_modules/browser-process-hrtime": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
@@ -7374,12 +6790,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/buffer-equal-constant-time": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-			"dev": true
-		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -7405,25 +6815,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/bytewise": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-			"integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
-			"dev": true,
-			"dependencies": {
-				"bytewise-core": "^1.2.2",
-				"typewise": "^1.0.3"
-			}
-		},
-		"node_modules/bytewise-core": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-			"integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
-			"dev": true,
-			"dependencies": {
-				"typewise-core": "^1.2"
 			}
 		},
 		"node_modules/call-bind": {
@@ -7516,15 +6907,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/catering": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
-			"integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -7549,12 +6931,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/charwise": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz",
-			"integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw==",
-			"dev": true
 		},
 		"node_modules/check-more-types": {
 			"version": "2.24.0",
@@ -7652,23 +7028,6 @@
 			"integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
 			"dev": true
 		},
-		"node_modules/classic-level": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.3.0.tgz",
-			"integrity": "sha512-iwFAJQYtqRTRM0F6L8h4JCt00ZSGdOyqh7yVrhhjrOpFhmBjNlRUey64MCiyo6UmQHMJ+No3c81nujPv+n9yrg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"dependencies": {
-				"abstract-level": "^1.0.2",
-				"catering": "^2.1.0",
-				"module-error": "^1.0.1",
-				"napi-macros": "^2.2.2",
-				"node-gyp-build": "^4.3.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/clean-css": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
@@ -7680,12 +7039,6 @@
 			"engines": {
 				"node": ">= 10.0"
 			}
-		},
-		"node_modules/clean-git-ref": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
-			"integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
-			"dev": true
 		},
 		"node_modules/cliui": {
 			"version": "8.0.1",
@@ -7699,15 +7052,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/cluster-key-slot": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
-			"integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/co": {
@@ -7811,16 +7155,6 @@
 			"integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
 			"dev": true
 		},
-		"node_modules/color": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^1.9.3",
-				"color-string": "^1.6.0"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7839,31 +7173,6 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
-		"node_modules/color-string": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
-		},
-		"node_modules/color/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/color/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
-		},
 		"node_modules/colord": {
 			"version": "2.9.3",
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
@@ -7875,16 +7184,6 @@
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
 			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
 			"dev": true
-		},
-		"node_modules/colorspace": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-			"integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-			"dev": true,
-			"dependencies": {
-				"color": "^3.1.3",
-				"text-hex": "1.0.x"
-			}
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
@@ -8036,28 +7335,6 @@
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true
 		},
-		"node_modules/cookie": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-			"integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/cookie-parser": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-			"integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
-			"dev": true,
-			"dependencies": {
-				"cookie": "0.4.1",
-				"cookie-signature": "1.0.6"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
 		"node_modules/cookie-signature": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -8104,19 +7381,6 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"dev": true
-		},
-		"node_modules/cors": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-			"dev": true,
-			"dependencies": {
-				"object-assign": "^4",
-				"vary": "^1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
 		},
 		"node_modules/cosmiconfig": {
 			"version": "8.2.0",
@@ -8780,21 +8044,6 @@
 			"integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
 			"dev": true
 		},
-		"node_modules/decompress-response": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-			"dev": true,
-			"dependencies": {
-				"mimic-response": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/dedent": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
@@ -8956,20 +8205,6 @@
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
 		},
-		"node_modules/detect-port": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
-			"integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
-			"dev": true,
-			"dependencies": {
-				"address": "^1.0.1",
-				"debug": "4"
-			},
-			"bin": {
-				"detect": "bin/detect-port.js",
-				"detect-port": "bin/detect-port.js"
-			}
-		},
 		"node_modules/detect-port-alt": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
@@ -9022,12 +8257,6 @@
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
-		},
-		"node_modules/diff3": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
-			"dev": true
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
@@ -9204,15 +8433,6 @@
 			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
 			"dev": true
 		},
-		"node_modules/ecdsa-sig-formatter": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"node_modules/ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -9267,12 +8487,6 @@
 				"node": ">= 4"
 			}
 		},
-		"node_modules/enabled": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
-			"dev": true
-		},
 		"node_modules/encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -9289,27 +8503,6 @@
 			"dev": true,
 			"dependencies": {
 				"once": "^1.4.0"
-			}
-		},
-		"node_modules/engine.io": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.3.tgz",
-			"integrity": "sha512-IML/R4eG/pUS5w7OfcDE0jKrljWS9nwnEfsxWCIJF5eO6AHo6+Hlv+lQbdlAYsiJPHzUthLm1RUjnBzWOs45cw==",
-			"dev": true,
-			"dependencies": {
-				"@types/cookie": "^0.4.1",
-				"@types/cors": "^2.8.12",
-				"@types/node": ">=10.0.0",
-				"accepts": "~1.3.4",
-				"base64id": "2.0.0",
-				"cookie": "~0.4.1",
-				"cors": "~2.8.5",
-				"debug": "~4.3.1",
-				"engine.io-parser": "~5.2.1",
-				"ws": "~8.11.0"
-			},
-			"engines": {
-				"node": ">=10.2.0"
 			}
 		},
 		"node_modules/engine.io-client": {
@@ -9352,27 +8545,6 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/engine.io/node_modules/ws": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.15.0",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
@@ -9393,18 +8565,6 @@
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/errno": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
-			"integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-			"dev": true,
-			"dependencies": {
-				"prr": "~1.0.1"
-			},
-			"bin": {
-				"errno": "cli.js"
 			}
 		},
 		"node_modules/error-ex": {
@@ -10577,12 +9737,6 @@
 				"pend": "~1.2.0"
 			}
 		},
-		"node_modules/fecha": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
-			"dev": true
-		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -10815,12 +9969,6 @@
 				"@fluidframework/map": "^1.3.7",
 				"@fluidframework/sequence": "^1.3.7"
 			}
-		},
-		"node_modules/fn.name": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-			"dev": true
 		},
 		"node_modules/follow-redirects": {
 			"version": "1.15.2",
@@ -11748,15 +10896,6 @@
 				"node": ">=10.17.0"
 			}
 		},
-		"node_modules/humanize-ms": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "^2.0.0"
-			}
-		},
 		"node_modules/iconv-lite": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -12040,29 +11179,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-buffer": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/is-callable": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -12197,22 +11313,6 @@
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
 			"integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
 			"dev": true
-		},
-		"node_modules/is-nan": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/is-negative-zero": {
 			"version": "2.0.2",
@@ -12470,40 +11570,6 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
-		},
-		"node_modules/isomorphic-git": {
-			"version": "1.24.5",
-			"resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.24.5.tgz",
-			"integrity": "sha512-07M4YscftHZJIuw7xZhgWkdFvVjHSBJBsIwWXkxgFCivhb0l8mGNchM7nO2hU27EKSIf0sT4gJivEgLGohWbzA==",
-			"dev": true,
-			"dependencies": {
-				"async-lock": "^1.1.0",
-				"clean-git-ref": "^2.0.1",
-				"crc-32": "^1.2.0",
-				"diff3": "0.0.3",
-				"ignore": "^5.1.4",
-				"minimisted": "^2.0.0",
-				"pako": "^1.0.10",
-				"pify": "^4.0.1",
-				"readable-stream": "^3.4.0",
-				"sha.js": "^2.4.9",
-				"simple-get": "^4.0.1"
-			},
-			"bin": {
-				"isogit": "cli.cjs"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/isomorphic-git/node_modules/pify": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.0",
@@ -14571,61 +13637,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/jsonwebtoken": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-			"integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-			"dev": true,
-			"dependencies": {
-				"jws": "^3.2.2",
-				"lodash.includes": "^4.3.0",
-				"lodash.isboolean": "^3.0.3",
-				"lodash.isinteger": "^4.0.4",
-				"lodash.isnumber": "^3.0.3",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.isstring": "^4.0.1",
-				"lodash.once": "^4.0.0",
-				"ms": "^2.1.1",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": ">=12",
-				"npm": ">=6"
-			}
-		},
-		"node_modules/jsonwebtoken/node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/jsonwebtoken/node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/jsonwebtoken/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
-		},
 		"node_modules/jsrsasign": {
 			"version": "10.8.6",
 			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.8.6.tgz",
@@ -14647,27 +13658,6 @@
 			},
 			"engines": {
 				"node": ">=4.0"
-			}
-		},
-		"node_modules/jwa": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-			"dev": true,
-			"dependencies": {
-				"buffer-equal-constant-time": "1.0.1",
-				"ecdsa-sig-formatter": "1.0.11",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"node_modules/jws": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-			"dev": true,
-			"dependencies": {
-				"jwa": "^1.4.1",
-				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/jwt-decode": {
@@ -14711,12 +13701,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/kuler": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-			"dev": true
-		},
 		"node_modules/language-subtag-registry": {
 			"version": "0.3.22",
 			"resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
@@ -14749,161 +13733,6 @@
 			"dev": true,
 			"engines": {
 				"node": "> 0.8"
-			}
-		},
-		"node_modules/level": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/level/-/level-8.0.0.tgz",
-			"integrity": "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==",
-			"dev": true,
-			"dependencies": {
-				"browser-level": "^1.0.1",
-				"classic-level": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/level"
-			}
-		},
-		"node_modules/level-codec": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
-			"integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^5.6.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/level-codec/node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
-		},
-		"node_modules/level-errors": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-			"integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-			"dev": true,
-			"dependencies": {
-				"errno": "~0.1.1"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/level-iterator-stream": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
-			"integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.5",
-				"xtend": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/level-iterator-stream/node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true
-		},
-		"node_modules/level-iterator-stream/node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-			"dev": true,
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/level-iterator-stream/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"node_modules/level-post": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
-			"integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
-			"dev": true,
-			"dependencies": {
-				"ltgt": "^2.1.2"
-			}
-		},
-		"node_modules/level-sublevel": {
-			"version": "6.6.4",
-			"resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.4.tgz",
-			"integrity": "sha512-pcCrTUOiO48+Kp6F1+UAzF/OtWqLcQVTVF39HLdZ3RO8XBoXt+XVPKZO1vVr1aUoxHZA9OtD2e1v7G+3S5KFDA==",
-			"dev": true,
-			"dependencies": {
-				"bytewise": "~1.1.0",
-				"level-codec": "^9.0.0",
-				"level-errors": "^2.0.0",
-				"level-iterator-stream": "^2.0.3",
-				"ltgt": "~2.1.1",
-				"pull-defer": "^0.2.2",
-				"pull-level": "^2.0.3",
-				"pull-stream": "^3.6.8",
-				"typewiselite": "~1.0.0",
-				"xtend": "~4.0.0"
-			}
-		},
-		"node_modules/level-supports": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
-			"integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/level-transcoder": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
-			"integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^6.0.3",
-				"module-error": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/leven": {
@@ -14989,60 +13818,6 @@
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
 			"dev": true
 		},
-		"node_modules/lodash.defaults": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-			"dev": true
-		},
-		"node_modules/lodash.flatten": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-			"dev": true
-		},
-		"node_modules/lodash.includes": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-			"dev": true
-		},
-		"node_modules/lodash.isarguments": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-			"dev": true
-		},
-		"node_modules/lodash.isboolean": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-			"dev": true
-		},
-		"node_modules/lodash.isinteger": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-			"dev": true
-		},
-		"node_modules/lodash.isnumber": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-			"dev": true
-		},
-		"node_modules/lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-			"dev": true
-		},
-		"node_modules/lodash.isstring": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-			"dev": true
-		},
 		"node_modules/lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -15055,12 +13830,6 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
-		"node_modules/lodash.once": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-			"dev": true
-		},
 		"node_modules/lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -15071,29 +13840,6 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
-			"dev": true
-		},
-		"node_modules/logform": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
-			"integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
-			"dev": true,
-			"dependencies": {
-				"@colors/colors": "1.6.0",
-				"@types/triple-beam": "^1.3.2",
-				"fecha": "^4.2.0",
-				"ms": "^2.1.1",
-				"safe-stable-stringify": "^2.3.1",
-				"triple-beam": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/looper": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
-			"integrity": "sha512-6DzMHJcjbQX/UPHc1rRCBfKlLwDkvuGZ715cIR36wSdYqWXFT35uLXq5P/2orl3tz+t+VOVPxw4yPinQlUDGDQ==",
 			"dev": true
 		},
 		"node_modules/loose-envify": {
@@ -15124,12 +13870,6 @@
 			"dependencies": {
 				"yallist": "^3.0.2"
 			}
-		},
-		"node_modules/ltgt": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
-			"integrity": "sha512-5VjHC5GsENtIi5rbJd+feEpDKhfr7j0odoUR2Uh978g+2p93nd5o34cTjQWohXsPsCZeqoDnIqEf88mPCe0Pfw==",
-			"dev": true
 		},
 		"node_modules/lz-string": {
 			"version": "1.5.0",
@@ -15324,18 +14064,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/mimic-response": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -15444,15 +14172,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/minimisted": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
-			"integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
-			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.5"
-			}
-		},
 		"node_modules/mitt": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -15476,58 +14195,6 @@
 			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
 			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
 			"dev": true
-		},
-		"node_modules/module-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
-			"integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/morgan": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-			"integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
-			"dev": true,
-			"dependencies": {
-				"basic-auth": "~2.0.1",
-				"debug": "2.6.9",
-				"depd": "~2.0.0",
-				"on-finished": "~2.3.0",
-				"on-headers": "~1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/morgan/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/morgan/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true
-		},
-		"node_modules/morgan/node_modules/on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-			"dev": true,
-			"dependencies": {
-				"ee-first": "1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/ms": {
 			"version": "2.1.2",
@@ -15576,12 +14243,6 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
-		"node_modules/napi-macros": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
-			"integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==",
-			"dev": true
-		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -15593,68 +14254,6 @@
 			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
 			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
 			"dev": true
-		},
-		"node_modules/nconf": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.1.tgz",
-			"integrity": "sha512-p2cfF+B3XXacQdswUYWZ0w6Vld0832A/tuqjLBu3H1sfUcby4N2oVbGhyuCkZv+t3iY3aiFEj7gZGqax9Q2c1w==",
-			"dev": true,
-			"dependencies": {
-				"async": "^3.0.0",
-				"ini": "^2.0.0",
-				"secure-keys": "^1.0.0",
-				"yargs": "^16.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
-		"node_modules/nconf/node_modules/cliui": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-			"dev": true,
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0",
-				"wrap-ansi": "^7.0.0"
-			}
-		},
-		"node_modules/nconf/node_modules/ini": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-			"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/nconf/node_modules/yargs": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-			"dev": true,
-			"dependencies": {
-				"cliui": "^7.0.2",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.0",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^20.2.2"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/nconf/node_modules/yargs-parser": {
-			"version": "20.2.9",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"node_modules/negotiator": {
 			"version": "0.6.3",
@@ -15718,17 +14317,6 @@
 				"node": ">= 6.13.0"
 			}
 		},
-		"node_modules/node-gyp-build": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
-			"integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
-			"dev": true,
-			"bin": {
-				"node-gyp-build": "bin.js",
-				"node-gyp-build-optional": "optional.js",
-				"node-gyp-build-test": "build-test.js"
-			}
-		},
 		"node_modules/node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -15770,12 +14358,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/notepack.io": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.3.0.tgz",
-			"integrity": "sha512-9RiFDxeydHsWOqdthRUck2Kd4UW2NzVd2xxOulZiQ9mvge6ElsHXLpwD3HEJyql6sFEnEn/eMO7HSdS0M5mWkA==",
-			"dev": true
 		},
 		"node_modules/npm-run-path": {
 			"version": "4.0.1",
@@ -16004,15 +14586,6 @@
 				"wrappy": "1"
 			}
 		},
-		"node_modules/one-time": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-			"dev": true,
-			"dependencies": {
-				"fn.name": "1.x.x"
-			}
-		},
 		"node_modules/onetime": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -16113,15 +14686,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/p-map": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/p-retry": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
@@ -16176,12 +14740,6 @@
 			"engines": {
 				"node": ">= 14"
 			}
-		},
-		"node_modules/pako": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-			"dev": true
 		},
 		"node_modules/param-case": {
 			"version": "3.0.4",
@@ -17932,12 +16490,6 @@
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"dev": true
 		},
-		"node_modules/prr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-			"dev": true
-		},
 		"node_modules/ps-tree": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
@@ -17958,64 +16510,6 @@
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
 			"integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
 			"dev": true
-		},
-		"node_modules/pull-cat": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
-			"integrity": "sha512-i3w+xZ3DCtTVz8S62hBOuNLRHqVDsHMNZmgrZsjPnsxXUgbWtXEee84lo1XswE7W2a3WHyqsNuDJTjVLAQR8xg==",
-			"dev": true
-		},
-		"node_modules/pull-defer": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
-			"integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA==",
-			"dev": true
-		},
-		"node_modules/pull-level": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
-			"integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
-			"dev": true,
-			"dependencies": {
-				"level-post": "^1.0.7",
-				"pull-cat": "^1.1.9",
-				"pull-live": "^1.0.1",
-				"pull-pushable": "^2.0.0",
-				"pull-stream": "^3.4.0",
-				"pull-window": "^2.1.4",
-				"stream-to-pull-stream": "^1.7.1"
-			}
-		},
-		"node_modules/pull-live": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
-			"integrity": "sha512-tkNz1QT5gId8aPhV5+dmwoIiA1nmfDOzJDlOOUpU5DNusj6neNd3EePybJ5+sITr2FwyCs/FVpx74YMCfc8YeA==",
-			"dev": true,
-			"dependencies": {
-				"pull-cat": "^1.1.9",
-				"pull-stream": "^3.4.0"
-			}
-		},
-		"node_modules/pull-pushable": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
-			"integrity": "sha512-M7dp95enQ2kaHvfCt2+DJfyzgCSpWVR2h2kWYnVsW6ZpxQBx5wOu0QWOvQPVoPnBLUZYitYP2y7HyHkLQNeGXg==",
-			"dev": true
-		},
-		"node_modules/pull-stream": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.7.0.tgz",
-			"integrity": "sha512-Eco+/R004UaCK2qEDE8vGklcTG2OeZSVm1kTUQNrykEjDwcFXDZhygFDsW49DbXyJMEhHeRL3z5cRVqPAhXlIw==",
-			"dev": true
-		},
-		"node_modules/pull-window": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
-			"integrity": "sha512-cbDzN76BMlcGG46OImrgpkMf/VkCnupj8JhsrpBw3aWBM9ye345aYnqitmZCgauBkc0HbbRRn9hCnsa3k2FNUg==",
-			"dev": true,
-			"dependencies": {
-				"looper": "^2.0.0"
-			}
 		},
 		"node_modules/pump": {
 			"version": "3.0.0",
@@ -19896,33 +18390,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/redis-commands": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
-			"dev": true
-		},
-		"node_modules/redis-errors": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-			"integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/redis-parser": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-			"integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-			"dev": true,
-			"dependencies": {
-				"redis-errors": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/reflect.getprototypeof": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
@@ -20350,29 +18817,6 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
-		"node_modules/run-parallel-limit": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
-			"integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"queue-microtask": "^1.2.2"
-			}
-		},
 		"node_modules/rxjs": {
 			"version": "7.8.1",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -20431,15 +18875,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/safe-stable-stringify": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/safer-buffer": {
@@ -20536,12 +18971,6 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
-		"node_modules/secure-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
-			"integrity": "sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg==",
-			"dev": true
-		},
 		"node_modules/select-hose": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -20613,33 +19042,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true
-		},
-		"node_modules/serialize-error": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
-			"integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
-			"dev": true,
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/serialize-error/node_modules/type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.1",
@@ -20815,66 +19217,6 @@
 			"resolved": "https://registry.npmjs.org/sillyname/-/sillyname-0.1.0.tgz",
 			"integrity": "sha512-GWA0Zont13ov+cMNw4T7nU4SCyW8jdhD3vjA5+qs8jr+09sCPxOf+FPS5zE0c9pYlCwD+NU/CiMimY462lgG9g=="
 		},
-		"node_modules/simple-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/simple-get": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"decompress-response": "^6.0.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
-			}
-		},
-		"node_modules/simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-			"dev": true,
-			"dependencies": {
-				"is-arrayish": "^0.3.1"
-			}
-		},
-		"node_modules/simple-swizzle/node_modules/is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-			"dev": true
-		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -20898,54 +19240,6 @@
 			"engines": {
 				"node": ">= 6.0.0",
 				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/socket.io": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.2.tgz",
-			"integrity": "sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==",
-			"dev": true,
-			"dependencies": {
-				"accepts": "~1.3.4",
-				"base64id": "~2.0.0",
-				"cors": "~2.8.5",
-				"debug": "~4.3.2",
-				"engine.io": "~6.5.2",
-				"socket.io-adapter": "~2.5.2",
-				"socket.io-parser": "~4.2.4"
-			},
-			"engines": {
-				"node": ">=10.2.0"
-			}
-		},
-		"node_modules/socket.io-adapter": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
-			"integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
-			"dev": true,
-			"dependencies": {
-				"ws": "~8.11.0"
-			}
-		},
-		"node_modules/socket.io-adapter/node_modules/ws": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/socket.io-client": {
@@ -21161,15 +19455,6 @@
 			"deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
 			"dev": true
 		},
-		"node_modules/stack-trace": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-			"integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/stack-utils": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -21195,12 +19480,6 @@
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
 			"integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
-			"dev": true
-		},
-		"node_modules/standard-as-callback": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-			"integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
 			"dev": true
 		},
 		"node_modules/start-server-and-test": {
@@ -21348,22 +19627,6 @@
 				"duplexer": "~0.1.1"
 			}
 		},
-		"node_modules/stream-to-pull-stream": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
-			"integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
-			"dev": true,
-			"dependencies": {
-				"looper": "^3.0.0",
-				"pull-stream": "^3.2.3"
-			}
-		},
-		"node_modules/stream-to-pull-stream/node_modules/looper": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-			"integrity": "sha512-LJ9wplN/uSn72oJRsXTx+snxPet5c8XiZmOKCm906NVYu+ag6SB6vUcnJcWxgnl2NfbIyeobAn7Bwv6xRj2XJg==",
-			"dev": true
-		},
 		"node_modules/streamx": {
 			"version": "2.15.1",
 			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.1.tgz",
@@ -21387,12 +19650,6 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"node_modules/string-hash": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-			"integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
 			"dev": true
 		},
 		"node_modules/string-length": {
@@ -22091,12 +20348,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/text-hex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-			"dev": true
-		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -22214,15 +20465,6 @@
 			"dev": true,
 			"bin": {
 				"tree-kill": "cli.js"
-			}
-		},
-		"node_modules/triple-beam": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
-			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/tryer": {
@@ -22430,33 +20672,6 @@
 			"engines": {
 				"node": ">=4.2.0"
 			}
-		},
-		"node_modules/typewise": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-			"integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
-			"dev": true,
-			"dependencies": {
-				"typewise-core": "^1.2.0"
-			}
-		},
-		"node_modules/typewise-core": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-			"integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
-			"dev": true
-		},
-		"node_modules/typewiselite": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
-			"integrity": "sha512-J9alhjVHupW3Wfz6qFRGgQw0N3gr8hOkw6zm7FZ6UR1Cse/oD9/JVok7DNE9TT9IbciDHX2Ex9+ksE6cRmtymw==",
-			"dev": true
-		},
-		"node_modules/uid2": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-			"integrity": "sha512-5gSP1liv10Gjp8cMEnFd6shzkL/D6W1uhXSFNCxDC+YI8+L8wkCYCbJ7n77Ezb4wE/xzMogecE+DtamEe9PZjg==",
-			"dev": true
 		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.2",
@@ -22673,19 +20888,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/util": {
-			"version": "0.12.5",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"is-arguments": "^1.0.4",
-				"is-generator-function": "^1.0.7",
-				"is-typed-array": "^1.1.3",
-				"which-typed-array": "^1.1.2"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -23331,42 +21533,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/winston": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
-			"integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
-			"dev": true,
-			"dependencies": {
-				"@colors/colors": "^1.6.0",
-				"@dabh/diagnostics": "^2.0.2",
-				"async": "^3.2.3",
-				"is-stream": "^2.0.0",
-				"logform": "^2.4.0",
-				"one-time": "^1.0.0",
-				"readable-stream": "^3.4.0",
-				"safe-stable-stringify": "^2.3.1",
-				"stack-trace": "0.0.x",
-				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.5.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/winston-transport": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.6.0.tgz",
-			"integrity": "sha512-wbBA9PbPAHxKiygo7ub7BYRiKxms0tpfU2ljtWzb3SjRjv5yl6Ozuy/TkXf00HTAt+Uylo3gSkNwzc4ME0wiIg==",
-			"dev": true,
-			"dependencies": {
-				"logform": "^2.3.2",
-				"readable-stream": "^3.6.0",
-				"triple-beam": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
 		"node_modules/word-wrap": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -23791,15 +21957,6 @@
 			"integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.4"
 			}
 		},
 		"node_modules/y18n": {

--- a/audience-demo/package.json
+++ b/audience-demo/package.json
@@ -13,7 +13,7 @@
 		"ci:test": "start-server-and-test start:server 7070 ci:test:jest",
 		"ci:test:jest": "jest --ci",
 		"start": "react-scripts start",
-		"start:server": "npx @fluidframework/azure-local-service",
+		"start:server": "npx tinylicious",
 		"build": "react-scripts build",
 		"eject": "react-scripts eject",
 		"test": "start-server-and-test start:server 7070 test:jest",
@@ -37,7 +37,6 @@
 		]
 	},
 	"devDependencies": {
-		"@fluidframework/azure-local-service": "^1.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@testing-library/jest-dom": "^6.1.3",
 		"@testing-library/react": "^14.0.0",
@@ -50,7 +49,8 @@
 		"puppeteer": "^21.1.1",
 		"react-scripts": "^5.0.1",
 		"start-server-and-test": "^2.0.0",
-		"url": "^0.11.2"
+		"url": "^0.11.2",
+		"tinylicious": "^1.0.0"
 	},
 	"jest-junit": {
 		"outputDirectory": "nyc",

--- a/audience-demo/package.json
+++ b/audience-demo/package.json
@@ -13,7 +13,7 @@
 		"ci:test": "start-server-and-test start:server 7070 ci:test:jest",
 		"ci:test:jest": "jest --ci",
 		"start": "react-scripts start",
-		"start:server": "npx tinylicious",
+		"start:server": "npx @fluidframework/azure-local-service",
 		"build": "react-scripts build",
 		"eject": "react-scripts eject",
 		"test": "start-server-and-test start:server 7070 test:jest",
@@ -37,6 +37,7 @@
 		]
 	},
 	"devDependencies": {
+		"@fluidframework/azure-local-service": "^1.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@testing-library/jest-dom": "^6.1.3",
 		"@testing-library/react": "^14.0.0",
@@ -49,8 +50,7 @@
 		"puppeteer": "^21.1.1",
 		"react-scripts": "^5.0.1",
 		"start-server-and-test": "^2.0.0",
-		"url": "^0.11.2",
-		"tinylicious": "^1.0.0"
+		"url": "^0.11.2"
 	},
 	"jest-junit": {
 		"outputDirectory": "nyc",

--- a/audience-demo/package.json
+++ b/audience-demo/package.json
@@ -37,7 +37,6 @@
 		]
 	},
 	"devDependencies": {
-		"@fluidframework/azure-local-service": "^1.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@testing-library/jest-dom": "^6.1.3",
 		"@testing-library/react": "^14.0.0",

--- a/brainstorm/README.md
+++ b/brainstorm/README.md
@@ -11,8 +11,8 @@ This package is based on the [Create React App](https://reactjs.org/docs/create-
 
 ### Local Mode
 
-Azure local service is a local, self-contained test service.
-Running `npx @fluidframework/azure-local-service@latest` from your terminal window will launch the Azure local server.
+Tinylicious is a local, self-contained test service.
+Running `npx tinylicious` from your terminal window will launch the Azure local server.
 The server will need to be started first in order to provide the ordering and storage requirement of Fluid runtime.
 
 Follow the steps below to run this in local mode (Azure local service):

--- a/brainstorm/README.md
+++ b/brainstorm/README.md
@@ -11,8 +11,8 @@ This package is based on the [Create React App](https://reactjs.org/docs/create-
 
 ### Local Mode
 
-Tinylicious is a local, self-contained test service.
-Running `npx tinylicious` from your terminal window will launch the Azure local server.
+`@fluidframework/azure-local-service` is a local, self-contained test service.
+Running `npx @fluidframework/azure-local-service` from your terminal window will launch the Azure local server.
 The server will need to be started first in order to provide the ordering and storage requirement of Fluid runtime.
 
 Follow the steps below to run this in local mode (Azure local service):

--- a/brainstorm/package-lock.json
+++ b/brainstorm/package-lock.json
@@ -21,7 +21,6 @@
 				"uuid": "^8.3.2"
 			},
 			"devDependencies": {
-				"@fluidframework/azure-local-service": "^1.1.0",
 				"@fluidframework/build-common": "^2.0.0",
 				"@testing-library/jest-dom": "^5.11.4",
 				"@testing-library/react": "^11.1.0",
@@ -2060,15 +2059,6 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
 		},
-		"node_modules/@colors/colors": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
-			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.1.90"
-			}
-		},
 		"node_modules/@csstools/normalize.css": {
 			"version": "12.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
@@ -2353,17 +2343,6 @@
 			},
 			"peerDependencies": {
 				"postcss-selector-parser": "^6.0.10"
-			}
-		},
-		"node_modules/@dabh/diagnostics": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-			"integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
-			"dev": true,
-			"dependencies": {
-				"colorspace": "1.1.x",
-				"enabled": "2.0.x",
-				"kuler": "^2.0.0"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -2712,397 +2691,6 @@
 			},
 			"peerDependencies": {
 				"fluid-framework": "^1.3.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-1.1.1.tgz",
-			"integrity": "sha512-gvk+qy8RytXBQaZ554OREszHGN73W3FmgpfwV+aXeOOP5RWLMPSvkPoac5K9gcUYN+nAFbRs517c055yucP9ug==",
-			"dev": true,
-			"dependencies": {
-				"tinylicious": "^0.4.89251"
-			},
-			"bin": {
-				"azure-local-service": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
-			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
-			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.4001.tgz",
-			"integrity": "sha512-rERfgXK5DXGJvxADjotkAZssKgp3ZxW6u7yUekrDnFDkXtbCW1Gcq+EwvjHTEyhsOp30YBnD0Z39xnZy4zEZRw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas-driver": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/semver": "^6.0.1",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"axios": "^0.26.0",
-				"buffer": "^6.0.3",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"semver": "^6.3.0",
-				"sha.js": "^2.4.11",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas-driver": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.4001.tgz",
-			"integrity": "sha512-qRs+vMbSS9aPx7vr3XemvER5DeY/nsJ5ZkcL3UDjUOxvLZxbOAD6C6JeH3Zgzc/jc8bqshcxai/u7qso2zCsFw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-local-server": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.4001.tgz",
-			"integrity": "sha512-FIlNUc9Ncul/5qzP+VyU53TJj8fxX7KZ1lweswZYalleRZwiqFA4Y+NbWRRWM0iJ1z8hvhyRZblG3iNrpGl04A==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.4001",
-				"@fluidframework/server-memory-orderer": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@fluidframework/server-test-utils": "^0.1038.4001",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"jsrsasign": "^10.5.25",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-memory-orderer": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.4001.tgz",
-			"integrity": "sha512-fdzTCLFRh8QfyY17MnB22/o8x2XEX1+wZrm+dn+1Av+ZVe/+ZhfdX5LsQCMKYv+X5mgAauNmC/12mQE4H6jvsQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/debug": "^4.1.5",
-				"@types/double-ended-queue": "^2.1.0",
-				"@types/lodash": "^4.14.118",
-				"@types/node": "^14.18.0",
-				"@types/ws": "^6.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1",
-				"ws": "^7.4.6"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
-			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-core": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.4001.tgz",
-			"integrity": "sha512-nuZ9ebvyeIoRdlpQQpBNGkawKtc2/tHKbc8CHbMZRMh7F7kwYUtoHd/J8powb9eUcg5IHDmXx1l+PQRbQX4vCg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/nconf": "^0.10.2",
-				"@types/node": "^14.18.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"nconf": "^0.12.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-shared": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.4001.tgz",
-			"integrity": "sha512-vDRB2G/Xnuhan+Ri0Eg5JMKfsm7hxstCXdEyQhzJzC7+bw66wts+ZIsEsn4Ha/3KkxblF/RSW3lBhrYpxii3cQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@socket.io/redis-adapter": "^7.2.0",
-				"body-parser": "^1.17.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"ioredis": "^4.24.2",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"notepack.io": "^2.3.0",
-				"querystring": "^0.2.0",
-				"socket.io": "^4.5.3",
-				"socket.io-adapter": "^2.4.0",
-				"socket.io-parser": "^4.2.1",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-telemetry": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.4001.tgz",
-			"integrity": "sha512-2leJhB04+71RTmC5ShRXm/4FWng9tLn9dlrUAjApZH4RlUJAx1JGsvo/5JU1tIbpUutMHUle2IpWyfu/RV+S5g==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"path-browserify": "^1.0.1",
-				"serialize-error": "^8.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-utils": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.4001.tgz",
-			"integrity": "sha512-K7X/0mlonDAu0pPIgTz8U9nLwRSbJY2oBpFPwpkp1UtE6SU02jx2ZzraT9epDmOl3EXeS1rHzA+mbvBSe1aFMg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"debug": "^4.1.1",
-				"express": "^4.17.3",
-				"ioredis": "^4.24.2",
-				"json-stringify-safe": "^5.0.1",
-				"jsonwebtoken": "^9.0.0",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0",
-				"sillyname": "^0.1.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0",
-				"winston-transport": "^4.5.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-test-utils": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.4001.tgz",
-			"integrity": "sha512-qrLp5H1UUPIJSEHlzZ1iYlPFJCQrd2WnmoafxnQIg0mfU1ZE8XUlG5MKUg8bT9pWsCoEGJDiOkkRHaq+WXupjQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"string-hash": "^1.1.3",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@types/node": {
-			"version": "14.18.63",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@types/semver": {
-			"version": "6.2.5",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.5.tgz",
-			"integrity": "sha512-NAxro9/RqWXTqdSjccDZAjA4nXK+6zRun+HvibYJfGy8TQhpOC7Vv6v2rlHYKrT0Q8jGGoNRd/xVdHRIQRNlFQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/denque": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/ioredis": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
-			"integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
-			"dev": true,
-			"dependencies": {
-				"cluster-key-slot": "^1.1.0",
-				"debug": "^4.3.1",
-				"denque": "^1.1.0",
-				"lodash.defaults": "^4.2.0",
-				"lodash.flatten": "^4.4.0",
-				"lodash.isarguments": "^3.1.0",
-				"p-map": "^2.1.0",
-				"redis-commands": "1.7.0",
-				"redis-errors": "^1.2.0",
-				"redis-parser": "^3.0.0",
-				"standard-as-callback": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ioredis"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/tinylicious": {
-			"version": "0.4.94771",
-			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
-			"integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.1000",
-				"@fluidframework/protocol-base": "^0.1038.1000",
-				"@fluidframework/protocol-definitions": "^1.0.0",
-				"@fluidframework/server-lambdas": "^0.1038.1000",
-				"@fluidframework/server-local-server": "^0.1038.1000",
-				"@fluidframework/server-memory-orderer": "^0.1038.1000",
-				"@fluidframework/server-services-client": "^0.1038.1000",
-				"@fluidframework/server-services-core": "^0.1038.1000",
-				"@fluidframework/server-services-shared": "^0.1038.1000",
-				"@fluidframework/server-services-telemetry": "^0.1038.1000",
-				"@fluidframework/server-services-utils": "^0.1038.1000",
-				"@fluidframework/server-test-utils": "^0.1038.1000",
-				"agentkeepalive": "^4.2.1",
-				"axios": "^0.26.0",
-				"body-parser": "^1.17.1",
-				"charwise": "^3.0.1",
-				"compression": "^1.7.2",
-				"cookie-parser": "^1.4.3",
-				"cors": "^2.8.4",
-				"detect-port": "^1.3.0",
-				"express": "^4.16.3",
-				"isomorphic-git": "^1.8.2",
-				"json-stringify-safe": "^5.0.1",
-				"level": "^8.0.0",
-				"level-sublevel": "6.6.4",
-				"lodash": "^4.17.21",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"socket.io": "^4.5.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.2",
-				"winston": "^3.6.0"
-			},
-			"bin": {
-				"tinylicious": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/ws": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@fluidframework/build-common": {
@@ -5191,27 +4779,6 @@
 			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
 			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
 		},
-		"node_modules/@socket.io/redis-adapter": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-7.2.0.tgz",
-			"integrity": "sha512-/r6oF6Myz0K9uatB/pfCi0BhKg/KRMh1OokrqcjlNz6aq40WiXdFLRbHJQuwGHq/KvB+D6141K+IynbVxZGvhw==",
-			"dev": true,
-			"dependencies": {
-				"debug": "~4.3.1",
-				"notepack.io": "~2.2.0",
-				"socket.io-adapter": "^2.4.0",
-				"uid2": "0.0.3"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/@socket.io/redis-adapter/node_modules/notepack.io": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.2.0.tgz",
-			"integrity": "sha512-9b5w3t5VSH6ZPosoYnyDONnUTF8o0UkBw7JLA6eBlYJWyGT1Q3vQa8Hmuj1/X6RYvHjjygBDgw6fJhe0JEojfw==",
-			"dev": true
-		},
 		"node_modules/@surma/rollup-plugin-off-main-thread": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -5669,36 +5236,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/cookie": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-			"integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-			"dev": true
-		},
-		"node_modules/@types/cors": {
-			"version": "2.8.15",
-			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.15.tgz",
-			"integrity": "sha512-n91JxbNLD8eQIuXDIChAN1tCKNWCEgpceU9b7ZMbFA+P+Q4yIeh80jizFLEvolRPc1ES0VdwFlGv+kJTSirogw==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@types/debug": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.10.tgz",
-			"integrity": "sha512-tOSCru6s732pofZ+sMv9o4o3Zc+Sa8l3bxd/tweTQudFn06vAzb13ZX46Zi6m6EJ+RUbRTHvgQJ1gBtSgkaUYA==",
-			"dev": true,
-			"dependencies": {
-				"@types/ms": "*"
-			}
-		},
-		"node_modules/@types/double-ended-queue": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@types/double-ended-queue/-/double-ended-queue-2.1.5.tgz",
-			"integrity": "sha512-Iyp30YLmx/PFvtmomdZq4i81N6uR/7Le+UFrUbnNVbHboRCcCuOKu64tPXlr2yFOb8Zh4t0SppDxRQ5DM/Hlhg==",
-			"dev": true
-		},
 		"node_modules/@types/eslint": {
 			"version": "8.44.2",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.2.tgz",
@@ -5862,28 +5399,10 @@
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
 		},
-		"node_modules/@types/lodash": {
-			"version": "4.14.200",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
-			"integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==",
-			"dev": true
-		},
 		"node_modules/@types/mime": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
 			"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-			"dev": true
-		},
-		"node_modules/@types/ms": {
-			"version": "0.7.33",
-			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.33.tgz",
-			"integrity": "sha512-AuHIyzR5Hea7ij0P9q7vx7xu4z0C28ucwjAZC0ja7JhINyCnOw8/DnvAPQQ9TfOlCtZAmCERKQX9+o1mgQhuOQ==",
-			"dev": true
-		},
-		"node_modules/@types/nconf": {
-			"version": "0.10.5",
-			"resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.5.tgz",
-			"integrity": "sha512-Rig8+FAyg9twg01Ya+aVR+QAakMxcTiO3QcvhY41Rn/m1ZvFIU5fb+D3qxxqIHxrFacQqxeg8c8apzZYZ+dqLA==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -6025,12 +5544,6 @@
 				"@types/jest": "*"
 			}
 		},
-		"node_modules/@types/triple-beam": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.4.tgz",
-			"integrity": "sha512-HlJjF3wxV4R2VQkFpKe0YqJLilYNgtRtsqqZtby7RkVsSs+i+vbyzjtUwpFEdUCKcrGzCiEJE7F/0mKjh0sunA==",
-			"dev": true
-		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.4.tgz",
@@ -6042,15 +5555,6 @@
 			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
 			"integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
 			"dev": true
-		},
-		"node_modules/@types/ws": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
-			"integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
 		},
 		"node_modules/@types/yargs": {
 			"version": "15.0.14",
@@ -6526,47 +6030,6 @@
 				"node": ">=6.5"
 			}
 		},
-		"node_modules/abstract-level": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
-			"integrity": "sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^6.0.3",
-				"catering": "^2.1.0",
-				"is-buffer": "^2.0.5",
-				"level-supports": "^4.0.0",
-				"level-transcoder": "^1.0.1",
-				"module-error": "^1.0.1",
-				"queue-microtask": "^1.2.3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/abstract-level/node_modules/is-buffer": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -6673,29 +6136,6 @@
 			},
 			"engines": {
 				"node": ">= 6.0.0"
-			}
-		},
-		"node_modules/agentkeepalive": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
-			"integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
-			"dev": true,
-			"dependencies": {
-				"debug": "^4.1.0",
-				"depd": "^1.1.2",
-				"humanize-ms": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 8.0.0"
-			}
-		},
-		"node_modules/agentkeepalive/node_modules/depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/ajv": {
@@ -7029,19 +6469,6 @@
 			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
 			"dev": true
 		},
-		"node_modules/assert": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
-			"integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"is-nan": "^1.3.2",
-				"object-is": "^1.1.5",
-				"object.assign": "^4.1.4",
-				"util": "^0.12.5"
-			}
-		},
 		"node_modules/ast-types": {
 			"version": "0.13.4",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -7064,12 +6491,6 @@
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
 			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-			"dev": true
-		},
-		"node_modules/async-lock": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz",
-			"integrity": "sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ==",
 			"dev": true
 		},
 		"node_modules/asynciterator.prototype": {
@@ -7437,33 +6858,6 @@
 				}
 			]
 		},
-		"node_modules/base64id": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-			"integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-			"dev": true,
-			"engines": {
-				"node": "^4.5.0 || >= 5.9"
-			}
-		},
-		"node_modules/basic-auth": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-			"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "5.1.2"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/basic-auth/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
 		"node_modules/basic-ftp": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
@@ -7606,18 +7000,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/browser-level": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
-			"integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
-			"dev": true,
-			"dependencies": {
-				"abstract-level": "^1.0.2",
-				"catering": "^2.1.1",
-				"module-error": "^1.0.2",
-				"run-parallel-limit": "^1.1.0"
-			}
-		},
 		"node_modules/browser-process-hrtime": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
@@ -7697,12 +7079,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/buffer-equal-constant-time": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-			"dev": true
-		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -7728,25 +7104,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/bytewise": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-			"integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
-			"dev": true,
-			"dependencies": {
-				"bytewise-core": "^1.2.2",
-				"typewise": "^1.0.3"
-			}
-		},
-		"node_modules/bytewise-core": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-			"integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
-			"dev": true,
-			"dependencies": {
-				"typewise-core": "^1.2"
 			}
 		},
 		"node_modules/call-bind": {
@@ -7840,15 +7197,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/catering": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
-			"integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/chalk": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -7870,12 +7218,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/charwise": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz",
-			"integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw==",
-			"dev": true
 		},
 		"node_modules/check-more-types": {
 			"version": "2.24.0",
@@ -7973,23 +7315,6 @@
 			"integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
 			"dev": true
 		},
-		"node_modules/classic-level": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.2.0.tgz",
-			"integrity": "sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"dependencies": {
-				"abstract-level": "^1.0.2",
-				"catering": "^2.1.0",
-				"module-error": "^1.0.1",
-				"napi-macros": "~2.0.0",
-				"node-gyp-build": "^4.3.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/clean-css": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
@@ -8001,12 +7326,6 @@
 			"engines": {
 				"node": ">= 10.0"
 			}
-		},
-		"node_modules/clean-git-ref": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
-			"integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
-			"dev": true
 		},
 		"node_modules/cliui": {
 			"version": "8.0.1",
@@ -8020,15 +7339,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/cluster-key-slot": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
-			"integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/co": {
@@ -8123,16 +7433,6 @@
 			"integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
 			"dev": true
 		},
-		"node_modules/color": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^1.9.3",
-				"color-string": "^1.6.0"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -8151,31 +7451,6 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
-		"node_modules/color-string": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
-		},
-		"node_modules/color/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/color/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
-		},
 		"node_modules/colord": {
 			"version": "2.9.3",
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
@@ -8187,16 +7462,6 @@
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
 			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
 			"dev": true
-		},
-		"node_modules/colorspace": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-			"integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-			"dev": true,
-			"dependencies": {
-				"color": "^3.1.3",
-				"text-hex": "1.0.x"
-			}
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
@@ -8348,28 +7613,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/cookie-parser": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-			"integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
-			"dev": true,
-			"dependencies": {
-				"cookie": "0.4.1",
-				"cookie-signature": "1.0.6"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/cookie-parser/node_modules/cookie": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-			"integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/cookie-signature": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -8416,19 +7659,6 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"dev": true
-		},
-		"node_modules/cors": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-			"dev": true,
-			"dependencies": {
-				"object-assign": "^4",
-				"vary": "^1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
 		},
 		"node_modules/cosmiconfig": {
 			"version": "7.0.1",
@@ -9116,21 +8346,6 @@
 			"integrity": "sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==",
 			"dev": true
 		},
-		"node_modules/decompress-response": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-			"dev": true,
-			"dependencies": {
-				"mimic-response": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -9296,20 +8511,6 @@
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
 		},
-		"node_modules/detect-port": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
-			"integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
-			"dev": true,
-			"dependencies": {
-				"address": "^1.0.1",
-				"debug": "4"
-			},
-			"bin": {
-				"detect": "bin/detect-port.js",
-				"detect-port": "bin/detect-port.js"
-			}
-		},
 		"node_modules/detect-port-alt": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
@@ -9362,12 +8563,6 @@
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
-		},
-		"node_modules/diff3": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
-			"dev": true
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
@@ -9564,15 +8759,6 @@
 			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
 			"dev": true
 		},
-		"node_modules/ecdsa-sig-formatter": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"node_modules/ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -9627,12 +8813,6 @@
 				"node": ">= 4"
 			}
 		},
-		"node_modules/enabled": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
-			"dev": true
-		},
 		"node_modules/encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -9649,27 +8829,6 @@
 			"dev": true,
 			"dependencies": {
 				"once": "^1.4.0"
-			}
-		},
-		"node_modules/engine.io": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.3.tgz",
-			"integrity": "sha512-IML/R4eG/pUS5w7OfcDE0jKrljWS9nwnEfsxWCIJF5eO6AHo6+Hlv+lQbdlAYsiJPHzUthLm1RUjnBzWOs45cw==",
-			"dev": true,
-			"dependencies": {
-				"@types/cookie": "^0.4.1",
-				"@types/cors": "^2.8.12",
-				"@types/node": ">=10.0.0",
-				"accepts": "~1.3.4",
-				"base64id": "2.0.0",
-				"cookie": "~0.4.1",
-				"cors": "~2.8.5",
-				"debug": "~4.3.1",
-				"engine.io-parser": "~5.2.1",
-				"ws": "~8.11.0"
-			},
-			"engines": {
-				"node": ">=10.2.0"
 			}
 		},
 		"node_modules/engine.io-client": {
@@ -9692,45 +8851,6 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/engine.io/node_modules/cookie": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/engine.io/node_modules/engine.io-parser": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
-			"integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/engine.io/node_modules/ws": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.15.0",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
@@ -9751,18 +8871,6 @@
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/errno": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
-			"integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-			"dev": true,
-			"dependencies": {
-				"prr": "~1.0.1"
-			},
-			"bin": {
-				"errno": "cli.js"
 			}
 		},
 		"node_modules/error-ex": {
@@ -10982,12 +10090,6 @@
 				"pend": "~1.2.0"
 			}
 		},
-		"node_modules/fecha": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
-			"dev": true
-		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -11239,12 +10341,6 @@
 				"@fluidframework/map": "^1.3.7",
 				"@fluidframework/sequence": "^1.3.7"
 			}
-		},
-		"node_modules/fn.name": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-			"dev": true
 		},
 		"node_modules/follow-redirects": {
 			"version": "1.15.2",
@@ -12250,15 +11346,6 @@
 				"node": ">=10.17.0"
 			}
 		},
-		"node_modules/humanize-ms": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "^2.0.0"
-			}
-		},
 		"node_modules/iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -12677,22 +11764,6 @@
 			"integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
 			"dev": true
 		},
-		"node_modules/is-nan": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-negative-zero": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
@@ -12939,31 +12010,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-		},
-		"node_modules/isomorphic-git": {
-			"version": "1.21.0",
-			"resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.21.0.tgz",
-			"integrity": "sha512-ZqCAUM63CYepA3fB8H7NVyPSiOkgzIbQ7T+QPrm9xtYgQypN9JUJ5uLMjB5iTfomdJf3mdm6aSxjZwnT6ubvEA==",
-			"dev": true,
-			"dependencies": {
-				"async-lock": "^1.1.0",
-				"clean-git-ref": "^2.0.1",
-				"crc-32": "^1.2.0",
-				"diff3": "0.0.3",
-				"ignore": "^5.1.4",
-				"minimisted": "^2.0.0",
-				"pako": "^1.0.10",
-				"pify": "^4.0.1",
-				"readable-stream": "^3.4.0",
-				"sha.js": "^2.4.9",
-				"simple-get": "^4.0.1"
-			},
-			"bin": {
-				"isogit": "cli.cjs"
-			},
-			"engines": {
-				"node": ">=12"
-			}
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.0",
@@ -16638,43 +15684,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/jsonwebtoken": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-			"integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-			"dev": true,
-			"dependencies": {
-				"jws": "^3.2.2",
-				"lodash.includes": "^4.3.0",
-				"lodash.isboolean": "^3.0.3",
-				"lodash.isinteger": "^4.0.4",
-				"lodash.isnumber": "^3.0.3",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.isstring": "^4.0.1",
-				"lodash.once": "^4.0.0",
-				"ms": "^2.1.1",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": ">=12",
-				"npm": ">=6"
-			}
-		},
-		"node_modules/jsonwebtoken/node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/jsrsasign": {
 			"version": "10.5.27",
 			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.27.tgz",
@@ -16696,27 +15705,6 @@
 			},
 			"engines": {
 				"node": ">=4.0"
-			}
-		},
-		"node_modules/jwa": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-			"dev": true,
-			"dependencies": {
-				"buffer-equal-constant-time": "1.0.1",
-				"ecdsa-sig-formatter": "1.0.11",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"node_modules/jws": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-			"dev": true,
-			"dependencies": {
-				"jwa": "^1.4.1",
-				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/jwt-decode": {
@@ -16760,12 +15748,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/kuler": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-			"dev": true
-		},
 		"node_modules/language-subtag-registry": {
 			"version": "0.3.22",
 			"resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
@@ -16798,170 +15780,6 @@
 			"dev": true,
 			"engines": {
 				"node": "> 0.8"
-			}
-		},
-		"node_modules/level": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/level/-/level-8.0.0.tgz",
-			"integrity": "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==",
-			"dev": true,
-			"dependencies": {
-				"browser-level": "^1.0.1",
-				"classic-level": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/level"
-			}
-		},
-		"node_modules/level-codec": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
-			"integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^5.6.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/level-codec/node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
-		},
-		"node_modules/level-errors": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-			"integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-			"dev": true,
-			"dependencies": {
-				"errno": "~0.1.1"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/level-iterator-stream": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
-			"integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.5",
-				"xtend": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/level-iterator-stream/node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true
-		},
-		"node_modules/level-iterator-stream/node_modules/readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/level-iterator-stream/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"node_modules/level-iterator-stream/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"node_modules/level-post": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
-			"integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
-			"dev": true,
-			"dependencies": {
-				"ltgt": "^2.1.2"
-			}
-		},
-		"node_modules/level-sublevel": {
-			"version": "6.6.4",
-			"resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.4.tgz",
-			"integrity": "sha512-pcCrTUOiO48+Kp6F1+UAzF/OtWqLcQVTVF39HLdZ3RO8XBoXt+XVPKZO1vVr1aUoxHZA9OtD2e1v7G+3S5KFDA==",
-			"dev": true,
-			"dependencies": {
-				"bytewise": "~1.1.0",
-				"level-codec": "^9.0.0",
-				"level-errors": "^2.0.0",
-				"level-iterator-stream": "^2.0.3",
-				"ltgt": "~2.1.1",
-				"pull-defer": "^0.2.2",
-				"pull-level": "^2.0.3",
-				"pull-stream": "^3.6.8",
-				"typewiselite": "~1.0.0",
-				"xtend": "~4.0.0"
-			}
-		},
-		"node_modules/level-supports": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
-			"integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/level-transcoder": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
-			"integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^6.0.3",
-				"module-error": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/leven": {
@@ -17047,60 +15865,6 @@
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
 			"dev": true
 		},
-		"node_modules/lodash.defaults": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-			"dev": true
-		},
-		"node_modules/lodash.flatten": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-			"dev": true
-		},
-		"node_modules/lodash.includes": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-			"dev": true
-		},
-		"node_modules/lodash.isarguments": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-			"dev": true
-		},
-		"node_modules/lodash.isboolean": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-			"dev": true
-		},
-		"node_modules/lodash.isinteger": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-			"dev": true
-		},
-		"node_modules/lodash.isnumber": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-			"dev": true
-		},
-		"node_modules/lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-			"dev": true
-		},
-		"node_modules/lodash.isstring": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-			"dev": true
-		},
 		"node_modules/lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -17113,12 +15877,6 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
-		"node_modules/lodash.once": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-			"dev": true
-		},
 		"node_modules/lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -17129,29 +15887,6 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
-			"dev": true
-		},
-		"node_modules/logform": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
-			"integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
-			"dev": true,
-			"dependencies": {
-				"@colors/colors": "1.6.0",
-				"@types/triple-beam": "^1.3.2",
-				"fecha": "^4.2.0",
-				"ms": "^2.1.1",
-				"safe-stable-stringify": "^2.3.1",
-				"triple-beam": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/looper": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
-			"integrity": "sha512-6DzMHJcjbQX/UPHc1rRCBfKlLwDkvuGZ715cIR36wSdYqWXFT35uLXq5P/2orl3tz+t+VOVPxw4yPinQlUDGDQ==",
 			"dev": true
 		},
 		"node_modules/loose-envify": {
@@ -17185,12 +15920,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/ltgt": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
-			"integrity": "sha512-5VjHC5GsENtIi5rbJd+feEpDKhfr7j0odoUR2Uh978g+2p93nd5o34cTjQWohXsPsCZeqoDnIqEf88mPCe0Pfw==",
-			"dev": true
 		},
 		"node_modules/lz-string": {
 			"version": "1.4.4",
@@ -17352,18 +16081,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/mimic-response": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -17472,15 +16189,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/minimisted": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
-			"integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
-			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.5"
-			}
-		},
 		"node_modules/mitt": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -17504,58 +16212,6 @@
 			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
 			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
 			"dev": true
-		},
-		"node_modules/module-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
-			"integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/morgan": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-			"integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
-			"dev": true,
-			"dependencies": {
-				"basic-auth": "~2.0.1",
-				"debug": "2.6.9",
-				"depd": "~2.0.0",
-				"on-finished": "~2.3.0",
-				"on-headers": "~1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/morgan/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/morgan/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true
-		},
-		"node_modules/morgan/node_modules/on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-			"dev": true,
-			"dependencies": {
-				"ee-first": "1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/ms": {
 			"version": "2.1.2",
@@ -17604,12 +16260,6 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
-		"node_modules/napi-macros": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
-			"integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
-			"dev": true
-		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -17621,68 +16271,6 @@
 			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
 			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
 			"dev": true
-		},
-		"node_modules/nconf": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.1.tgz",
-			"integrity": "sha512-p2cfF+B3XXacQdswUYWZ0w6Vld0832A/tuqjLBu3H1sfUcby4N2oVbGhyuCkZv+t3iY3aiFEj7gZGqax9Q2c1w==",
-			"dev": true,
-			"dependencies": {
-				"async": "^3.0.0",
-				"ini": "^2.0.0",
-				"secure-keys": "^1.0.0",
-				"yargs": "^16.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
-		"node_modules/nconf/node_modules/cliui": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-			"dev": true,
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0",
-				"wrap-ansi": "^7.0.0"
-			}
-		},
-		"node_modules/nconf/node_modules/ini": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-			"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/nconf/node_modules/yargs": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-			"dev": true,
-			"dependencies": {
-				"cliui": "^7.0.2",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.0",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^20.2.2"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/nconf/node_modules/yargs-parser": {
-			"version": "20.2.9",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"node_modules/negotiator": {
 			"version": "0.6.3",
@@ -17744,17 +16332,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 6.13.0"
-			}
-		},
-		"node_modules/node-gyp-build": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-			"integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
-			"dev": true,
-			"bin": {
-				"node-gyp-build": "bin.js",
-				"node-gyp-build-optional": "optional.js",
-				"node-gyp-build-test": "build-test.js"
 			}
 		},
 		"node_modules/node-int64": {
@@ -17831,12 +16408,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/notepack.io": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.3.0.tgz",
-			"integrity": "sha512-9RiFDxeydHsWOqdthRUck2Kd4UW2NzVd2xxOulZiQ9mvge6ElsHXLpwD3HEJyql6sFEnEn/eMO7HSdS0M5mWkA==",
-			"dev": true
 		},
 		"node_modules/npm-run-path": {
 			"version": "4.0.1",
@@ -18061,15 +16632,6 @@
 				"wrappy": "1"
 			}
 		},
-		"node_modules/one-time": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-			"dev": true,
-			"dependencies": {
-				"fn.name": "1.x.x"
-			}
-		},
 		"node_modules/onetime": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -18153,15 +16715,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/p-map": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/p-retry": {
@@ -18256,12 +16809,6 @@
 			"engines": {
 				"node": ">= 14"
 			}
-		},
-		"node_modules/pako": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-			"dev": true
 		},
 		"node_modules/param-case": {
 			"version": "3.0.4",
@@ -18426,15 +16973,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/pify": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/pirates": {
@@ -20068,12 +18606,6 @@
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"dev": true
 		},
-		"node_modules/prr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-			"dev": true
-		},
 		"node_modules/ps-tree": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
@@ -20094,64 +18626,6 @@
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
 			"integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
 			"dev": true
-		},
-		"node_modules/pull-cat": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
-			"integrity": "sha512-i3w+xZ3DCtTVz8S62hBOuNLRHqVDsHMNZmgrZsjPnsxXUgbWtXEee84lo1XswE7W2a3WHyqsNuDJTjVLAQR8xg==",
-			"dev": true
-		},
-		"node_modules/pull-defer": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
-			"integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA==",
-			"dev": true
-		},
-		"node_modules/pull-level": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
-			"integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
-			"dev": true,
-			"dependencies": {
-				"level-post": "^1.0.7",
-				"pull-cat": "^1.1.9",
-				"pull-live": "^1.0.1",
-				"pull-pushable": "^2.0.0",
-				"pull-stream": "^3.4.0",
-				"pull-window": "^2.1.4",
-				"stream-to-pull-stream": "^1.7.1"
-			}
-		},
-		"node_modules/pull-live": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
-			"integrity": "sha512-tkNz1QT5gId8aPhV5+dmwoIiA1nmfDOzJDlOOUpU5DNusj6neNd3EePybJ5+sITr2FwyCs/FVpx74YMCfc8YeA==",
-			"dev": true,
-			"dependencies": {
-				"pull-cat": "^1.1.9",
-				"pull-stream": "^3.4.0"
-			}
-		},
-		"node_modules/pull-pushable": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
-			"integrity": "sha512-M7dp95enQ2kaHvfCt2+DJfyzgCSpWVR2h2kWYnVsW6ZpxQBx5wOu0QWOvQPVoPnBLUZYitYP2y7HyHkLQNeGXg==",
-			"dev": true
-		},
-		"node_modules/pull-stream": {
-			"version": "3.6.14",
-			"resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
-			"integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew==",
-			"dev": true
-		},
-		"node_modules/pull-window": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
-			"integrity": "sha512-cbDzN76BMlcGG46OImrgpkMf/VkCnupj8JhsrpBw3aWBM9ye345aYnqitmZCgauBkc0HbbRRn9hCnsa3k2FNUg==",
-			"dev": true,
-			"dependencies": {
-				"looper": "^2.0.0"
-			}
 		},
 		"node_modules/pump": {
 			"version": "3.0.0",
@@ -22332,33 +20806,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/redis-commands": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
-			"dev": true
-		},
-		"node_modules/redis-errors": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-			"integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/redis-parser": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-			"integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-			"dev": true,
-			"dependencies": {
-				"redis-errors": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/redux": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
@@ -22869,29 +21316,6 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
-		"node_modules/run-parallel-limit": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
-			"integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"queue-microtask": "^1.2.2"
-			}
-		},
 		"node_modules/rxjs": {
 			"version": "7.8.1",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -22950,15 +21374,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/safe-stable-stringify": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/safer-buffer": {
@@ -23056,12 +21471,6 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
-		"node_modules/secure-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
-			"integrity": "sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg==",
-			"dev": true
-		},
 		"node_modules/select-hose": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -23133,21 +21542,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true
-		},
-		"node_modules/serialize-error": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
-			"integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
-			"dev": true,
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.1",
@@ -23344,66 +21738,6 @@
 			"resolved": "https://registry.npmjs.org/sillyname/-/sillyname-0.1.0.tgz",
 			"integrity": "sha512-GWA0Zont13ov+cMNw4T7nU4SCyW8jdhD3vjA5+qs8jr+09sCPxOf+FPS5zE0c9pYlCwD+NU/CiMimY462lgG9g=="
 		},
-		"node_modules/simple-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/simple-get": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"decompress-response": "^6.0.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
-			}
-		},
-		"node_modules/simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-			"dev": true,
-			"dependencies": {
-				"is-arrayish": "^0.3.1"
-			}
-		},
-		"node_modules/simple-swizzle/node_modules/is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-			"dev": true
-		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -23427,54 +21761,6 @@
 			"engines": {
 				"node": ">= 6.0.0",
 				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/socket.io": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.2.tgz",
-			"integrity": "sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==",
-			"dev": true,
-			"dependencies": {
-				"accepts": "~1.3.4",
-				"base64id": "~2.0.0",
-				"cors": "~2.8.5",
-				"debug": "~4.3.2",
-				"engine.io": "~6.5.2",
-				"socket.io-adapter": "~2.5.2",
-				"socket.io-parser": "~4.2.4"
-			},
-			"engines": {
-				"node": ">=10.2.0"
-			}
-		},
-		"node_modules/socket.io-adapter": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
-			"integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
-			"dev": true,
-			"dependencies": {
-				"ws": "~8.11.0"
-			}
-		},
-		"node_modules/socket.io-adapter/node_modules/ws": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/socket.io-client": {
@@ -23714,15 +22000,6 @@
 			"deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
 			"dev": true
 		},
-		"node_modules/stack-trace": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-			"integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/stack-utils": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -23748,12 +22025,6 @@
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
 			"integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
-			"dev": true
-		},
-		"node_modules/standard-as-callback": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-			"integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
 			"dev": true
 		},
 		"node_modules/start-server-and-test": {
@@ -23798,22 +22069,6 @@
 				"duplexer": "~0.1.1"
 			}
 		},
-		"node_modules/stream-to-pull-stream": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
-			"integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
-			"dev": true,
-			"dependencies": {
-				"looper": "^3.0.0",
-				"pull-stream": "^3.2.3"
-			}
-		},
-		"node_modules/stream-to-pull-stream/node_modules/looper": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-			"integrity": "sha512-LJ9wplN/uSn72oJRsXTx+snxPet5c8XiZmOKCm906NVYu+ag6SB6vUcnJcWxgnl2NfbIyeobAn7Bwv6xRj2XJg==",
-			"dev": true
-		},
 		"node_modules/streamx": {
 			"version": "2.15.1",
 			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.1.tgz",
@@ -23832,12 +22087,6 @@
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
 			}
-		},
-		"node_modules/string-hash": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-			"integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
-			"dev": true
 		},
 		"node_modules/string-length": {
 			"version": "4.0.2",
@@ -24492,12 +22741,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/text-hex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-			"dev": true
-		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -24609,15 +22852,6 @@
 			"dev": true,
 			"bin": {
 				"tree-kill": "cli.js"
-			}
-		},
-		"node_modules/triple-beam": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
-			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/tryer": {
@@ -24824,33 +23058,6 @@
 				"node": ">=4.2.0"
 			}
 		},
-		"node_modules/typewise": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-			"integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
-			"dev": true,
-			"dependencies": {
-				"typewise-core": "^1.2.0"
-			}
-		},
-		"node_modules/typewise-core": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-			"integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
-			"dev": true
-		},
-		"node_modules/typewiselite": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
-			"integrity": "sha512-J9alhjVHupW3Wfz6qFRGgQw0N3gr8hOkw6zm7FZ6UR1Cse/oD9/JVok7DNE9TT9IbciDHX2Ex9+ksE6cRmtymw==",
-			"dev": true
-		},
-		"node_modules/uid2": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-			"integrity": "sha512-5gSP1liv10Gjp8cMEnFd6shzkL/D6W1uhXSFNCxDC+YI8+L8wkCYCbJ7n77Ezb4wE/xzMogecE+DtamEe9PZjg==",
-			"dev": true
-		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -25050,19 +23257,6 @@
 			"dependencies": {
 				"querystringify": "^2.1.1",
 				"requires-port": "^1.0.0"
-			}
-		},
-		"node_modules/util": {
-			"version": "0.12.5",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"is-arguments": "^1.0.4",
-				"is-generator-function": "^1.0.7",
-				"is-typed-array": "^1.1.3",
-				"which-typed-array": "^1.1.2"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -25728,42 +23922,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/winston": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
-			"integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
-			"dev": true,
-			"dependencies": {
-				"@colors/colors": "^1.6.0",
-				"@dabh/diagnostics": "^2.0.2",
-				"async": "^3.2.3",
-				"is-stream": "^2.0.0",
-				"logform": "^2.4.0",
-				"one-time": "^1.0.0",
-				"readable-stream": "^3.4.0",
-				"safe-stable-stringify": "^2.3.1",
-				"stack-trace": "0.0.x",
-				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.5.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/winston-transport": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.6.0.tgz",
-			"integrity": "sha512-wbBA9PbPAHxKiygo7ub7BYRiKxms0tpfU2ljtWzb3SjRjv5yl6Ozuy/TkXf00HTAt+Uylo3gSkNwzc4ME0wiIg==",
-			"dev": true,
-			"dependencies": {
-				"logform": "^2.3.2",
-				"readable-stream": "^3.6.0",
-				"triple-beam": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
 		"node_modules/workbox-background-sync": {
 			"version": "6.6.0",
 			"resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-6.6.0.tgz",
@@ -26186,15 +24344,6 @@
 			"integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.4"
 			}
 		},
 		"node_modules/y18n": {

--- a/brainstorm/package-lock.json
+++ b/brainstorm/package-lock.json
@@ -21,7 +21,6 @@
 				"uuid": "^8.3.2"
 			},
 			"devDependencies": {
-				"@fluidframework/azure-local-service": "^1.1.0",
 				"@fluidframework/build-common": "^2.0.0",
 				"@testing-library/jest-dom": "^5.11.4",
 				"@testing-library/react": "^11.1.0",
@@ -37,6 +36,7 @@
 				"puppeteer": "^21.0.0",
 				"react-scripts": "^5.0.1",
 				"start-server-and-test": "^2.0.0",
+				"tinylicious": "^1.0.0",
 				"typescript": "~4.5.5"
 			},
 			"engines": {
@@ -2061,9 +2061,9 @@
 			"dev": true
 		},
 		"node_modules/@colors/colors": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.1.90"
@@ -2446,18 +2446,6 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
-		"node_modules/@eslint/eslintrc/node_modules/type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/@eslint/js": {
 			"version": "8.49.0",
 			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.49.0.tgz",
@@ -2726,21 +2714,6 @@
 				"fluid-framework": "^1.3.0"
 			}
 		},
-		"node_modules/@fluidframework/azure-local-service": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-1.1.0.tgz",
-			"integrity": "sha512-DhhKY0vR59g5eh4spIPFRkMCTjapItfnWy/Q7Mrx+x3m9xr/JDa1xZIy8oyPnmjc/xDd6/UfB3U3c7O3Ley8UQ==",
-			"dev": true,
-			"dependencies": {
-				"tinylicious": "^0.4.89251"
-			},
-			"bin": {
-				"azure-local-service": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
 		"node_modules/@fluidframework/build-common": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.0.tgz",
@@ -2756,9 +2729,9 @@
 			"integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
 		},
 		"node_modules/@fluidframework/common-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.0.0.tgz",
-			"integrity": "sha512-O3UoZ2dQR/ZWMXTSbDcTH93WMqHmEKoYhYMn6cybESswmMOA2E9UF3B2TkJ+aofBLOLllDKXXGtuhPmu/9rTqQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@types/events": "^3.0.0",
@@ -3498,74 +3471,80 @@
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.2000.tgz",
-			"integrity": "sha512-r3T2gix3IcsGNJCtzWef/8BHF1mwl32Zq8e3eWKmFFSnXYnsW0u1JUuozSXdRByi8P6py39yDK2CmfAnxwWnUg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-1.0.1.tgz",
+			"integrity": "sha512-lwVKg4dVDvbNH4ckj328z5cNu1plHhArzIMP3kpl8T94L6OubqsJ8vf3g46Wab/SjwltHC41p/wWigJapXZjqA==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas-driver": "^0.1038.2000",
-				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/server-services-core": "^0.1038.2000",
-				"@fluidframework/server-services-telemetry": "^0.1038.2000",
-				"@types/semver": "^6.0.1",
+				"@fluidframework/server-lambdas-driver": "^1.0.1",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"@types/semver": "^7.5.0",
+				"assert": "^2.0.0",
 				"async": "^3.2.2",
 				"axios": "^0.26.0",
 				"buffer": "^6.0.3",
 				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
 				"json-stringify-safe": "^5.0.1",
 				"lodash": "^4.17.21",
 				"nconf": "^0.12.0",
-				"semver": "^6.3.0",
+				"semver": "^7.5.3",
 				"sha.js": "^2.4.11",
 				"uuid": "^8.3.1"
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas-driver": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.2000.tgz",
-			"integrity": "sha512-uyk1hFfRHah8/iMxiuQw/xC10v5tmJKp4mA8+ombtLPWtWuVl6dzX3XIfrF1tIqjahzzWqMVuHWVMEAESOFblg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-1.0.1.tgz",
+			"integrity": "sha512-TfQ7rz2/6pW6Rq5CbGBu9ShiSKyOHg2pXX0cUVHtnuuUPsWTxQDWlVilYukyG0uxHJfE3ZDU3R1QgnWUQQmGgg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/server-services-core": "^0.1038.2000",
-				"@fluidframework/server-services-telemetry": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"assert": "^2.0.0",
 				"async": "^3.2.2",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"serialize-error": "^8.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.2000.tgz",
-			"integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.2000.tgz",
-			"integrity": "sha512-2yqIvtt3NBKWfZgQk/nxthf+evIZ0cOW4Klz/zgdIzSFSHLNjo1eItkQc+7wLG3F7v1tD5tn9AVOQsFrDWdvYg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.2000.tgz",
-			"integrity": "sha512-A8oB7jKUDCqlU1qFSc72o7zMcGAeo52WDWWhoSYgZzMV3ZHgaPjq+FYTTpGiJPACnYUhV644UPiFvGWriLIzDA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -3588,32 +3567,32 @@
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.2000.tgz",
-			"integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.2000.tgz",
-			"integrity": "sha512-2yqIvtt3NBKWfZgQk/nxthf+evIZ0cOW4Klz/zgdIzSFSHLNjo1eItkQc+7wLG3F7v1tD5tn9AVOQsFrDWdvYg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.2000.tgz",
-			"integrity": "sha512-A8oB7jKUDCqlU1qFSc72o7zMcGAeo52WDWWhoSYgZzMV3ZHgaPjq+FYTTpGiJPACnYUhV644UPiFvGWriLIzDA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -3635,52 +3614,68 @@
 				"follow-redirects": "^1.14.8"
 			}
 		},
-		"node_modules/@fluidframework/server-local-server": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.2000.tgz",
-			"integrity": "sha512-kf+IsWeSiPiXT92h2Wexx2n4gVu+1eygYAc5KLVG/M6yyFqr8GYEHjluyjg2JMqaLh6vPGa44F0HzKIv3FppOw==",
+		"node_modules/@fluidframework/server-lambdas/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@fluidframework/server-local-server": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-1.0.1.tgz",
+			"integrity": "sha512-494H0PYNa6aqngyq/M46K7wlY7NHdIx1B4qcfRCRQmjJZrD9GPza3FHt2/426teBQ93F6SOKkBrMw2vbmoUUGg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.2000",
-				"@fluidframework/server-memory-orderer": "^0.1038.2000",
-				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/server-services-core": "^0.1038.2000",
-				"@fluidframework/server-services-telemetry": "^0.1038.2000",
-				"@fluidframework/server-test-utils": "^0.1038.2000",
+				"@fluidframework/server-lambdas": "^1.0.1",
+				"@fluidframework/server-memory-orderer": "^1.0.1",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"@fluidframework/server-test-utils": "^1.0.1",
 				"debug": "^4.1.1",
+				"events": "^3.1.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
 			}
 		},
 		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.2000.tgz",
-			"integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.2000.tgz",
-			"integrity": "sha512-2yqIvtt3NBKWfZgQk/nxthf+evIZ0cOW4Klz/zgdIzSFSHLNjo1eItkQc+7wLG3F7v1tD5tn9AVOQsFrDWdvYg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.2000.tgz",
-			"integrity": "sha512-A8oB7jKUDCqlU1qFSc72o7zMcGAeo52WDWWhoSYgZzMV3ZHgaPjq+FYTTpGiJPACnYUhV644UPiFvGWriLIzDA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -3703,25 +3698,27 @@
 			}
 		},
 		"node_modules/@fluidframework/server-memory-orderer": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.2000.tgz",
-			"integrity": "sha512-A+oIAJ5evNzEwEit5NBQSvOTQrzf6Zx+1yBES0v89ypjcIXYoT8oqJWvzuaFbxu4RH6w8JMFMkVZ1gnF1WGpog==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-1.0.1.tgz",
+			"integrity": "sha512-zUuNICwyKC7OTSl/W9MSiwplSccnRHVmRpdxImCe5qVs+VSK1jHuIGiIzCkt6dlVNMu3WHyUXmrKCLmhJZmFeQ==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.2000",
-				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/server-services-core": "^0.1038.2000",
-				"@fluidframework/server-services-telemetry": "^0.1038.2000",
+				"@fluidframework/server-lambdas": "^1.0.1",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/lodash": "^4.14.118",
-				"@types/node": "^14.18.0",
+				"@types/node": "^16.18.16",
 				"@types/ws": "^6.0.1",
+				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
 				"lodash": "^4.17.21",
 				"sillyname": "^0.1.0",
 				"uuid": "^8.3.1",
@@ -3729,32 +3726,32 @@
 			}
 		},
 		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.2000.tgz",
-			"integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.2000.tgz",
-			"integrity": "sha512-2yqIvtt3NBKWfZgQk/nxthf+evIZ0cOW4Klz/zgdIzSFSHLNjo1eItkQc+7wLG3F7v1tD5tn9AVOQsFrDWdvYg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.2000.tgz",
-			"integrity": "sha512-A8oB7jKUDCqlU1qFSc72o7zMcGAeo52WDWWhoSYgZzMV3ZHgaPjq+FYTTpGiJPACnYUhV644UPiFvGWriLIzDA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -3768,9 +3765,9 @@
 			}
 		},
 		"node_modules/@fluidframework/server-memory-orderer/node_modules/@types/node": {
-			"version": "14.18.56",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.56.tgz",
-			"integrity": "sha512-+k+57NVS9opgrEn5l9c0gvD1r6C+PtyhVE4BTnMMRwiEA8ZO8uFcs6Yy2sXIy0eC95ZurBtRSvhZiHXBysbl6w==",
+			"version": "16.18.59",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.59.tgz",
+			"integrity": "sha512-PJ1w2cNeKUEdey4LiPra0ZuxZFOGvetswE8qHRriV/sUkL5Al4tTmPV9D2+Y/TPIxTHHgxTfRjZVKWhPw/ORhQ==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-memory-orderer/node_modules/axios": {
@@ -3853,49 +3850,50 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-core": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.2000.tgz",
-			"integrity": "sha512-kAYxPg1AAqRJxXzN7lXPlShSI31vr3MpDvBLeEQG4fcAWlZHcS5a0DtiA+kV8qKrhJCHfC+KyoS/UruJ4L2yxQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-1.0.1.tgz",
+			"integrity": "sha512-/Lb5ZZxb4aHtzLH3p+lrboi6TW/WD0I53di8FI4rMmn5AM7+h69BolPW7nume52t3HUi1I2Mnqhx1W8FKV8BbA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/server-services-telemetry": "^0.1038.2000",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
 				"@types/nconf": "^0.10.2",
-				"@types/node": "^14.18.0",
+				"@types/node": "^16.18.16",
 				"debug": "^4.1.1",
+				"events": "^3.1.0",
 				"nconf": "^0.12.0"
 			}
 		},
 		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.2000.tgz",
-			"integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.2000.tgz",
-			"integrity": "sha512-2yqIvtt3NBKWfZgQk/nxthf+evIZ0cOW4Klz/zgdIzSFSHLNjo1eItkQc+7wLG3F7v1tD5tn9AVOQsFrDWdvYg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.2000.tgz",
-			"integrity": "sha512-A8oB7jKUDCqlU1qFSc72o7zMcGAeo52WDWWhoSYgZzMV3ZHgaPjq+FYTTpGiJPACnYUhV644UPiFvGWriLIzDA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -3909,9 +3907,9 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-core/node_modules/@types/node": {
-			"version": "14.18.56",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.56.tgz",
-			"integrity": "sha512-+k+57NVS9opgrEn5l9c0gvD1r6C+PtyhVE4BTnMMRwiEA8ZO8uFcs6Yy2sXIy0eC95ZurBtRSvhZiHXBysbl6w==",
+			"version": "16.18.59",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.59.tgz",
+			"integrity": "sha512-PJ1w2cNeKUEdey4LiPra0ZuxZFOGvetswE8qHRriV/sUkL5Al4tTmPV9D2+Y/TPIxTHHgxTfRjZVKWhPw/ORhQ==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-services-core/node_modules/axios": {
@@ -3924,60 +3922,62 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-shared": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.2000.tgz",
-			"integrity": "sha512-Qh/ZN8E/LTLXsWkmU2zBhiTzrVy9+sL/Jf1+qyN2incu6R4lbB5zCQ9shDBuImboWFhD39yBBm/j5iDspOoOhQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-1.0.1.tgz",
+			"integrity": "sha512-Z+IyqWHUk/y0aZ5cUXUoehcOiIr4qw1VkDR5i+1rnLntCRkPKk7h6FFXcWo+OBmI7D3AJOKZagMr6npezIPEmQ==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/server-services-core": "^0.1038.2000",
-				"@fluidframework/server-services-telemetry": "^0.1038.2000",
-				"@socket.io/redis-adapter": "^7.0.0",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"@socket.io/redis-adapter": "^7.2.0",
 				"body-parser": "^1.17.1",
 				"debug": "^4.1.1",
-				"ioredis": "^4.24.2",
+				"events": "^3.1.0",
+				"ioredis": "^5.2.3",
 				"lodash": "^4.17.21",
 				"nconf": "^0.12.0",
 				"notepack.io": "^2.3.0",
 				"querystring": "^0.2.0",
-				"socket.io": "^4.5.0",
-				"socket.io-adapter": "^2.3.1",
-				"socket.io-parser": "^4.0.4",
+				"serialize-error": "^8.1.0",
+				"socket.io": "^4.5.3",
+				"socket.io-adapter": "^2.4.0",
+				"socket.io-parser": "^4.2.1",
 				"uuid": "^8.3.1",
 				"winston": "^3.6.0"
 			}
 		},
 		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.2000.tgz",
-			"integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.2000.tgz",
-			"integrity": "sha512-2yqIvtt3NBKWfZgQk/nxthf+evIZ0cOW4Klz/zgdIzSFSHLNjo1eItkQc+7wLG3F7v1tD5tn9AVOQsFrDWdvYg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.2000.tgz",
-			"integrity": "sha512-A8oB7jKUDCqlU1qFSc72o7zMcGAeo52WDWWhoSYgZzMV3ZHgaPjq+FYTTpGiJPACnYUhV644UPiFvGWriLIzDA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -4000,12 +4000,12 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-telemetry": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.2000.tgz",
-			"integrity": "sha512-RBDh+uYZ53GfvXsH1XKDTAsCWpBIFZAl6IHaDZkLE11Zw4ZRk3Bz4063buuBklZ4K3HnLhv+p9Eu9jVsK+v3jA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-1.0.1.tgz",
+			"integrity": "sha512-qeNtIr5mnkDS5hwD9t+2kcmsRK4zxdAtR+F0j0/rZ/pBWuaVmJI6YiKC5HzWTuszW5F1VDpGnul0M8HEWyhrgQ==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
+				"@fluidframework/common-utils": "^1.1.1",
 				"json-stringify-safe": "^5.0.1",
 				"path-browserify": "^1.0.1",
 				"serialize-error": "^8.1.0",
@@ -4013,56 +4013,57 @@
 			}
 		},
 		"node_modules/@fluidframework/server-services-utils": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.2000.tgz",
-			"integrity": "sha512-NOfl50zlR8BWGYyxGUaJ+cg/5XbLDbLMcOtwKswK3jy8EQzv9sc7bc+Bt+5vZOgCvoFtUwwpeva8w9M7+vgkTg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-1.0.1.tgz",
+			"integrity": "sha512-MzoonbJ/EQMbPi+m7/TZxWqyYzs1wxOdtN/Fe4FkaKOcHJjXR1e33iBw3YTkMQR9W8Z8E3WfSe6UVmzNDNH1TQ==",
 			"dev": true,
 			"dependencies": {
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/server-services-core": "^0.1038.2000",
-				"@fluidframework/server-services-telemetry": "^0.1038.2000",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
 				"debug": "^4.1.1",
-				"express": "^4.16.3",
-				"ioredis": "^4.24.2",
+				"express": "^4.17.3",
+				"ioredis": "^5.2.3",
 				"json-stringify-safe": "^5.0.1",
-				"jsonwebtoken": "^8.4.0",
+				"jsonwebtoken": "^9.0.0",
 				"morgan": "^1.8.1",
 				"nconf": "^0.12.0",
 				"serialize-error": "^8.1.0",
 				"sillyname": "^0.1.0",
 				"split": "^1.0.0",
 				"uuid": "^8.3.1",
-				"winston": "^3.6.0"
+				"winston": "^3.6.0",
+				"winston-transport": "^4.5.0"
 			}
 		},
 		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.2000.tgz",
-			"integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.2000.tgz",
-			"integrity": "sha512-2yqIvtt3NBKWfZgQk/nxthf+evIZ0cOW4Klz/zgdIzSFSHLNjo1eItkQc+7wLG3F7v1tD5tn9AVOQsFrDWdvYg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.2000.tgz",
-			"integrity": "sha512-A8oB7jKUDCqlU1qFSc72o7zMcGAeo52WDWWhoSYgZzMV3ZHgaPjq+FYTTpGiJPACnYUhV644UPiFvGWriLIzDA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -4097,51 +4098,53 @@
 			}
 		},
 		"node_modules/@fluidframework/server-test-utils": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.2000.tgz",
-			"integrity": "sha512-w08VsOC+x0hzXZs5YIrmjFyG2gV+6bMXzMsxSeDuLPkwz1xQXNJxpVG1FM9hAJUke41kzxbRvielSdMfzp3N6A==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-1.0.1.tgz",
+			"integrity": "sha512-+2ZP2pU4eq3KY5EySJhcwyAZqy9WojPhirA+fNUPKblT0fmeAn2ks6mF3d98fcxwqjMPb+5UPLRWDf7/+i1/Aw==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/server-services-core": "^0.1038.2000",
-				"@fluidframework/server-services-telemetry": "^0.1038.2000",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"assert": "^2.0.0",
 				"debug": "^4.1.1",
+				"events": "^3.1.0",
 				"lodash": "^4.17.21",
 				"string-hash": "^1.1.3",
 				"uuid": "^8.3.1"
 			}
 		},
 		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.2000.tgz",
-			"integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.2000.tgz",
-			"integrity": "sha512-2yqIvtt3NBKWfZgQk/nxthf+evIZ0cOW4Klz/zgdIzSFSHLNjo1eItkQc+7wLG3F7v1tD5tn9AVOQsFrDWdvYg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.2000.tgz",
-			"integrity": "sha512-A8oB7jKUDCqlU1qFSc72o7zMcGAeo52WDWWhoSYgZzMV3ZHgaPjq+FYTTpGiJPACnYUhV644UPiFvGWriLIzDA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -4360,6 +4363,12 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+			"dev": true
+		},
+		"node_modules/@ioredis/commands": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+			"integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
 			"dev": true
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
@@ -5929,24 +5938,27 @@
 			"dev": true
 		},
 		"node_modules/@types/cors": {
-			"version": "2.8.12",
-			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
-			"integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
-			"dev": true
+			"version": "2.8.15",
+			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.15.tgz",
+			"integrity": "sha512-n91JxbNLD8eQIuXDIChAN1tCKNWCEgpceU9b7ZMbFA+P+Q4yIeh80jizFLEvolRPc1ES0VdwFlGv+kJTSirogw==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/debug": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-			"integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.10.tgz",
+			"integrity": "sha512-tOSCru6s732pofZ+sMv9o4o3Zc+Sa8l3bxd/tweTQudFn06vAzb13ZX46Zi6m6EJ+RUbRTHvgQJ1gBtSgkaUYA==",
 			"dev": true,
 			"dependencies": {
 				"@types/ms": "*"
 			}
 		},
 		"node_modules/@types/double-ended-queue": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@types/double-ended-queue/-/double-ended-queue-2.1.1.tgz",
-			"integrity": "sha512-O2+umEIlHBVyi+ePmucPjpINqTvSnsz+hAok0D4IpvrOsIsDr6c34B0AbNXW2UDVYuxbv51z5dxnrRt23ohgWg==",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@types/double-ended-queue/-/double-ended-queue-2.1.5.tgz",
+			"integrity": "sha512-Iyp30YLmx/PFvtmomdZq4i81N6uR/7Le+UFrUbnNVbHboRCcCuOKu64tPXlr2yFOb8Zh4t0SppDxRQ5DM/Hlhg==",
 			"dev": true
 		},
 		"node_modules/@types/eslint": {
@@ -6113,9 +6125,9 @@
 			"dev": true
 		},
 		"node_modules/@types/lodash": {
-			"version": "4.14.188",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.188.tgz",
-			"integrity": "sha512-zmEmF5OIM3rb7SbLCFYoQhO4dGt2FRM9AMkxvA3LaADOF1n8in/zGJlWji9fmafLoNyz+FoL6FE0SLtGIArD7w==",
+			"version": "4.14.200",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
+			"integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==",
 			"dev": true
 		},
 		"node_modules/@types/mime": {
@@ -6125,15 +6137,15 @@
 			"dev": true
 		},
 		"node_modules/@types/ms": {
-			"version": "0.7.31",
-			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+			"version": "0.7.33",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.33.tgz",
+			"integrity": "sha512-AuHIyzR5Hea7ij0P9q7vx7xu4z0C28ucwjAZC0ja7JhINyCnOw8/DnvAPQQ9TfOlCtZAmCERKQX9+o1mgQhuOQ==",
 			"dev": true
 		},
 		"node_modules/@types/nconf": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.3.tgz",
-			"integrity": "sha512-leyIuBk/rMIp9114FlPRkc/cQG+/JzCz1Afx3BD+CwK2ep3ZRxoC843V1rqnE2pC/jRRjANWhuVBEn4clCwlug==",
+			"version": "0.10.5",
+			"resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.5.tgz",
+			"integrity": "sha512-Rig8+FAyg9twg01Ya+aVR+QAakMxcTiO3QcvhY41Rn/m1ZvFIU5fb+D3qxxqIHxrFacQqxeg8c8apzZYZ+dqLA==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -6216,9 +6228,9 @@
 			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
 		},
 		"node_modules/@types/semver": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.3.tgz",
-			"integrity": "sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==",
 			"dev": true
 		},
 		"node_modules/@types/send": {
@@ -6274,6 +6286,12 @@
 			"dependencies": {
 				"@types/jest": "*"
 			}
+		},
+		"node_modules/@types/triple-beam": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.4.tgz",
+			"integrity": "sha512-HlJjF3wxV4R2VQkFpKe0YqJLilYNgtRtsqqZtby7RkVsSs+i+vbyzjtUwpFEdUCKcrGzCiEJE7F/0mKjh0sunA==",
+			"dev": true
 		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.4",
@@ -6540,12 +6558,6 @@
 			"peerDependencies": {
 				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
-		},
-		"node_modules/@typescript-eslint/utils/node_modules/@types/semver": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.2.tgz",
-			"integrity": "sha512-7aqorHYgdNO4DM36stTiGO3DvKoex9TQRwsJU6vMaFGyqpBA1MNZkz+PG3gaNUPpTAOYhT1WR7M1JyA3fbS9Cw==",
-			"dev": true
 		},
 		"node_modules/@typescript-eslint/utils/node_modules/eslint-scope": {
 			"version": "5.1.1",
@@ -7278,6 +7290,19 @@
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
 			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
 			"dev": true
+		},
+		"node_modules/assert": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+			"integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"is-nan": "^1.3.2",
+				"object-is": "^1.1.5",
+				"object.assign": "^4.1.4",
+				"util": "^0.12.5"
+			}
 		},
 		"node_modules/ast-types": {
 			"version": "0.13.4",
@@ -9491,9 +9516,9 @@
 			}
 		},
 		"node_modules/denque": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+			"integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10"
@@ -9541,6 +9566,20 @@
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
+		},
+		"node_modules/detect-port": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
+			"integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
+			"dev": true,
+			"dependencies": {
+				"address": "^1.0.1",
+				"debug": "4"
+			},
+			"bin": {
+				"detect": "bin/detect-port.js",
+				"detect-port": "bin/detect-port.js"
+			}
 		},
 		"node_modules/detect-port-alt": {
 			"version": "1.1.6",
@@ -9884,9 +9923,9 @@
 			}
 		},
 		"node_modules/engine.io": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.0.tgz",
-			"integrity": "sha512-4KzwW3F3bk+KlzSOY57fj/Jx6LyRQ1nbcyIadehl+AnXjKT7gDO0ORdRi/84ixvMKTym6ZKuxvbzN62HDDU1Lg==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.3.tgz",
+			"integrity": "sha512-IML/R4eG/pUS5w7OfcDE0jKrljWS9nwnEfsxWCIJF5eO6AHo6+Hlv+lQbdlAYsiJPHzUthLm1RUjnBzWOs45cw==",
 			"dev": true,
 			"dependencies": {
 				"@types/cookie": "^0.4.1",
@@ -9897,11 +9936,11 @@
 				"cookie": "~0.4.1",
 				"cors": "~2.8.5",
 				"debug": "~4.3.1",
-				"engine.io-parser": "~5.0.3",
-				"ws": "~8.2.3"
+				"engine.io-parser": "~5.2.1",
+				"ws": "~8.11.0"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=10.2.0"
 			}
 		},
 		"node_modules/engine.io-client": {
@@ -9931,6 +9970,36 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/engine.io/node_modules/engine.io-parser": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
+			"integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/engine.io/node_modules/ws": {
+			"version": "8.11.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/enhanced-resolve": {
@@ -10788,18 +10857,6 @@
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/eslint/node_modules/type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -12651,38 +12708,27 @@
 			}
 		},
 		"node_modules/ioredis": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
-			"integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
+			"integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
 			"dev": true,
 			"dependencies": {
+				"@ioredis/commands": "^1.1.1",
 				"cluster-key-slot": "^1.1.0",
-				"debug": "^4.3.1",
-				"denque": "^1.1.0",
+				"debug": "^4.3.4",
+				"denque": "^2.1.0",
 				"lodash.defaults": "^4.2.0",
-				"lodash.flatten": "^4.4.0",
 				"lodash.isarguments": "^3.1.0",
-				"p-map": "^2.1.0",
-				"redis-commands": "1.7.0",
 				"redis-errors": "^1.2.0",
 				"redis-parser": "^3.0.0",
 				"standard-as-callback": "^2.1.0"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=12.22.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/ioredis"
-			}
-		},
-		"node_modules/ioredis/node_modules/p-map": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/ip": {
@@ -12925,6 +12971,22 @@
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
 			"integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
 			"dev": true
+		},
+		"node_modules/is-nan": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/is-negative-zero": {
 			"version": "2.0.2",
@@ -16872,9 +16934,9 @@
 			}
 		},
 		"node_modules/jsonwebtoken": {
-			"version": "8.5.1",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-			"integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+			"integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
 			"dev": true,
 			"dependencies": {
 				"jws": "^3.2.2",
@@ -16886,20 +16948,26 @@
 				"lodash.isstring": "^4.0.1",
 				"lodash.once": "^4.0.0",
 				"ms": "^2.1.1",
-				"semver": "^5.6.0"
+				"semver": "^7.5.4"
 			},
 			"engines": {
-				"node": ">=4",
-				"npm": ">=1.4.28"
+				"node": ">=12",
+				"npm": ">=6"
 			}
 		},
 		"node_modules/jsonwebtoken/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
 			"bin": {
-				"semver": "bin/semver"
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/jsrsasign": {
@@ -17280,12 +17348,6 @@
 			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
 			"dev": true
 		},
-		"node_modules/lodash.flatten": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-			"dev": true
-		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -17359,16 +17421,20 @@
 			"dev": true
 		},
 		"node_modules/logform": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.4.2.tgz",
-			"integrity": "sha512-W4c9himeAwXEdZ05dQNerhFz2XG80P9Oj0loPUMV23VC2it0orMHQhJm4hdnnor3rd1HsGf6a2lPwBM1zeXHGw==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
+			"integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
 			"dev": true,
 			"dependencies": {
-				"@colors/colors": "1.5.0",
+				"@colors/colors": "1.6.0",
+				"@types/triple-beam": "^1.3.2",
 				"fecha": "^4.2.0",
 				"ms": "^2.1.1",
 				"safe-stable-stringify": "^2.3.1",
 				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/looper": {
@@ -17846,9 +17912,9 @@
 			"dev": true
 		},
 		"node_modules/nconf": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.0.tgz",
-			"integrity": "sha512-T3fZPw3c7Dfrz8JBQEbEcZJ2s8f7cUMpKuyBtsGQe0b71pcXx6gNh4oti2xh5dxB+gO9ufNfISBlGvvWtfyMcA==",
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.1.tgz",
+			"integrity": "sha512-p2cfF+B3XXacQdswUYWZ0w6Vld0832A/tuqjLBu3H1sfUcby4N2oVbGhyuCkZv+t3iY3aiFEj7gZGqax9Q2c1w==",
 			"dev": true,
 			"dependencies": {
 				"async": "^3.0.0",
@@ -22546,12 +22612,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/redis-commands": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
-			"dev": true
-		},
 		"node_modules/redis-errors": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
@@ -23167,9 +23227,9 @@
 			}
 		},
 		"node_modules/safe-stable-stringify": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
-			"integrity": "sha512-dVHE6bMtS/bnL2mwualjc6IxEv1F+OCUpA46pKUj6F8uDbUM0jCCulPqRNPSnWwGNKx5etqMjZYdXtrm5KJZGA==",
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
 			"dev": true,
 			"engines": {
 				"node": ">=10"
@@ -23356,18 +23416,6 @@
 			"dependencies": {
 				"type-fest": "^0.20.2"
 			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/serialize-error/node_modules/type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -23656,27 +23704,52 @@
 			}
 		},
 		"node_modules/socket.io": {
-			"version": "4.5.3",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.3.tgz",
-			"integrity": "sha512-zdpnnKU+H6mOp7nYRXH4GNv1ux6HL6+lHL8g7Ds7Lj8CkdK1jJK/dlwsKDculbyOHifcJ0Pr/yeXnZQ5GeFrcg==",
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.2.tgz",
+			"integrity": "sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==",
 			"dev": true,
 			"dependencies": {
 				"accepts": "~1.3.4",
 				"base64id": "~2.0.0",
+				"cors": "~2.8.5",
 				"debug": "~4.3.2",
-				"engine.io": "~6.2.0",
-				"socket.io-adapter": "~2.4.0",
-				"socket.io-parser": "~4.2.0"
+				"engine.io": "~6.5.2",
+				"socket.io-adapter": "~2.5.2",
+				"socket.io-parser": "~4.2.4"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=10.2.0"
 			}
 		},
 		"node_modules/socket.io-adapter": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
-			"integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==",
-			"dev": true
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+			"integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+			"dev": true,
+			"dependencies": {
+				"ws": "~8.11.0"
+			}
+		},
+		"node_modules/socket.io-adapter/node_modules/ws": {
+			"version": "8.11.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/socket.io-client": {
 			"version": "4.5.3",
@@ -23693,9 +23766,9 @@
 			}
 		},
 		"node_modules/socket.io-parser": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
-			"integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+			"integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
 			"dependencies": {
 				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.3.1"
@@ -24739,24 +24812,24 @@
 			"dev": true
 		},
 		"node_modules/tinylicious": {
-			"version": "0.4.94771",
-			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
-			"integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-1.0.0.tgz",
+			"integrity": "sha512-ACL8mEKT5LPbFyAXCDjYWqi3vcNef7y2ABMnU3O4jK1cRuEn0MywH7ppMM5ZrMgtSMMsJAINcWxZjpq3ndH8hg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.1000",
-				"@fluidframework/protocol-base": "^0.1038.1000",
-				"@fluidframework/protocol-definitions": "^1.0.0",
-				"@fluidframework/server-lambdas": "^0.1038.1000",
-				"@fluidframework/server-local-server": "^0.1038.1000",
-				"@fluidframework/server-memory-orderer": "^0.1038.1000",
-				"@fluidframework/server-services-client": "^0.1038.1000",
-				"@fluidframework/server-services-core": "^0.1038.1000",
-				"@fluidframework/server-services-shared": "^0.1038.1000",
-				"@fluidframework/server-services-telemetry": "^0.1038.1000",
-				"@fluidframework/server-services-utils": "^0.1038.1000",
-				"@fluidframework/server-test-utils": "^0.1038.1000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.0",
+				"@fluidframework/protocol-base": "^1.0.0",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^1.0.0",
+				"@fluidframework/server-local-server": "^1.0.0",
+				"@fluidframework/server-memory-orderer": "^1.0.0",
+				"@fluidframework/server-services-client": "^1.0.0",
+				"@fluidframework/server-services-core": "^1.0.0",
+				"@fluidframework/server-services-shared": "^1.0.0",
+				"@fluidframework/server-services-telemetry": "^1.0.0",
+				"@fluidframework/server-services-utils": "^1.0.0",
+				"@fluidframework/server-test-utils": "^1.0.0",
 				"agentkeepalive": "^4.2.1",
 				"axios": "^0.26.0",
 				"body-parser": "^1.17.1",
@@ -24765,7 +24838,7 @@
 				"cookie-parser": "^1.4.3",
 				"cors": "^2.8.4",
 				"detect-port": "^1.3.0",
-				"express": "^4.16.3",
+				"express": "^4.17.3",
 				"isomorphic-git": "^1.8.2",
 				"json-stringify-safe": "^5.0.1",
 				"level": "^8.0.0",
@@ -24786,32 +24859,32 @@
 			}
 		},
 		"node_modules/tinylicious/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.2000.tgz",
-			"integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
 			"dev": true
 		},
 		"node_modules/tinylicious/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.2000.tgz",
-			"integrity": "sha512-2yqIvtt3NBKWfZgQk/nxthf+evIZ0cOW4Klz/zgdIzSFSHLNjo1eItkQc+7wLG3F7v1tD5tn9AVOQsFrDWdvYg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"lodash": "^4.17.21"
+				"events": "^3.1.0"
 			}
 		},
 		"node_modules/tinylicious/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.2000.tgz",
-			"integrity": "sha512-A8oB7jKUDCqlU1qFSc72o7zMcGAeo52WDWWhoSYgZzMV3ZHgaPjq+FYTTpGiJPACnYUhV644UPiFvGWriLIzDA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/protocol-base": "^0.1038.2000",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -24831,20 +24904,6 @@
 			"dev": true,
 			"dependencies": {
 				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/tinylicious/node_modules/detect-port": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
-			"integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
-			"dev": true,
-			"dependencies": {
-				"address": "^1.0.1",
-				"debug": "4"
-			},
-			"bin": {
-				"detect": "bin/detect-port.js",
-				"detect-port": "bin/detect-port.js"
 			}
 		},
 		"node_modules/tinylicious/node_modules/split": {
@@ -24934,10 +24993,13 @@
 			}
 		},
 		"node_modules/triple-beam": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
-			"integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==",
-			"dev": true
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 14.0.0"
+			}
 		},
 		"node_modules/tryer": {
 			"version": "1.0.1",
@@ -25029,6 +25091,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/type-is": {
@@ -25357,6 +25431,19 @@
 			"dependencies": {
 				"querystringify": "^2.1.1",
 				"requires-port": "^1.0.0"
+			}
+		},
+		"node_modules/util": {
+			"version": "0.12.5",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"is-arguments": "^1.0.4",
+				"is-generator-function": "^1.0.7",
+				"is-typed-array": "^1.1.3",
+				"which-typed-array": "^1.1.2"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -26023,12 +26110,12 @@
 			}
 		},
 		"node_modules/winston": {
-			"version": "3.8.2",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.8.2.tgz",
-			"integrity": "sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==",
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
+			"integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
 			"dev": true,
 			"dependencies": {
-				"@colors/colors": "1.5.0",
+				"@colors/colors": "^1.6.0",
 				"@dabh/diagnostics": "^2.0.2",
 				"async": "^3.2.3",
 				"is-stream": "^2.0.0",
@@ -26045,9 +26132,9 @@
 			}
 		},
 		"node_modules/winston-transport": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
-			"integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.6.0.tgz",
+			"integrity": "sha512-wbBA9PbPAHxKiygo7ub7BYRiKxms0tpfU2ljtWzb3SjRjv5yl6Ozuy/TkXf00HTAt+Uylo3gSkNwzc4ME0wiIg==",
 			"dev": true,
 			"dependencies": {
 				"logform": "^2.3.2",
@@ -26055,7 +26142,7 @@
 				"triple-beam": "^1.3.0"
 			},
 			"engines": {
-				"node": ">= 6.4.0"
+				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/workbox-background-sync": {

--- a/brainstorm/package-lock.json
+++ b/brainstorm/package-lock.json
@@ -21,6 +21,7 @@
 				"uuid": "^8.3.2"
 			},
 			"devDependencies": {
+				"@fluidframework/azure-local-service": "^1.1.0",
 				"@fluidframework/build-common": "^2.0.0",
 				"@testing-library/jest-dom": "^5.11.4",
 				"@testing-library/react": "^11.1.0",
@@ -36,7 +37,6 @@
 				"puppeteer": "^21.0.0",
 				"react-scripts": "^5.0.1",
 				"start-server-and-test": "^2.0.0",
-				"tinylicious": "^1.0.0",
 				"typescript": "~4.5.5"
 			},
 			"engines": {
@@ -2714,6 +2714,397 @@
 				"fluid-framework": "^1.3.0"
 			}
 		},
+		"node_modules/@fluidframework/azure-local-service": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-1.1.1.tgz",
+			"integrity": "sha512-gvk+qy8RytXBQaZ554OREszHGN73W3FmgpfwV+aXeOOP5RWLMPSvkPoac5K9gcUYN+nAFbRs517c055yucP9ug==",
+			"dev": true,
+			"dependencies": {
+				"tinylicious": "^0.4.89251"
+			},
+			"bin": {
+				"azure-local-service": "dist/index.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/gitresources": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
+			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-base": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
+			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.4001.tgz",
+			"integrity": "sha512-rERfgXK5DXGJvxADjotkAZssKgp3ZxW6u7yUekrDnFDkXtbCW1Gcq+EwvjHTEyhsOp30YBnD0Z39xnZy4zEZRw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas-driver": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/semver": "^6.0.1",
+				"assert": "^2.0.0",
+				"async": "^3.2.2",
+				"axios": "^0.26.0",
+				"buffer": "^6.0.3",
+				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
+				"json-stringify-safe": "^5.0.1",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"semver": "^6.3.0",
+				"sha.js": "^2.4.11",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas-driver": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.4001.tgz",
+			"integrity": "sha512-qRs+vMbSS9aPx7vr3XemvER5DeY/nsJ5ZkcL3UDjUOxvLZxbOAD6C6JeH3Zgzc/jc8bqshcxai/u7qso2zCsFw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"assert": "^2.0.0",
+				"async": "^3.2.2",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-local-server": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.4001.tgz",
+			"integrity": "sha512-FIlNUc9Ncul/5qzP+VyU53TJj8fxX7KZ1lweswZYalleRZwiqFA4Y+NbWRRWM0iJ1z8hvhyRZblG3iNrpGl04A==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^0.1038.4001",
+				"@fluidframework/server-memory-orderer": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@fluidframework/server-test-utils": "^0.1038.4001",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"jsrsasign": "^10.5.25",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-memory-orderer": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.4001.tgz",
+			"integrity": "sha512-fdzTCLFRh8QfyY17MnB22/o8x2XEX1+wZrm+dn+1Av+ZVe/+ZhfdX5LsQCMKYv+X5mgAauNmC/12mQE4H6jvsQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/debug": "^4.1.5",
+				"@types/double-ended-queue": "^2.1.0",
+				"@types/lodash": "^4.14.118",
+				"@types/node": "^14.18.0",
+				"@types/ws": "^6.0.1",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1",
+				"ws": "^7.4.6"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-client": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
+			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"axios": "^0.26.0",
+				"crc-32": "1.2.0",
+				"debug": "^4.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"jsrsasign": "^10.5.25",
+				"jwt-decode": "^3.0.0",
+				"querystring": "^0.2.0",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-core": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.4001.tgz",
+			"integrity": "sha512-nuZ9ebvyeIoRdlpQQpBNGkawKtc2/tHKbc8CHbMZRMh7F7kwYUtoHd/J8powb9eUcg5IHDmXx1l+PQRbQX4vCg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/nconf": "^0.10.2",
+				"@types/node": "^14.18.0",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"nconf": "^0.12.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-shared": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.4001.tgz",
+			"integrity": "sha512-vDRB2G/Xnuhan+Ri0Eg5JMKfsm7hxstCXdEyQhzJzC7+bw66wts+ZIsEsn4Ha/3KkxblF/RSW3lBhrYpxii3cQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@socket.io/redis-adapter": "^7.2.0",
+				"body-parser": "^1.17.1",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"ioredis": "^4.24.2",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"notepack.io": "^2.3.0",
+				"querystring": "^0.2.0",
+				"socket.io": "^4.5.3",
+				"socket.io-adapter": "^2.4.0",
+				"socket.io-parser": "^4.2.1",
+				"uuid": "^8.3.1",
+				"winston": "^3.6.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-telemetry": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.4001.tgz",
+			"integrity": "sha512-2leJhB04+71RTmC5ShRXm/4FWng9tLn9dlrUAjApZH4RlUJAx1JGsvo/5JU1tIbpUutMHUle2IpWyfu/RV+S5g==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"path-browserify": "^1.0.1",
+				"serialize-error": "^8.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-utils": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.4001.tgz",
+			"integrity": "sha512-K7X/0mlonDAu0pPIgTz8U9nLwRSbJY2oBpFPwpkp1UtE6SU02jx2ZzraT9epDmOl3EXeS1rHzA+mbvBSe1aFMg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"debug": "^4.1.1",
+				"express": "^4.17.3",
+				"ioredis": "^4.24.2",
+				"json-stringify-safe": "^5.0.1",
+				"jsonwebtoken": "^9.0.0",
+				"morgan": "^1.8.1",
+				"nconf": "^0.12.0",
+				"serialize-error": "^8.1.0",
+				"sillyname": "^0.1.0",
+				"split": "^1.0.0",
+				"uuid": "^8.3.1",
+				"winston": "^3.6.0",
+				"winston-transport": "^4.5.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-test-utils": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.4001.tgz",
+			"integrity": "sha512-qrLp5H1UUPIJSEHlzZ1iYlPFJCQrd2WnmoafxnQIg0mfU1ZE8XUlG5MKUg8bT9pWsCoEGJDiOkkRHaq+WXupjQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"string-hash": "^1.1.3",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@types/node": {
+			"version": "14.18.63",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@types/semver": {
+			"version": "6.2.5",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.5.tgz",
+			"integrity": "sha512-NAxro9/RqWXTqdSjccDZAjA4nXK+6zRun+HvibYJfGy8TQhpOC7Vv6v2rlHYKrT0Q8jGGoNRd/xVdHRIQRNlFQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/axios": {
+			"version": "0.26.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+			"dev": true,
+			"dependencies": {
+				"follow-redirects": "^1.14.8"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/denque": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/ioredis": {
+			"version": "4.28.5",
+			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
+			"integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+			"dev": true,
+			"dependencies": {
+				"cluster-key-slot": "^1.1.0",
+				"debug": "^4.3.1",
+				"denque": "^1.1.0",
+				"lodash.defaults": "^4.2.0",
+				"lodash.flatten": "^4.4.0",
+				"lodash.isarguments": "^3.1.0",
+				"p-map": "^2.1.0",
+				"redis-commands": "1.7.0",
+				"redis-errors": "^1.2.0",
+				"redis-parser": "^3.0.0",
+				"standard-as-callback": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ioredis"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/split": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"dev": true,
+			"dependencies": {
+				"through": "2"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/tinylicious": {
+			"version": "0.4.94771",
+			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
+			"integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.0.0",
+				"@fluidframework/gitresources": "^0.1038.1000",
+				"@fluidframework/protocol-base": "^0.1038.1000",
+				"@fluidframework/protocol-definitions": "^1.0.0",
+				"@fluidframework/server-lambdas": "^0.1038.1000",
+				"@fluidframework/server-local-server": "^0.1038.1000",
+				"@fluidframework/server-memory-orderer": "^0.1038.1000",
+				"@fluidframework/server-services-client": "^0.1038.1000",
+				"@fluidframework/server-services-core": "^0.1038.1000",
+				"@fluidframework/server-services-shared": "^0.1038.1000",
+				"@fluidframework/server-services-telemetry": "^0.1038.1000",
+				"@fluidframework/server-services-utils": "^0.1038.1000",
+				"@fluidframework/server-test-utils": "^0.1038.1000",
+				"agentkeepalive": "^4.2.1",
+				"axios": "^0.26.0",
+				"body-parser": "^1.17.1",
+				"charwise": "^3.0.1",
+				"compression": "^1.7.2",
+				"cookie-parser": "^1.4.3",
+				"cors": "^2.8.4",
+				"detect-port": "^1.3.0",
+				"express": "^4.16.3",
+				"isomorphic-git": "^1.8.2",
+				"json-stringify-safe": "^5.0.1",
+				"level": "^8.0.0",
+				"level-sublevel": "6.6.4",
+				"lodash": "^4.17.21",
+				"morgan": "^1.8.1",
+				"nconf": "^0.12.0",
+				"socket.io": "^4.5.0",
+				"split": "^1.0.0",
+				"uuid": "^8.3.2",
+				"winston": "^3.6.0"
+			},
+			"bin": {
+				"tinylicious": "dist/index.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/ws": {
+			"version": "7.5.9",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.3.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@fluidframework/build-common": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.0.tgz",
@@ -3470,336 +3861,6 @@
 				"@fluidframework/common-definitions": "^0.20.1"
 			}
 		},
-		"node_modules/@fluidframework/server-lambdas": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-1.0.1.tgz",
-			"integrity": "sha512-lwVKg4dVDvbNH4ckj328z5cNu1plHhArzIMP3kpl8T94L6OubqsJ8vf3g46Wab/SjwltHC41p/wWigJapXZjqA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas-driver": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/semver": "^7.5.0",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"axios": "^0.26.0",
-				"buffer": "^6.0.3",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"semver": "^7.5.3",
-				"sha.js": "^2.4.11",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-1.0.1.tgz",
-			"integrity": "sha512-TfQ7rz2/6pW6Rq5CbGBu9ShiSKyOHg2pXX0cUVHtnuuUPsWTxQDWlVilYukyG0uxHJfE3ZDU3R1QgnWUQQmGgg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-1.0.1.tgz",
-			"integrity": "sha512-494H0PYNa6aqngyq/M46K7wlY7NHdIx1B4qcfRCRQmjJZrD9GPza3FHt2/426teBQ93F6SOKkBrMw2vbmoUUGg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.1",
-				"@fluidframework/server-memory-orderer": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@fluidframework/server-test-utils": "^1.0.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"jsrsasign": "^10.5.25",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-1.0.1.tgz",
-			"integrity": "sha512-zUuNICwyKC7OTSl/W9MSiwplSccnRHVmRpdxImCe5qVs+VSK1jHuIGiIzCkt6dlVNMu3WHyUXmrKCLmhJZmFeQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/debug": "^4.1.5",
-				"@types/double-ended-queue": "^2.1.0",
-				"@types/lodash": "^4.14.118",
-				"@types/node": "^16.18.16",
-				"@types/ws": "^6.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1",
-				"ws": "^7.4.6"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@types/node": {
-			"version": "16.18.59",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.59.tgz",
-			"integrity": "sha512-PJ1w2cNeKUEdey4LiPra0ZuxZFOGvetswE8qHRriV/sUkL5Al4tTmPV9D2+Y/TPIxTHHgxTfRjZVKWhPw/ORhQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/ws": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@fluidframework/server-services-client": {
 			"version": "0.1036.5000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5000.tgz",
@@ -3845,323 +3906,6 @@
 			"version": "0.26.1",
 			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
 			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-1.0.1.tgz",
-			"integrity": "sha512-/Lb5ZZxb4aHtzLH3p+lrboi6TW/WD0I53di8FI4rMmn5AM7+h69BolPW7nume52t3HUi1I2Mnqhx1W8FKV8BbA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/nconf": "^0.10.2",
-				"@types/node": "^16.18.16",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"nconf": "^0.12.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@types/node": {
-			"version": "16.18.59",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.59.tgz",
-			"integrity": "sha512-PJ1w2cNeKUEdey4LiPra0ZuxZFOGvetswE8qHRriV/sUkL5Al4tTmPV9D2+Y/TPIxTHHgxTfRjZVKWhPw/ORhQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-1.0.1.tgz",
-			"integrity": "sha512-Z+IyqWHUk/y0aZ5cUXUoehcOiIr4qw1VkDR5i+1rnLntCRkPKk7h6FFXcWo+OBmI7D3AJOKZagMr6npezIPEmQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@socket.io/redis-adapter": "^7.2.0",
-				"body-parser": "^1.17.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"ioredis": "^5.2.3",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"notepack.io": "^2.3.0",
-				"querystring": "^0.2.0",
-				"serialize-error": "^8.1.0",
-				"socket.io": "^4.5.3",
-				"socket.io-adapter": "^2.4.0",
-				"socket.io-parser": "^4.2.1",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/@fluidframework/server-services-telemetry": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-1.0.1.tgz",
-			"integrity": "sha512-qeNtIr5mnkDS5hwD9t+2kcmsRK4zxdAtR+F0j0/rZ/pBWuaVmJI6YiKC5HzWTuszW5F1VDpGnul0M8HEWyhrgQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"path-browserify": "^1.0.1",
-				"serialize-error": "^8.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-1.0.1.tgz",
-			"integrity": "sha512-MzoonbJ/EQMbPi+m7/TZxWqyYzs1wxOdtN/Fe4FkaKOcHJjXR1e33iBw3YTkMQR9W8Z8E3WfSe6UVmzNDNH1TQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"debug": "^4.1.1",
-				"express": "^4.17.3",
-				"ioredis": "^5.2.3",
-				"json-stringify-safe": "^5.0.1",
-				"jsonwebtoken": "^9.0.0",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0",
-				"sillyname": "^0.1.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0",
-				"winston-transport": "^4.5.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-1.0.1.tgz",
-			"integrity": "sha512-+2ZP2pU4eq3KY5EySJhcwyAZqy9WojPhirA+fNUPKblT0fmeAn2ks6mF3d98fcxwqjMPb+5UPLRWDf7/+i1/Aw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"string-hash": "^1.1.3",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
 			"dependencies": {
 				"follow-redirects": "^1.14.8"
 			}
@@ -4363,12 +4107,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-			"dev": true
-		},
-		"node_modules/@ioredis/commands": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-			"integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
 			"dev": true
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
@@ -9515,15 +9253,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/denque": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-			"integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
 		"node_modules/depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -12705,30 +12434,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/ioredis": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
-			"integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
-			"dev": true,
-			"dependencies": {
-				"@ioredis/commands": "^1.1.1",
-				"cluster-key-slot": "^1.1.0",
-				"debug": "^4.3.4",
-				"denque": "^2.1.0",
-				"lodash.defaults": "^4.2.0",
-				"lodash.isarguments": "^3.1.0",
-				"redis-errors": "^1.2.0",
-				"redis-parser": "^3.0.0",
-				"standard-as-callback": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=12.22.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ioredis"
 			}
 		},
 		"node_modules/ip": {
@@ -17348,6 +17053,12 @@
 			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
 			"dev": true
 		},
+		"node_modules/lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+			"dev": true
+		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -18442,6 +18153,15 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/p-map": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/p-retry": {
@@ -22612,6 +22332,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/redis-commands": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
+			"dev": true
+		},
 		"node_modules/redis-errors": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
@@ -24810,113 +24536,6 @@
 			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
 			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
 			"dev": true
-		},
-		"node_modules/tinylicious": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-1.0.0.tgz",
-			"integrity": "sha512-ACL8mEKT5LPbFyAXCDjYWqi3vcNef7y2ABMnU3O4jK1cRuEn0MywH7ppMM5ZrMgtSMMsJAINcWxZjpq3ndH8hg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.0",
-				"@fluidframework/protocol-base": "^1.0.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.0",
-				"@fluidframework/server-local-server": "^1.0.0",
-				"@fluidframework/server-memory-orderer": "^1.0.0",
-				"@fluidframework/server-services-client": "^1.0.0",
-				"@fluidframework/server-services-core": "^1.0.0",
-				"@fluidframework/server-services-shared": "^1.0.0",
-				"@fluidframework/server-services-telemetry": "^1.0.0",
-				"@fluidframework/server-services-utils": "^1.0.0",
-				"@fluidframework/server-test-utils": "^1.0.0",
-				"agentkeepalive": "^4.2.1",
-				"axios": "^0.26.0",
-				"body-parser": "^1.17.1",
-				"charwise": "^3.0.1",
-				"compression": "^1.7.2",
-				"cookie-parser": "^1.4.3",
-				"cors": "^2.8.4",
-				"detect-port": "^1.3.0",
-				"express": "^4.17.3",
-				"isomorphic-git": "^1.8.2",
-				"json-stringify-safe": "^5.0.1",
-				"level": "^8.0.0",
-				"level-sublevel": "6.6.4",
-				"lodash": "^4.17.21",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"socket.io": "^4.5.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.2",
-				"winston": "^3.6.0"
-			},
-			"bin": {
-				"tinylicious": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/tinylicious/node_modules/axios": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.8"
-			}
-		},
-		"node_modules/tinylicious/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
 		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",

--- a/brainstorm/package.json
+++ b/brainstorm/package.json
@@ -17,7 +17,7 @@
 		"ci:test:jest": "jest --ci --reporters=default --reporters=jest-junit",
 		"eject": "react-scripts eject",
 		"start": "react-scripts start",
-		"start:server": "npx @fluidframework/azure-local-service",
+		"start:server": "npx tinylicious",
 		"start:azure": "cross-env REACT_APP_FLUID_CLIENT='\"azure\"' npm run start",
 		"test": "start-server-and-test start:server 7070 test:jest",
 		"test:jest": "jest",
@@ -67,7 +67,6 @@
 		"uuid": "^8.3.2"
 	},
 	"devDependencies": {
-		"@fluidframework/azure-local-service": "^1.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@testing-library/jest-dom": "^5.11.4",
 		"@testing-library/react": "^11.1.0",
@@ -83,6 +82,7 @@
 		"puppeteer": "^21.0.0",
 		"react-scripts": "^5.0.1",
 		"start-server-and-test": "^2.0.0",
+		"tinylicious": "^1.0.0",
 		"typescript": "~4.5.5"
 	},
 	"jest-junit": {

--- a/brainstorm/package.json
+++ b/brainstorm/package.json
@@ -67,7 +67,6 @@
 		"uuid": "^8.3.2"
 	},
 	"devDependencies": {
-		"@fluidframework/azure-local-service": "^1.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@testing-library/jest-dom": "^5.11.4",
 		"@testing-library/react": "^11.1.0",

--- a/brainstorm/package.json
+++ b/brainstorm/package.json
@@ -17,7 +17,7 @@
 		"ci:test:jest": "jest --ci --reporters=default --reporters=jest-junit",
 		"eject": "react-scripts eject",
 		"start": "react-scripts start",
-		"start:server": "npx tinylicious",
+		"start:server": "npx @fluidframework/azure-local-service",
 		"start:azure": "cross-env REACT_APP_FLUID_CLIENT='\"azure\"' npm run start",
 		"test": "start-server-and-test start:server 7070 test:jest",
 		"test:jest": "jest",
@@ -67,6 +67,7 @@
 		"uuid": "^8.3.2"
 	},
 	"devDependencies": {
+		"@fluidframework/azure-local-service": "^1.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@testing-library/jest-dom": "^5.11.4",
 		"@testing-library/react": "^11.1.0",
@@ -82,7 +83,6 @@
 		"puppeteer": "^21.0.0",
 		"react-scripts": "^5.0.1",
 		"start-server-and-test": "^2.0.0",
-		"tinylicious": "^1.0.0",
 		"typescript": "~4.5.5"
 	},
 	"jest-junit": {

--- a/collaborative-text-area/README.md
+++ b/collaborative-text-area/README.md
@@ -30,10 +30,10 @@ For a more detailed explanation of this example please click [here](https://flui
 
 ### Run the app locally
 
-To run our local server, Tinylicious, on the default URL of `localhost:7070`, enter the following into a terminal window:
+To run our local server, `@fluidframework/azure-local-service`, on the default URL of `localhost:7070`, enter the following into a terminal window:
 
 ```
-npx tinylicious
+npx @fluidframework/azure-local-service
 ```
 
 Now, with our local service running in the background, we need to connect the application to it.

--- a/collaborative-text-area/package-lock.json
+++ b/collaborative-text-area/package-lock.json
@@ -17,6 +17,7 @@
 				"react-dom": "^17.0.2"
 			},
 			"devDependencies": {
+				"@fluidframework/azure-local-service": "^1.1.0",
 				"@fluidframework/build-common": "^2.0.0",
 				"@testing-library/react": "^11.2.7",
 				"@testing-library/user-event": "^12.8.3",
@@ -29,7 +30,6 @@
 				"puppeteer": "^21.0.0",
 				"react-scripts": "^5.0.1",
 				"start-server-and-test": "^2.0.0",
-				"tinylicious": "^1.0.0",
 				"typescript": "^4.5.5"
 			},
 			"engines": {
@@ -2518,6 +2518,421 @@
 				"uuid": "^8.3.1"
 			}
 		},
+		"node_modules/@fluidframework/azure-local-service": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-1.1.1.tgz",
+			"integrity": "sha512-gvk+qy8RytXBQaZ554OREszHGN73W3FmgpfwV+aXeOOP5RWLMPSvkPoac5K9gcUYN+nAFbRs517c055yucP9ug==",
+			"dev": true,
+			"dependencies": {
+				"tinylicious": "^0.4.89251"
+			},
+			"bin": {
+				"azure-local-service": "dist/index.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/common-utils": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@types/events": "^3.0.0",
+				"base64-js": "^1.5.1",
+				"buffer": "^6.0.3",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sha.js": "^2.4.11"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/gitresources": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
+			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-base": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
+			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-definitions": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.4001.tgz",
+			"integrity": "sha512-rERfgXK5DXGJvxADjotkAZssKgp3ZxW6u7yUekrDnFDkXtbCW1Gcq+EwvjHTEyhsOp30YBnD0Z39xnZy4zEZRw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas-driver": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/semver": "^6.0.1",
+				"assert": "^2.0.0",
+				"async": "^3.2.2",
+				"axios": "^0.26.0",
+				"buffer": "^6.0.3",
+				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
+				"json-stringify-safe": "^5.0.1",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"semver": "^6.3.0",
+				"sha.js": "^2.4.11",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas-driver": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.4001.tgz",
+			"integrity": "sha512-qRs+vMbSS9aPx7vr3XemvER5DeY/nsJ5ZkcL3UDjUOxvLZxbOAD6C6JeH3Zgzc/jc8bqshcxai/u7qso2zCsFw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"assert": "^2.0.0",
+				"async": "^3.2.2",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-local-server": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.4001.tgz",
+			"integrity": "sha512-FIlNUc9Ncul/5qzP+VyU53TJj8fxX7KZ1lweswZYalleRZwiqFA4Y+NbWRRWM0iJ1z8hvhyRZblG3iNrpGl04A==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^0.1038.4001",
+				"@fluidframework/server-memory-orderer": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@fluidframework/server-test-utils": "^0.1038.4001",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"jsrsasign": "^10.5.25",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-memory-orderer": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.4001.tgz",
+			"integrity": "sha512-fdzTCLFRh8QfyY17MnB22/o8x2XEX1+wZrm+dn+1Av+ZVe/+ZhfdX5LsQCMKYv+X5mgAauNmC/12mQE4H6jvsQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/debug": "^4.1.5",
+				"@types/double-ended-queue": "^2.1.0",
+				"@types/lodash": "^4.14.118",
+				"@types/node": "^14.18.0",
+				"@types/ws": "^6.0.1",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1",
+				"ws": "^7.4.6"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-client": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
+			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"axios": "^0.26.0",
+				"crc-32": "1.2.0",
+				"debug": "^4.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"jsrsasign": "^10.5.25",
+				"jwt-decode": "^3.0.0",
+				"querystring": "^0.2.0",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-core": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.4001.tgz",
+			"integrity": "sha512-nuZ9ebvyeIoRdlpQQpBNGkawKtc2/tHKbc8CHbMZRMh7F7kwYUtoHd/J8powb9eUcg5IHDmXx1l+PQRbQX4vCg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/nconf": "^0.10.2",
+				"@types/node": "^14.18.0",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"nconf": "^0.12.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-shared": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.4001.tgz",
+			"integrity": "sha512-vDRB2G/Xnuhan+Ri0Eg5JMKfsm7hxstCXdEyQhzJzC7+bw66wts+ZIsEsn4Ha/3KkxblF/RSW3lBhrYpxii3cQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@socket.io/redis-adapter": "^7.2.0",
+				"body-parser": "^1.17.1",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"ioredis": "^4.24.2",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"notepack.io": "^2.3.0",
+				"querystring": "^0.2.0",
+				"socket.io": "^4.5.3",
+				"socket.io-adapter": "^2.4.0",
+				"socket.io-parser": "^4.2.1",
+				"uuid": "^8.3.1",
+				"winston": "^3.6.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-telemetry": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.4001.tgz",
+			"integrity": "sha512-2leJhB04+71RTmC5ShRXm/4FWng9tLn9dlrUAjApZH4RlUJAx1JGsvo/5JU1tIbpUutMHUle2IpWyfu/RV+S5g==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"path-browserify": "^1.0.1",
+				"serialize-error": "^8.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-utils": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.4001.tgz",
+			"integrity": "sha512-K7X/0mlonDAu0pPIgTz8U9nLwRSbJY2oBpFPwpkp1UtE6SU02jx2ZzraT9epDmOl3EXeS1rHzA+mbvBSe1aFMg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"debug": "^4.1.1",
+				"express": "^4.17.3",
+				"ioredis": "^4.24.2",
+				"json-stringify-safe": "^5.0.1",
+				"jsonwebtoken": "^9.0.0",
+				"morgan": "^1.8.1",
+				"nconf": "^0.12.0",
+				"serialize-error": "^8.1.0",
+				"sillyname": "^0.1.0",
+				"split": "^1.0.0",
+				"uuid": "^8.3.1",
+				"winston": "^3.6.0",
+				"winston-transport": "^4.5.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-test-utils": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.4001.tgz",
+			"integrity": "sha512-qrLp5H1UUPIJSEHlzZ1iYlPFJCQrd2WnmoafxnQIg0mfU1ZE8XUlG5MKUg8bT9pWsCoEGJDiOkkRHaq+WXupjQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"string-hash": "^1.1.3",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@types/node": {
+			"version": "14.18.63",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@types/semver": {
+			"version": "6.2.5",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.5.tgz",
+			"integrity": "sha512-NAxro9/RqWXTqdSjccDZAjA4nXK+6zRun+HvibYJfGy8TQhpOC7Vv6v2rlHYKrT0Q8jGGoNRd/xVdHRIQRNlFQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/denque": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/ioredis": {
+			"version": "4.28.5",
+			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
+			"integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+			"dev": true,
+			"dependencies": {
+				"cluster-key-slot": "^1.1.0",
+				"debug": "^4.3.1",
+				"denque": "^1.1.0",
+				"lodash.defaults": "^4.2.0",
+				"lodash.flatten": "^4.4.0",
+				"lodash.isarguments": "^3.1.0",
+				"p-map": "^2.1.0",
+				"redis-commands": "1.7.0",
+				"redis-errors": "^1.2.0",
+				"redis-parser": "^3.0.0",
+				"standard-as-callback": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ioredis"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/split": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"dev": true,
+			"dependencies": {
+				"through": "2"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/tinylicious": {
+			"version": "0.4.94771",
+			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
+			"integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.0.0",
+				"@fluidframework/gitresources": "^0.1038.1000",
+				"@fluidframework/protocol-base": "^0.1038.1000",
+				"@fluidframework/protocol-definitions": "^1.0.0",
+				"@fluidframework/server-lambdas": "^0.1038.1000",
+				"@fluidframework/server-local-server": "^0.1038.1000",
+				"@fluidframework/server-memory-orderer": "^0.1038.1000",
+				"@fluidframework/server-services-client": "^0.1038.1000",
+				"@fluidframework/server-services-core": "^0.1038.1000",
+				"@fluidframework/server-services-shared": "^0.1038.1000",
+				"@fluidframework/server-services-telemetry": "^0.1038.1000",
+				"@fluidframework/server-services-utils": "^0.1038.1000",
+				"@fluidframework/server-test-utils": "^0.1038.1000",
+				"agentkeepalive": "^4.2.1",
+				"axios": "^0.26.0",
+				"body-parser": "^1.17.1",
+				"charwise": "^3.0.1",
+				"compression": "^1.7.2",
+				"cookie-parser": "^1.4.3",
+				"cors": "^2.8.4",
+				"detect-port": "^1.3.0",
+				"express": "^4.16.3",
+				"isomorphic-git": "^1.8.2",
+				"json-stringify-safe": "^5.0.1",
+				"level": "^8.0.0",
+				"level-sublevel": "6.6.4",
+				"lodash": "^4.17.21",
+				"morgan": "^1.8.1",
+				"nconf": "^0.12.0",
+				"socket.io": "^4.5.0",
+				"split": "^1.0.0",
+				"uuid": "^8.3.2",
+				"winston": "^3.6.0"
+			},
+			"bin": {
+				"tinylicious": "dist/index.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/ws": {
+			"version": "7.5.9",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.3.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@fluidframework/build-common": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.0.tgz",
@@ -2900,381 +3315,6 @@
 				"uuid": "^8.3.1"
 			}
 		},
-		"node_modules/@fluidframework/server-lambdas": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-1.0.1.tgz",
-			"integrity": "sha512-lwVKg4dVDvbNH4ckj328z5cNu1plHhArzIMP3kpl8T94L6OubqsJ8vf3g46Wab/SjwltHC41p/wWigJapXZjqA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas-driver": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/semver": "^7.5.0",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"axios": "^0.26.0",
-				"buffer": "^6.0.3",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"semver": "^7.5.3",
-				"sha.js": "^2.4.11",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-1.0.1.tgz",
-			"integrity": "sha512-TfQ7rz2/6pW6Rq5CbGBu9ShiSKyOHg2pXX0cUVHtnuuUPsWTxQDWlVilYukyG0uxHJfE3ZDU3R1QgnWUQQmGgg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-1.0.1.tgz",
-			"integrity": "sha512-494H0PYNa6aqngyq/M46K7wlY7NHdIx1B4qcfRCRQmjJZrD9GPza3FHt2/426teBQ93F6SOKkBrMw2vbmoUUGg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.1",
-				"@fluidframework/server-memory-orderer": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@fluidframework/server-test-utils": "^1.0.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"jsrsasign": "^10.5.25",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-1.0.1.tgz",
-			"integrity": "sha512-zUuNICwyKC7OTSl/W9MSiwplSccnRHVmRpdxImCe5qVs+VSK1jHuIGiIzCkt6dlVNMu3WHyUXmrKCLmhJZmFeQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/debug": "^4.1.5",
-				"@types/double-ended-queue": "^2.1.0",
-				"@types/lodash": "^4.14.118",
-				"@types/node": "^16.18.16",
-				"@types/ws": "^6.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1",
-				"ws": "^7.4.6"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@types/node": {
-			"version": "16.18.51",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.51.tgz",
-			"integrity": "sha512-LKA7ZhY30I8PiUOzBzhtnIULQTACpiEpPXLiYMWyS+tPAORf+rmXUadHZXB/KFrFyMjeHeKc1GFvLd+3f7LE3w==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/ws": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@fluidframework/server-services-client": {
 			"version": "0.1036.5001",
 			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5001.tgz",
@@ -3289,398 +3329,6 @@
 				"debug": "^4.1.1",
 				"json-stringify-safe": "^5.0.1",
 				"jsrsasign": "^10.2.0",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-1.0.1.tgz",
-			"integrity": "sha512-/Lb5ZZxb4aHtzLH3p+lrboi6TW/WD0I53di8FI4rMmn5AM7+h69BolPW7nume52t3HUi1I2Mnqhx1W8FKV8BbA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/nconf": "^0.10.2",
-				"@types/node": "^16.18.16",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"nconf": "^0.12.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@types/node": {
-			"version": "16.18.51",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.51.tgz",
-			"integrity": "sha512-LKA7ZhY30I8PiUOzBzhtnIULQTACpiEpPXLiYMWyS+tPAORf+rmXUadHZXB/KFrFyMjeHeKc1GFvLd+3f7LE3w==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-shared": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-1.0.1.tgz",
-			"integrity": "sha512-Z+IyqWHUk/y0aZ5cUXUoehcOiIr4qw1VkDR5i+1rnLntCRkPKk7h6FFXcWo+OBmI7D3AJOKZagMr6npezIPEmQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@socket.io/redis-adapter": "^7.2.0",
-				"body-parser": "^1.17.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"ioredis": "^5.2.3",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"notepack.io": "^2.3.0",
-				"querystring": "^0.2.0",
-				"serialize-error": "^8.1.0",
-				"socket.io": "^4.5.3",
-				"socket.io-adapter": "^2.4.0",
-				"socket.io-parser": "^4.2.1",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-telemetry": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-1.0.1.tgz",
-			"integrity": "sha512-qeNtIr5mnkDS5hwD9t+2kcmsRK4zxdAtR+F0j0/rZ/pBWuaVmJI6YiKC5HzWTuszW5F1VDpGnul0M8HEWyhrgQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"path-browserify": "^1.0.1",
-				"serialize-error": "^8.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-telemetry/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-1.0.1.tgz",
-			"integrity": "sha512-MzoonbJ/EQMbPi+m7/TZxWqyYzs1wxOdtN/Fe4FkaKOcHJjXR1e33iBw3YTkMQR9W8Z8E3WfSe6UVmzNDNH1TQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"debug": "^4.1.1",
-				"express": "^4.17.3",
-				"ioredis": "^5.2.3",
-				"json-stringify-safe": "^5.0.1",
-				"jsonwebtoken": "^9.0.0",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0",
-				"sillyname": "^0.1.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0",
-				"winston-transport": "^4.5.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-1.0.1.tgz",
-			"integrity": "sha512-+2ZP2pU4eq3KY5EySJhcwyAZqy9WojPhirA+fNUPKblT0fmeAn2ks6mF3d98fcxwqjMPb+5UPLRWDf7/+i1/Aw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"string-hash": "^1.1.3",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
 				"jwt-decode": "^3.0.0",
 				"querystring": "^0.2.0",
 				"sillyname": "^0.1.0",
@@ -3816,12 +3464,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-			"dev": true
-		},
-		"node_modules/@ioredis/commands": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-			"integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
 			"dev": true
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
@@ -9849,15 +9491,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/denque": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-			"integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
 		"node_modules/depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -9900,6 +9533,20 @@
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
+		},
+		"node_modules/detect-port": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
+			"integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
+			"dev": true,
+			"dependencies": {
+				"address": "^1.0.1",
+				"debug": "4"
+			},
+			"bin": {
+				"detect": "bin/detect-port.js",
+				"detect-port": "bin/detect-port.js"
+			}
 		},
 		"node_modules/detect-port-alt": {
 			"version": "1.1.6",
@@ -13007,30 +12654,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/ioredis": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
-			"integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
-			"dev": true,
-			"dependencies": {
-				"@ioredis/commands": "^1.1.1",
-				"cluster-key-slot": "^1.1.0",
-				"debug": "^4.3.4",
-				"denque": "^2.1.0",
-				"lodash.defaults": "^4.2.0",
-				"lodash.isarguments": "^3.1.0",
-				"redis-errors": "^1.2.0",
-				"redis-parser": "^3.0.0",
-				"standard-as-callback": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=12.22.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ioredis"
 			}
 		},
 		"node_modules/ip": {
@@ -17784,6 +17407,12 @@
 			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
 			"dev": true
 		},
+		"node_modules/lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+			"dev": true
+		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -18857,6 +18486,15 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/p-map": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/p-retry": {
@@ -21933,6 +21571,12 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/redis-commands": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
+			"dev": true
+		},
 		"node_modules/redis-errors": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
@@ -24073,142 +23717,6 @@
 			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
 			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
 			"dev": true
-		},
-		"node_modules/tinylicious": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-1.0.0.tgz",
-			"integrity": "sha512-ACL8mEKT5LPbFyAXCDjYWqi3vcNef7y2ABMnU3O4jK1cRuEn0MywH7ppMM5ZrMgtSMMsJAINcWxZjpq3ndH8hg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.0",
-				"@fluidframework/protocol-base": "^1.0.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.0",
-				"@fluidframework/server-local-server": "^1.0.0",
-				"@fluidframework/server-memory-orderer": "^1.0.0",
-				"@fluidframework/server-services-client": "^1.0.0",
-				"@fluidframework/server-services-core": "^1.0.0",
-				"@fluidframework/server-services-shared": "^1.0.0",
-				"@fluidframework/server-services-telemetry": "^1.0.0",
-				"@fluidframework/server-services-utils": "^1.0.0",
-				"@fluidframework/server-test-utils": "^1.0.0",
-				"agentkeepalive": "^4.2.1",
-				"axios": "^0.26.0",
-				"body-parser": "^1.17.1",
-				"charwise": "^3.0.1",
-				"compression": "^1.7.2",
-				"cookie-parser": "^1.4.3",
-				"cors": "^2.8.4",
-				"detect-port": "^1.3.0",
-				"express": "^4.17.3",
-				"isomorphic-git": "^1.8.2",
-				"json-stringify-safe": "^5.0.1",
-				"level": "^8.0.0",
-				"level-sublevel": "6.6.4",
-				"lodash": "^4.17.21",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"socket.io": "^4.5.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.2",
-				"winston": "^3.6.0"
-			},
-			"bin": {
-				"tinylicious": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/tinylicious/node_modules/detect-port": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
-			"integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
-			"dev": true,
-			"dependencies": {
-				"address": "^1.0.1",
-				"debug": "4"
-			},
-			"bin": {
-				"detect": "bin/detect-port.js",
-				"detect-port": "bin/detect-port.js"
-			}
-		},
-		"node_modules/tinylicious/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
 		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",

--- a/collaborative-text-area/package-lock.json
+++ b/collaborative-text-area/package-lock.json
@@ -17,7 +17,6 @@
 				"react-dom": "^17.0.2"
 			},
 			"devDependencies": {
-				"@fluidframework/azure-local-service": "^1.1.0",
 				"@fluidframework/build-common": "^2.0.0",
 				"@testing-library/react": "^11.2.7",
 				"@testing-library/user-event": "^12.8.3",
@@ -2074,15 +2073,6 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
 		},
-		"node_modules/@colors/colors": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.1.90"
-			}
-		},
 		"node_modules/@csstools/normalize.css": {
 			"version": "12.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
@@ -2369,17 +2359,6 @@
 				"postcss-selector-parser": "^6.0.10"
 			}
 		},
-		"node_modules/@dabh/diagnostics": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-			"integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
-			"dev": true,
-			"dependencies": {
-				"colorspace": "1.1.x",
-				"enabled": "2.0.x",
-				"kuler": "^2.0.0"
-			}
-		},
 		"node_modules/@eslint-community/eslint-utils": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -2516,421 +2495,6 @@
 				"@fluidframework/synthesize": "^1.3.7",
 				"@fluidframework/view-interfaces": "^1.3.7",
 				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-1.1.1.tgz",
-			"integrity": "sha512-gvk+qy8RytXBQaZ554OREszHGN73W3FmgpfwV+aXeOOP5RWLMPSvkPoac5K9gcUYN+nAFbRs517c055yucP9ug==",
-			"dev": true,
-			"dependencies": {
-				"tinylicious": "^0.4.89251"
-			},
-			"bin": {
-				"azure-local-service": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
-			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
-			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.4001.tgz",
-			"integrity": "sha512-rERfgXK5DXGJvxADjotkAZssKgp3ZxW6u7yUekrDnFDkXtbCW1Gcq+EwvjHTEyhsOp30YBnD0Z39xnZy4zEZRw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas-driver": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/semver": "^6.0.1",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"axios": "^0.26.0",
-				"buffer": "^6.0.3",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"semver": "^6.3.0",
-				"sha.js": "^2.4.11",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas-driver": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.4001.tgz",
-			"integrity": "sha512-qRs+vMbSS9aPx7vr3XemvER5DeY/nsJ5ZkcL3UDjUOxvLZxbOAD6C6JeH3Zgzc/jc8bqshcxai/u7qso2zCsFw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-local-server": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.4001.tgz",
-			"integrity": "sha512-FIlNUc9Ncul/5qzP+VyU53TJj8fxX7KZ1lweswZYalleRZwiqFA4Y+NbWRRWM0iJ1z8hvhyRZblG3iNrpGl04A==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.4001",
-				"@fluidframework/server-memory-orderer": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@fluidframework/server-test-utils": "^0.1038.4001",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"jsrsasign": "^10.5.25",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-memory-orderer": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.4001.tgz",
-			"integrity": "sha512-fdzTCLFRh8QfyY17MnB22/o8x2XEX1+wZrm+dn+1Av+ZVe/+ZhfdX5LsQCMKYv+X5mgAauNmC/12mQE4H6jvsQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/debug": "^4.1.5",
-				"@types/double-ended-queue": "^2.1.0",
-				"@types/lodash": "^4.14.118",
-				"@types/node": "^14.18.0",
-				"@types/ws": "^6.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1",
-				"ws": "^7.4.6"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
-			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-core": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.4001.tgz",
-			"integrity": "sha512-nuZ9ebvyeIoRdlpQQpBNGkawKtc2/tHKbc8CHbMZRMh7F7kwYUtoHd/J8powb9eUcg5IHDmXx1l+PQRbQX4vCg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/nconf": "^0.10.2",
-				"@types/node": "^14.18.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"nconf": "^0.12.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-shared": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.4001.tgz",
-			"integrity": "sha512-vDRB2G/Xnuhan+Ri0Eg5JMKfsm7hxstCXdEyQhzJzC7+bw66wts+ZIsEsn4Ha/3KkxblF/RSW3lBhrYpxii3cQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@socket.io/redis-adapter": "^7.2.0",
-				"body-parser": "^1.17.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"ioredis": "^4.24.2",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"notepack.io": "^2.3.0",
-				"querystring": "^0.2.0",
-				"socket.io": "^4.5.3",
-				"socket.io-adapter": "^2.4.0",
-				"socket.io-parser": "^4.2.1",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-telemetry": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.4001.tgz",
-			"integrity": "sha512-2leJhB04+71RTmC5ShRXm/4FWng9tLn9dlrUAjApZH4RlUJAx1JGsvo/5JU1tIbpUutMHUle2IpWyfu/RV+S5g==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"path-browserify": "^1.0.1",
-				"serialize-error": "^8.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-utils": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.4001.tgz",
-			"integrity": "sha512-K7X/0mlonDAu0pPIgTz8U9nLwRSbJY2oBpFPwpkp1UtE6SU02jx2ZzraT9epDmOl3EXeS1rHzA+mbvBSe1aFMg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"debug": "^4.1.1",
-				"express": "^4.17.3",
-				"ioredis": "^4.24.2",
-				"json-stringify-safe": "^5.0.1",
-				"jsonwebtoken": "^9.0.0",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0",
-				"sillyname": "^0.1.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0",
-				"winston-transport": "^4.5.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-test-utils": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.4001.tgz",
-			"integrity": "sha512-qrLp5H1UUPIJSEHlzZ1iYlPFJCQrd2WnmoafxnQIg0mfU1ZE8XUlG5MKUg8bT9pWsCoEGJDiOkkRHaq+WXupjQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"string-hash": "^1.1.3",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@types/node": {
-			"version": "14.18.63",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@types/semver": {
-			"version": "6.2.5",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.5.tgz",
-			"integrity": "sha512-NAxro9/RqWXTqdSjccDZAjA4nXK+6zRun+HvibYJfGy8TQhpOC7Vv6v2rlHYKrT0Q8jGGoNRd/xVdHRIQRNlFQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/denque": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/ioredis": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
-			"integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
-			"dev": true,
-			"dependencies": {
-				"cluster-key-slot": "^1.1.0",
-				"debug": "^4.3.1",
-				"denque": "^1.1.0",
-				"lodash.defaults": "^4.2.0",
-				"lodash.flatten": "^4.4.0",
-				"lodash.isarguments": "^3.1.0",
-				"p-map": "^2.1.0",
-				"redis-commands": "1.7.0",
-				"redis-errors": "^1.2.0",
-				"redis-parser": "^3.0.0",
-				"standard-as-callback": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ioredis"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/tinylicious": {
-			"version": "0.4.94771",
-			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
-			"integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.1000",
-				"@fluidframework/protocol-base": "^0.1038.1000",
-				"@fluidframework/protocol-definitions": "^1.0.0",
-				"@fluidframework/server-lambdas": "^0.1038.1000",
-				"@fluidframework/server-local-server": "^0.1038.1000",
-				"@fluidframework/server-memory-orderer": "^0.1038.1000",
-				"@fluidframework/server-services-client": "^0.1038.1000",
-				"@fluidframework/server-services-core": "^0.1038.1000",
-				"@fluidframework/server-services-shared": "^0.1038.1000",
-				"@fluidframework/server-services-telemetry": "^0.1038.1000",
-				"@fluidframework/server-services-utils": "^0.1038.1000",
-				"@fluidframework/server-test-utils": "^0.1038.1000",
-				"agentkeepalive": "^4.2.1",
-				"axios": "^0.26.0",
-				"body-parser": "^1.17.1",
-				"charwise": "^3.0.1",
-				"compression": "^1.7.2",
-				"cookie-parser": "^1.4.3",
-				"cors": "^2.8.4",
-				"detect-port": "^1.3.0",
-				"express": "^4.16.3",
-				"isomorphic-git": "^1.8.2",
-				"json-stringify-safe": "^5.0.1",
-				"level": "^8.0.0",
-				"level-sublevel": "6.6.4",
-				"lodash": "^4.17.21",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"socket.io": "^4.5.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.2",
-				"winston": "^3.6.0"
-			},
-			"bin": {
-				"tinylicious": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/ws": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@fluidframework/build-common": {
@@ -5720,27 +5284,6 @@
 			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
 			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
 		},
-		"node_modules/@socket.io/redis-adapter": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-7.2.0.tgz",
-			"integrity": "sha512-/r6oF6Myz0K9uatB/pfCi0BhKg/KRMh1OokrqcjlNz6aq40WiXdFLRbHJQuwGHq/KvB+D6141K+IynbVxZGvhw==",
-			"dev": true,
-			"dependencies": {
-				"debug": "~4.3.1",
-				"notepack.io": "~2.2.0",
-				"socket.io-adapter": "^2.4.0",
-				"uid2": "0.0.3"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/@socket.io/redis-adapter/node_modules/notepack.io": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.2.0.tgz",
-			"integrity": "sha512-9b5w3t5VSH6ZPosoYnyDONnUTF8o0UkBw7JLA6eBlYJWyGT1Q3vQa8Hmuj1/X6RYvHjjygBDgw6fJhe0JEojfw==",
-			"dev": true
-		},
 		"node_modules/@surma/rollup-plugin-off-main-thread": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -6135,36 +5678,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/cookie": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-			"integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-			"dev": true
-		},
-		"node_modules/@types/cors": {
-			"version": "2.8.14",
-			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.14.tgz",
-			"integrity": "sha512-RXHUvNWYICtbP6s18PnOCaqToK8y14DnLd75c6HfyKf228dxy7pHNOQkxPtvXKp/hINFMDjbYzsj63nnpPMSRQ==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@types/debug": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
-			"integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
-			"dev": true,
-			"dependencies": {
-				"@types/ms": "*"
-			}
-		},
-		"node_modules/@types/double-ended-queue": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@types/double-ended-queue/-/double-ended-queue-2.1.3.tgz",
-			"integrity": "sha512-PWBSlai2jeSM3xOlr4JPI0oDiGFLVkVvylJ1nK1+oK9V/RiBIqDy8vCtsk+gOQN/I1gU6O1cR1OHheBanFdbCQ==",
-			"dev": true
-		},
 		"node_modules/@types/eslint": {
 			"version": "8.44.2",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.2.tgz",
@@ -6286,28 +5799,10 @@
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
 		},
-		"node_modules/@types/lodash": {
-			"version": "4.14.198",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.198.tgz",
-			"integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg==",
-			"dev": true
-		},
 		"node_modules/@types/mime": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
 			"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-			"dev": true
-		},
-		"node_modules/@types/ms": {
-			"version": "0.7.31",
-			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
-			"dev": true
-		},
-		"node_modules/@types/nconf": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.3.tgz",
-			"integrity": "sha512-leyIuBk/rMIp9114FlPRkc/cQG+/JzCz1Afx3BD+CwK2ep3ZRxoC843V1rqnE2pC/jRRjANWhuVBEn4clCwlug==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -6444,26 +5939,11 @@
 			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
 			"dev": true
 		},
-		"node_modules/@types/triple-beam": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.3.tgz",
-			"integrity": "sha512-6tOUG+nVHn0cJbVp25JFayS5UE6+xlbcNF9Lo9mU7U0zk3zeUShZied4YEQZjy1JBF043FSkdXw8YkUJuVtB5g==",
-			"dev": true
-		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.4.tgz",
 			"integrity": "sha512-IDaobHimLQhjwsQ/NMwRVfa/yL7L/wriQPMhw1ZJall0KX6E1oxk29XMDeilW5qTIg5aoiqf5Udy8U/51aNoQQ==",
 			"dev": true
-		},
-		"node_modules/@types/ws": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
-			"integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
 		},
 		"node_modules/@types/yargs": {
 			"version": "15.0.14",
@@ -6894,47 +6374,6 @@
 				"node": ">=6.5"
 			}
 		},
-		"node_modules/abstract-level": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
-			"integrity": "sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^6.0.3",
-				"catering": "^2.1.0",
-				"is-buffer": "^2.0.5",
-				"level-supports": "^4.0.0",
-				"level-transcoder": "^1.0.1",
-				"module-error": "^1.0.1",
-				"queue-microtask": "^1.2.3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/abstract-level/node_modules/is-buffer": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -7041,29 +6480,6 @@
 			},
 			"engines": {
 				"node": ">= 14"
-			}
-		},
-		"node_modules/agentkeepalive": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
-			"integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
-			"dev": true,
-			"dependencies": {
-				"debug": "^4.1.0",
-				"depd": "^1.1.2",
-				"humanize-ms": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 8.0.0"
-			}
-		},
-		"node_modules/agentkeepalive/node_modules/depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/ajv": {
@@ -7398,19 +6814,6 @@
 			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
 			"dev": true
 		},
-		"node_modules/assert": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
-			"integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"is-nan": "^1.3.2",
-				"object-is": "^1.1.5",
-				"object.assign": "^4.1.4",
-				"util": "^0.12.5"
-			}
-		},
 		"node_modules/ast-types": {
 			"version": "0.13.4",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -7433,12 +6836,6 @@
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
 			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-			"dev": true
-		},
-		"node_modules/async-lock": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz",
-			"integrity": "sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ==",
 			"dev": true
 		},
 		"node_modules/asynciterator.prototype": {
@@ -7827,33 +7224,6 @@
 				}
 			]
 		},
-		"node_modules/base64id": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-			"integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-			"dev": true,
-			"engines": {
-				"node": "^4.5.0 || >= 5.9"
-			}
-		},
-		"node_modules/basic-auth": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-			"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "5.1.2"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/basic-auth/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
 		"node_modules/basic-ftp": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
@@ -7908,66 +7278,6 @@
 			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
 			"dev": true
 		},
-		"node_modules/body-parser": {
-			"version": "1.20.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-			"integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
-			"dev": true,
-			"dependencies": {
-				"bytes": "3.1.2",
-				"content-type": "~1.0.5",
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"destroy": "1.2.0",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"on-finished": "2.4.1",
-				"qs": "6.11.0",
-				"raw-body": "2.5.2",
-				"type-is": "~1.6.18",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8",
-				"npm": "1.2.8000 || >= 1.4.16"
-			}
-		},
-		"node_modules/body-parser/node_modules/bytes": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/body-parser/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/body-parser/node_modules/iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/body-parser/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true
-		},
 		"node_modules/bonjour-service": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.1.tgz",
@@ -8012,18 +7322,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/browser-level": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
-			"integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
-			"dev": true,
-			"dependencies": {
-				"abstract-level": "^1.0.2",
-				"catering": "^2.1.1",
-				"module-error": "^1.0.2",
-				"run-parallel-limit": "^1.1.0"
 			}
 		},
 		"node_modules/browser-process-hrtime": {
@@ -8105,12 +7403,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/buffer-equal-constant-time": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-			"dev": true
-		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -8136,25 +7428,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/bytewise": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-			"integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
-			"dev": true,
-			"dependencies": {
-				"bytewise-core": "^1.2.2",
-				"typewise": "^1.0.3"
-			}
-		},
-		"node_modules/bytewise-core": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-			"integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
-			"dev": true,
-			"dependencies": {
-				"typewise-core": "^1.2"
 			}
 		},
 		"node_modules/call-bind": {
@@ -8250,15 +7523,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/catering": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
-			"integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -8337,12 +7601,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/charwise": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz",
-			"integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw==",
-			"dev": true
 		},
 		"node_modules/check-more-types": {
 			"version": "2.24.0",
@@ -8440,23 +7698,6 @@
 			"integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
 			"dev": true
 		},
-		"node_modules/classic-level": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.2.0.tgz",
-			"integrity": "sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"dependencies": {
-				"abstract-level": "^1.0.2",
-				"catering": "^2.1.0",
-				"module-error": "^1.0.1",
-				"napi-macros": "~2.0.0",
-				"node-gyp-build": "^4.3.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/clean-css": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
@@ -8468,12 +7709,6 @@
 			"engines": {
 				"node": ">= 10.0"
 			}
-		},
-		"node_modules/clean-git-ref": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
-			"integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
-			"dev": true
 		},
 		"node_modules/cliui": {
 			"version": "8.0.1",
@@ -8487,15 +7722,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/cluster-key-slot": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
-			"integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/co": {
@@ -8542,16 +7768,6 @@
 			"integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
 			"dev": true
 		},
-		"node_modules/color": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^1.9.3",
-				"color-string": "^1.6.0"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -8567,16 +7783,6 @@
 			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
 			"dev": true
 		},
-		"node_modules/color-string": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
-		},
 		"node_modules/colord": {
 			"version": "2.9.3",
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
@@ -8588,16 +7794,6 @@
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
 			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
 			"dev": true
-		},
-		"node_modules/colorspace": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-			"integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-			"dev": true,
-			"dependencies": {
-				"color": "^3.1.3",
-				"text-hex": "1.0.x"
-			}
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
@@ -8749,28 +7945,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/cookie-parser": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-			"integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
-			"dev": true,
-			"dependencies": {
-				"cookie": "0.4.1",
-				"cookie-signature": "1.0.6"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/cookie-parser/node_modules/cookie": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-			"integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/cookie-signature": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -8817,19 +7991,6 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"dev": true
-		},
-		"node_modules/cors": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-			"dev": true,
-			"dependencies": {
-				"object-assign": "^4",
-				"vary": "^1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
 		},
 		"node_modules/cosmiconfig": {
 			"version": "7.0.1",
@@ -9380,21 +8541,6 @@
 			"integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
 			"dev": true
 		},
-		"node_modules/decompress-response": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-			"dev": true,
-			"dependencies": {
-				"mimic-response": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -9534,20 +8680,6 @@
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
 		},
-		"node_modules/detect-port": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
-			"integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
-			"dev": true,
-			"dependencies": {
-				"address": "^1.0.1",
-				"debug": "4"
-			},
-			"bin": {
-				"detect": "bin/detect-port.js",
-				"detect-port": "bin/detect-port.js"
-			}
-		},
 		"node_modules/detect-port-alt": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
@@ -9600,12 +8732,6 @@
 			"engines": {
 				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
 			}
-		},
-		"node_modules/diff3": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
-			"dev": true
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
@@ -9792,15 +8918,6 @@
 			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
 			"dev": true
 		},
-		"node_modules/ecdsa-sig-formatter": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"node_modules/ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -9855,12 +8972,6 @@
 				"node": ">= 4"
 			}
 		},
-		"node_modules/enabled": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
-			"dev": true
-		},
 		"node_modules/encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -9877,27 +8988,6 @@
 			"dev": true,
 			"dependencies": {
 				"once": "^1.4.0"
-			}
-		},
-		"node_modules/engine.io": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.2.tgz",
-			"integrity": "sha512-IXsMcGpw/xRfjra46sVZVHiSWo/nJ/3g1337q9KNXtS6YRzbW5yIzTCb9DjhrBe7r3GZQR0I4+nq+4ODk5g/cA==",
-			"dev": true,
-			"dependencies": {
-				"@types/cookie": "^0.4.1",
-				"@types/cors": "^2.8.12",
-				"@types/node": ">=10.0.0",
-				"accepts": "~1.3.4",
-				"base64id": "2.0.0",
-				"cookie": "~0.4.1",
-				"cors": "~2.8.5",
-				"debug": "~4.3.1",
-				"engine.io-parser": "~5.2.1",
-				"ws": "~8.11.0"
-			},
-			"engines": {
-				"node": ">=10.2.0"
 			}
 		},
 		"node_modules/engine.io-client": {
@@ -9940,36 +9030,6 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/engine.io/node_modules/cookie": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/engine.io/node_modules/ws": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.15.0",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
@@ -9990,18 +9050,6 @@
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/errno": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
-			"integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-			"dev": true,
-			"dependencies": {
-				"prr": "~1.0.1"
-			},
-			"bin": {
-				"errno": "cli.js"
 			}
 		},
 		"node_modules/error-ex": {
@@ -11341,12 +10389,6 @@
 				"pend": "~1.2.0"
 			}
 		},
-		"node_modules/fecha": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
-			"dev": true
-		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -11564,12 +10606,6 @@
 				"@fluidframework/map": "^1.3.7",
 				"@fluidframework/sequence": "^1.3.7"
 			}
-		},
-		"node_modules/fn.name": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-			"dev": true
 		},
 		"node_modules/follow-redirects": {
 			"version": "1.15.2",
@@ -12488,15 +11524,6 @@
 				"node": ">=10.17.0"
 			}
 		},
-		"node_modules/humanize-ms": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "^2.0.0"
-			}
-		},
 		"node_modules/iconv-lite": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -12669,22 +11696,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.10"
-			}
-		},
-		"node_modules/is-arguments": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-array-buffer": {
@@ -12896,22 +11907,6 @@
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
 			"integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
 			"dev": true
-		},
-		"node_modules/is-nan": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/is-negative-zero": {
 			"version": "2.0.2",
@@ -13169,45 +12164,6 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
-		},
-		"node_modules/isomorphic-git": {
-			"version": "1.21.0",
-			"resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.21.0.tgz",
-			"integrity": "sha512-ZqCAUM63CYepA3fB8H7NVyPSiOkgzIbQ7T+QPrm9xtYgQypN9JUJ5uLMjB5iTfomdJf3mdm6aSxjZwnT6ubvEA==",
-			"dev": true,
-			"dependencies": {
-				"async-lock": "^1.1.0",
-				"clean-git-ref": "^2.0.1",
-				"crc-32": "^1.2.0",
-				"diff3": "0.0.3",
-				"ignore": "^5.1.4",
-				"minimisted": "^2.0.0",
-				"pako": "^1.0.10",
-				"pify": "^4.0.1",
-				"readable-stream": "^3.4.0",
-				"sha.js": "^2.4.9",
-				"simple-get": "^4.0.1"
-			},
-			"bin": {
-				"isogit": "cli.cjs"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/isomorphic-git/node_modules/readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.0",
@@ -17043,28 +15999,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/jsonwebtoken": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-			"integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-			"dev": true,
-			"dependencies": {
-				"jws": "^3.2.2",
-				"lodash.includes": "^4.3.0",
-				"lodash.isboolean": "^3.0.3",
-				"lodash.isinteger": "^4.0.4",
-				"lodash.isnumber": "^3.0.3",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.isstring": "^4.0.1",
-				"lodash.once": "^4.0.0",
-				"ms": "^2.1.1",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": ">=12",
-				"npm": ">=6"
-			}
-		},
 		"node_modules/jsrsasign": {
 			"version": "10.8.6",
 			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.8.6.tgz",
@@ -17086,27 +16020,6 @@
 			},
 			"engines": {
 				"node": ">=4.0"
-			}
-		},
-		"node_modules/jwa": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-			"dev": true,
-			"dependencies": {
-				"buffer-equal-constant-time": "1.0.1",
-				"ecdsa-sig-formatter": "1.0.11",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"node_modules/jws": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-			"dev": true,
-			"dependencies": {
-				"jwa": "^1.4.1",
-				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/jwt-decode": {
@@ -17150,12 +16063,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/kuler": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-			"dev": true
-		},
 		"node_modules/language-subtag-registry": {
 			"version": "0.3.22",
 			"resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
@@ -17188,134 +16095,6 @@
 			"dev": true,
 			"engines": {
 				"node": "> 0.8"
-			}
-		},
-		"node_modules/level": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/level/-/level-8.0.0.tgz",
-			"integrity": "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==",
-			"dev": true,
-			"dependencies": {
-				"browser-level": "^1.0.1",
-				"classic-level": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/level"
-			}
-		},
-		"node_modules/level-codec": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
-			"integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^5.6.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/level-codec/node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
-		},
-		"node_modules/level-errors": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-			"integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-			"dev": true,
-			"dependencies": {
-				"errno": "~0.1.1"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/level-iterator-stream": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
-			"integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.5",
-				"xtend": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/level-post": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
-			"integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
-			"dev": true,
-			"dependencies": {
-				"ltgt": "^2.1.2"
-			}
-		},
-		"node_modules/level-sublevel": {
-			"version": "6.6.4",
-			"resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.4.tgz",
-			"integrity": "sha512-pcCrTUOiO48+Kp6F1+UAzF/OtWqLcQVTVF39HLdZ3RO8XBoXt+XVPKZO1vVr1aUoxHZA9OtD2e1v7G+3S5KFDA==",
-			"dev": true,
-			"dependencies": {
-				"bytewise": "~1.1.0",
-				"level-codec": "^9.0.0",
-				"level-errors": "^2.0.0",
-				"level-iterator-stream": "^2.0.3",
-				"ltgt": "~2.1.1",
-				"pull-defer": "^0.2.2",
-				"pull-level": "^2.0.3",
-				"pull-stream": "^3.6.8",
-				"typewiselite": "~1.0.0",
-				"xtend": "~4.0.0"
-			}
-		},
-		"node_modules/level-supports": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
-			"integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/level-transcoder": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
-			"integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^6.0.3",
-				"module-error": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/leven": {
@@ -17401,60 +16180,6 @@
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
 			"dev": true
 		},
-		"node_modules/lodash.defaults": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-			"dev": true
-		},
-		"node_modules/lodash.flatten": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-			"dev": true
-		},
-		"node_modules/lodash.includes": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-			"dev": true
-		},
-		"node_modules/lodash.isarguments": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-			"dev": true
-		},
-		"node_modules/lodash.isboolean": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-			"dev": true
-		},
-		"node_modules/lodash.isinteger": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-			"dev": true
-		},
-		"node_modules/lodash.isnumber": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-			"dev": true
-		},
-		"node_modules/lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-			"dev": true
-		},
-		"node_modules/lodash.isstring": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-			"dev": true
-		},
 		"node_modules/lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -17467,12 +16192,6 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
-		"node_modules/lodash.once": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-			"dev": true
-		},
 		"node_modules/lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -17483,26 +16202,6 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
-			"dev": true
-		},
-		"node_modules/logform": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.5.1.tgz",
-			"integrity": "sha512-9FyqAm9o9NKKfiAKfZoYo9bGXXuwMkxQiQttkT4YjjVtQVIQtK6LmVtlxmCaFswo6N4AfEkHqZTV0taDtPotNg==",
-			"dev": true,
-			"dependencies": {
-				"@colors/colors": "1.5.0",
-				"@types/triple-beam": "^1.3.2",
-				"fecha": "^4.2.0",
-				"ms": "^2.1.1",
-				"safe-stable-stringify": "^2.3.1",
-				"triple-beam": "^1.3.0"
-			}
-		},
-		"node_modules/looper": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
-			"integrity": "sha512-6DzMHJcjbQX/UPHc1rRCBfKlLwDkvuGZ715cIR36wSdYqWXFT35uLXq5P/2orl3tz+t+VOVPxw4yPinQlUDGDQ==",
 			"dev": true
 		},
 		"node_modules/loose-envify": {
@@ -17536,12 +16235,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/ltgt": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
-			"integrity": "sha512-5VjHC5GsENtIi5rbJd+feEpDKhfr7j0odoUR2Uh978g+2p93nd5o34cTjQWohXsPsCZeqoDnIqEf88mPCe0Pfw==",
-			"dev": true
 		},
 		"node_modules/lz-string": {
 			"version": "1.4.4",
@@ -17712,18 +16405,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/mimic-response": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/mini-css-extract-plugin": {
 			"version": "2.7.6",
 			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz",
@@ -17823,15 +16504,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/minimisted": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
-			"integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
-			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.5"
-			}
-		},
 		"node_modules/mitt": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -17855,58 +16527,6 @@
 			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
 			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
 			"dev": true
-		},
-		"node_modules/module-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
-			"integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/morgan": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-			"integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
-			"dev": true,
-			"dependencies": {
-				"basic-auth": "~2.0.1",
-				"debug": "2.6.9",
-				"depd": "~2.0.0",
-				"on-finished": "~2.3.0",
-				"on-headers": "~1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/morgan/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/morgan/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true
-		},
-		"node_modules/morgan/node_modules/on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-			"dev": true,
-			"dependencies": {
-				"ee-first": "1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/ms": {
 			"version": "2.1.2",
@@ -17955,12 +16575,6 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
-		"node_modules/napi-macros": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
-			"integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
-			"dev": true
-		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -17972,68 +16586,6 @@
 			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
 			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
 			"dev": true
-		},
-		"node_modules/nconf": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.0.tgz",
-			"integrity": "sha512-T3fZPw3c7Dfrz8JBQEbEcZJ2s8f7cUMpKuyBtsGQe0b71pcXx6gNh4oti2xh5dxB+gO9ufNfISBlGvvWtfyMcA==",
-			"dev": true,
-			"dependencies": {
-				"async": "^3.0.0",
-				"ini": "^2.0.0",
-				"secure-keys": "^1.0.0",
-				"yargs": "^16.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
-		"node_modules/nconf/node_modules/cliui": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-			"dev": true,
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0",
-				"wrap-ansi": "^7.0.0"
-			}
-		},
-		"node_modules/nconf/node_modules/ini": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-			"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/nconf/node_modules/yargs": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-			"dev": true,
-			"dependencies": {
-				"cliui": "^7.0.2",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.0",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^20.2.2"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/nconf/node_modules/yargs-parser": {
-			"version": "20.2.9",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"node_modules/negotiator": {
 			"version": "0.6.3",
@@ -18097,17 +16649,6 @@
 				"node": ">= 6.13.0"
 			}
 		},
-		"node_modules/node-gyp-build": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-			"integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
-			"dev": true,
-			"bin": {
-				"node-gyp-build": "bin.js",
-				"node-gyp-build-optional": "optional.js",
-				"node-gyp-build-test": "build-test.js"
-			}
-		},
 		"node_modules/node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -18166,12 +16707,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/notepack.io": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.3.0.tgz",
-			"integrity": "sha512-9RiFDxeydHsWOqdthRUck2Kd4UW2NzVd2xxOulZiQ9mvge6ElsHXLpwD3HEJyql6sFEnEn/eMO7HSdS0M5mWkA==",
-			"dev": true
-		},
 		"node_modules/npm-run-path": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -18220,22 +16755,6 @@
 			"version": "1.12.3",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
 			"integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object-is": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-			"integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -18394,15 +16913,6 @@
 				"wrappy": "1"
 			}
 		},
-		"node_modules/one-time": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-			"dev": true,
-			"dependencies": {
-				"fn.name": "1.x.x"
-			}
-		},
 		"node_modules/onetime": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -18488,15 +16998,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/p-map": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/p-retry": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
@@ -18551,12 +17052,6 @@
 			"engines": {
 				"node": ">= 14"
 			}
-		},
-		"node_modules/pako": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-			"dev": true
 		},
 		"node_modules/param-case": {
 			"version": "3.0.4",
@@ -18722,15 +17217,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/pify": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/pirates": {
@@ -20343,12 +18829,6 @@
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"dev": true
 		},
-		"node_modules/prr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-			"dev": true
-		},
 		"node_modules/ps-tree": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
@@ -20369,64 +18849,6 @@
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
 			"integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
 			"dev": true
-		},
-		"node_modules/pull-cat": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
-			"integrity": "sha512-i3w+xZ3DCtTVz8S62hBOuNLRHqVDsHMNZmgrZsjPnsxXUgbWtXEee84lo1XswE7W2a3WHyqsNuDJTjVLAQR8xg==",
-			"dev": true
-		},
-		"node_modules/pull-defer": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
-			"integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA==",
-			"dev": true
-		},
-		"node_modules/pull-level": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
-			"integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
-			"dev": true,
-			"dependencies": {
-				"level-post": "^1.0.7",
-				"pull-cat": "^1.1.9",
-				"pull-live": "^1.0.1",
-				"pull-pushable": "^2.0.0",
-				"pull-stream": "^3.4.0",
-				"pull-window": "^2.1.4",
-				"stream-to-pull-stream": "^1.7.1"
-			}
-		},
-		"node_modules/pull-live": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
-			"integrity": "sha512-tkNz1QT5gId8aPhV5+dmwoIiA1nmfDOzJDlOOUpU5DNusj6neNd3EePybJ5+sITr2FwyCs/FVpx74YMCfc8YeA==",
-			"dev": true,
-			"dependencies": {
-				"pull-cat": "^1.1.9",
-				"pull-stream": "^3.4.0"
-			}
-		},
-		"node_modules/pull-pushable": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
-			"integrity": "sha512-M7dp95enQ2kaHvfCt2+DJfyzgCSpWVR2h2kWYnVsW6ZpxQBx5wOu0QWOvQPVoPnBLUZYitYP2y7HyHkLQNeGXg==",
-			"dev": true
-		},
-		"node_modules/pull-stream": {
-			"version": "3.6.14",
-			"resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
-			"integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew==",
-			"dev": true
-		},
-		"node_modules/pull-window": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
-			"integrity": "sha512-cbDzN76BMlcGG46OImrgpkMf/VkCnupj8JhsrpBw3aWBM9ye345aYnqitmZCgauBkc0HbbRRn9hCnsa3k2FNUg==",
-			"dev": true,
-			"dependencies": {
-				"looper": "^2.0.0"
-			}
 		},
 		"node_modules/pump": {
 			"version": "3.0.0",
@@ -20637,42 +19059,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/raw-body": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-			"integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-			"dev": true,
-			"dependencies": {
-				"bytes": "3.1.2",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/raw-body/node_modules/bytes": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/raw-body/node_modules/iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/react": {
@@ -21571,33 +19957,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/redis-commands": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
-			"dev": true
-		},
-		"node_modules/redis-errors": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-			"integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/redis-parser": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-			"integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-			"dev": true,
-			"dependencies": {
-				"redis-errors": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/reflect.getprototypeof": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
@@ -22135,29 +20494,6 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
-		"node_modules/run-parallel-limit": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
-			"integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"queue-microtask": "^1.2.2"
-			}
-		},
 		"node_modules/rxjs": {
 			"version": "7.8.1",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -22222,15 +20558,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/safe-stable-stringify": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/safer-buffer": {
@@ -22328,12 +20655,6 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
-		"node_modules/secure-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
-			"integrity": "sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg==",
-			"dev": true
-		},
 		"node_modules/select-hose": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -22411,21 +20732,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true
-		},
-		"node_modules/serialize-error": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
-			"integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
-			"dev": true,
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.1",
@@ -22623,66 +20929,6 @@
 			"resolved": "https://registry.npmjs.org/sillyname/-/sillyname-0.1.0.tgz",
 			"integrity": "sha512-GWA0Zont13ov+cMNw4T7nU4SCyW8jdhD3vjA5+qs8jr+09sCPxOf+FPS5zE0c9pYlCwD+NU/CiMimY462lgG9g=="
 		},
-		"node_modules/simple-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/simple-get": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"decompress-response": "^6.0.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
-			}
-		},
-		"node_modules/simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-			"dev": true,
-			"dependencies": {
-				"is-arrayish": "^0.3.1"
-			}
-		},
-		"node_modules/simple-swizzle/node_modules/is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-			"dev": true
-		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -22706,54 +20952,6 @@
 			"engines": {
 				"node": ">= 6.0.0",
 				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/socket.io": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.2.tgz",
-			"integrity": "sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==",
-			"dev": true,
-			"dependencies": {
-				"accepts": "~1.3.4",
-				"base64id": "~2.0.0",
-				"cors": "~2.8.5",
-				"debug": "~4.3.2",
-				"engine.io": "~6.5.2",
-				"socket.io-adapter": "~2.5.2",
-				"socket.io-parser": "~4.2.4"
-			},
-			"engines": {
-				"node": ">=10.2.0"
-			}
-		},
-		"node_modules/socket.io-adapter": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
-			"integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
-			"dev": true,
-			"dependencies": {
-				"ws": "~8.11.0"
-			}
-		},
-		"node_modules/socket.io-adapter/node_modules/ws": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/socket.io-client": {
@@ -22983,15 +21181,6 @@
 			"deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
 			"dev": true
 		},
-		"node_modules/stack-trace": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-			"integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/stack-utils": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -23017,12 +21206,6 @@
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
 			"integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
-			"dev": true
-		},
-		"node_modules/standard-as-callback": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-			"integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
 			"dev": true
 		},
 		"node_modules/start-server-and-test": {
@@ -23067,22 +21250,6 @@
 				"duplexer": "~0.1.1"
 			}
 		},
-		"node_modules/stream-to-pull-stream": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
-			"integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
-			"dev": true,
-			"dependencies": {
-				"looper": "^3.0.0",
-				"pull-stream": "^3.2.3"
-			}
-		},
-		"node_modules/stream-to-pull-stream/node_modules/looper": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-			"integrity": "sha512-LJ9wplN/uSn72oJRsXTx+snxPet5c8XiZmOKCm906NVYu+ag6SB6vUcnJcWxgnl2NfbIyeobAn7Bwv6xRj2XJg==",
-			"dev": true
-		},
 		"node_modules/streamx": {
 			"version": "2.15.1",
 			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.1.tgz",
@@ -23106,12 +21273,6 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"node_modules/string-hash": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-			"integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
 			"dev": true
 		},
 		"node_modules/string-length": {
@@ -23667,12 +21828,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/text-hex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-			"dev": true
-		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -23790,15 +21945,6 @@
 			"dev": true,
 			"bin": {
 				"tree-kill": "cli.js"
-			}
-		},
-		"node_modules/triple-beam": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
-			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/tryer": {
@@ -23996,33 +22142,6 @@
 			"engines": {
 				"node": ">=4.2.0"
 			}
-		},
-		"node_modules/typewise": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-			"integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
-			"dev": true,
-			"dependencies": {
-				"typewise-core": "^1.2.0"
-			}
-		},
-		"node_modules/typewise-core": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-			"integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
-			"dev": true
-		},
-		"node_modules/typewiselite": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
-			"integrity": "sha512-J9alhjVHupW3Wfz6qFRGgQw0N3gr8hOkw6zm7FZ6UR1Cse/oD9/JVok7DNE9TT9IbciDHX2Ex9+ksE6cRmtymw==",
-			"dev": true
-		},
-		"node_modules/uid2": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-			"integrity": "sha512-5gSP1liv10Gjp8cMEnFd6shzkL/D6W1uhXSFNCxDC+YI8+L8wkCYCbJ7n77Ezb4wE/xzMogecE+DtamEe9PZjg==",
-			"dev": true
 		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.2",
@@ -24233,19 +22352,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/util": {
-			"version": "0.12.5",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"is-arguments": "^1.0.4",
-				"is-generator-function": "^1.0.7",
-				"is-typed-array": "^1.1.3",
-				"which-typed-array": "^1.1.2"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -24891,70 +22997,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/winston": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.10.0.tgz",
-			"integrity": "sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==",
-			"dev": true,
-			"dependencies": {
-				"@colors/colors": "1.5.0",
-				"@dabh/diagnostics": "^2.0.2",
-				"async": "^3.2.3",
-				"is-stream": "^2.0.0",
-				"logform": "^2.4.0",
-				"one-time": "^1.0.0",
-				"readable-stream": "^3.4.0",
-				"safe-stable-stringify": "^2.3.1",
-				"stack-trace": "0.0.x",
-				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.5.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/winston-transport": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
-			"integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
-			"dev": true,
-			"dependencies": {
-				"logform": "^2.3.2",
-				"readable-stream": "^3.6.0",
-				"triple-beam": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 6.4.0"
-			}
-		},
-		"node_modules/winston-transport/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/winston/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/workbox-background-sync": {
 			"version": "6.6.0",
 			"resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-6.6.0.tgz",
@@ -25402,15 +23444,6 @@
 			"integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.4"
 			}
 		},
 		"node_modules/y18n": {

--- a/collaborative-text-area/package.json
+++ b/collaborative-text-area/package.json
@@ -19,7 +19,6 @@
 		"react-dom": "^17.0.2"
 	},
 	"devDependencies": {
-		"@fluidframework/azure-local-service": "^1.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@testing-library/react": "^11.2.7",
 		"@testing-library/user-event": "^12.8.3",

--- a/collaborative-text-area/package.json
+++ b/collaborative-text-area/package.json
@@ -19,6 +19,7 @@
 		"react-dom": "^17.0.2"
 	},
 	"devDependencies": {
+		"@fluidframework/azure-local-service": "^1.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@testing-library/react": "^11.2.7",
 		"@testing-library/user-event": "^12.8.3",
@@ -31,14 +32,13 @@
 		"puppeteer": "^21.0.0",
 		"react-scripts": "^5.0.1",
 		"start-server-and-test": "^2.0.0",
-		"tinylicious": "^1.0.0",
 		"typescript": "^4.5.5"
 	},
 	"scripts": {
 		"ci:test": "start-server-and-test start:server 7070 ci:test:jest",
 		"ci:test:jest": "jest --ci --reporters=default --reporters=jest-junit",
 		"start": "react-scripts start",
-		"start:server": "npx tinylicious",
+		"start:server": "npx @fluidframework/azure-local-service",
 		"build": "react-scripts build",
 		"test": "start-server-and-test start:server 7070 test:jest",
 		"test:jest": "jest",

--- a/collaborative-text-area/package.json
+++ b/collaborative-text-area/package.json
@@ -38,7 +38,7 @@
 		"ci:test": "start-server-and-test start:server 7070 ci:test:jest",
 		"ci:test:jest": "jest --ci --reporters=default --reporters=jest-junit",
 		"start": "react-scripts start",
-		"start:server": "npx tinylicious@latest",
+		"start:server": "npx tinylicious",
 		"build": "react-scripts build",
 		"test": "start-server-and-test start:server 7070 test:jest",
 		"test:jest": "jest",

--- a/multi-framework-diceroller/README.md
+++ b/multi-framework-diceroller/README.md
@@ -7,7 +7,7 @@ This repository contains a simple app that enables all connected clients to roll
 To run an Azure Client service locally, on the default values of `localhost:7070`, enter the following into a terminal window:
 
 ```bash
-npx tinylicious
+npx @fluidframework/azure-local-service
 ```
 
 With the local service running in the background, we need to connect the application to it.

--- a/multi-framework-diceroller/package-lock.json
+++ b/multi-framework-diceroller/package-lock.json
@@ -19,6 +19,7 @@
             "devDependencies": {
                 "@babel/core": "^7.15.5",
                 "@babel/preset-env": "^7.15.0",
+                "@fluidframework/azure-local-service": "^1.1.0",
                 "@fluidframework/build-common": "^2.0.0",
                 "babel-loader": "^8.2.2",
                 "clean-webpack-plugin": "^3.0.0",
@@ -29,7 +30,6 @@
                 "prettier": "^2.7.1",
                 "puppeteer": "^21.0.0",
                 "start-server-and-test": "^2.0.0",
-                "tinylicious": "^1.0.0",
                 "webpack": "^5.88.2",
                 "webpack-cli": "^5.1.4",
                 "webpack-dev-server": "^4.15.1"
@@ -1815,6 +1815,412 @@
                 "uuid": "^8.3.1"
             }
         },
+        "node_modules/@fluidframework/azure-local-service": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-1.1.1.tgz",
+            "integrity": "sha512-gvk+qy8RytXBQaZ554OREszHGN73W3FmgpfwV+aXeOOP5RWLMPSvkPoac5K9gcUYN+nAFbRs517c055yucP9ug==",
+            "dev": true,
+            "dependencies": {
+                "tinylicious": "^0.4.89251"
+            },
+            "bin": {
+                "azure-local-service": "dist/index.js"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/common-utils": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+            "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+            "dev": true,
+            "dependencies": {
+                "@fluidframework/common-definitions": "^0.20.1",
+                "@types/events": "^3.0.0",
+                "base64-js": "^1.5.1",
+                "buffer": "^6.0.3",
+                "events": "^3.1.0",
+                "lodash": "^4.17.21",
+                "sha.js": "^2.4.11"
+            }
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/gitresources": {
+            "version": "0.1038.4001",
+            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
+            "integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+            "dev": true
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-base": {
+            "version": "0.1038.4001",
+            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
+            "integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+            "dev": true,
+            "dependencies": {
+                "@fluidframework/common-utils": "^1.1.1",
+                "@fluidframework/gitresources": "^0.1038.4001",
+                "@fluidframework/protocol-definitions": "^1.1.0",
+                "events": "^3.1.0",
+                "lodash": "^4.17.21"
+            }
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-definitions": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+            "integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
+            "dev": true,
+            "dependencies": {
+                "@fluidframework/common-definitions": "^0.20.1"
+            }
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas": {
+            "version": "0.1038.4001",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.4001.tgz",
+            "integrity": "sha512-rERfgXK5DXGJvxADjotkAZssKgp3ZxW6u7yUekrDnFDkXtbCW1Gcq+EwvjHTEyhsOp30YBnD0Z39xnZy4zEZRw==",
+            "dev": true,
+            "dependencies": {
+                "@fluidframework/common-definitions": "^0.20.1",
+                "@fluidframework/common-utils": "^1.1.1",
+                "@fluidframework/gitresources": "^0.1038.4001",
+                "@fluidframework/protocol-base": "^0.1038.4001",
+                "@fluidframework/protocol-definitions": "^1.1.0",
+                "@fluidframework/server-lambdas-driver": "^0.1038.4001",
+                "@fluidframework/server-services-client": "^0.1038.4001",
+                "@fluidframework/server-services-core": "^0.1038.4001",
+                "@fluidframework/server-services-telemetry": "^0.1038.4001",
+                "@types/semver": "^6.0.1",
+                "assert": "^2.0.0",
+                "async": "^3.2.2",
+                "axios": "^0.26.0",
+                "buffer": "^6.0.3",
+                "double-ended-queue": "^2.1.0-0",
+                "events": "^3.1.0",
+                "json-stringify-safe": "^5.0.1",
+                "lodash": "^4.17.21",
+                "nconf": "^0.12.0",
+                "semver": "^6.3.0",
+                "sha.js": "^2.4.11",
+                "uuid": "^8.3.1"
+            }
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas-driver": {
+            "version": "0.1038.4001",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.4001.tgz",
+            "integrity": "sha512-qRs+vMbSS9aPx7vr3XemvER5DeY/nsJ5ZkcL3UDjUOxvLZxbOAD6C6JeH3Zgzc/jc8bqshcxai/u7qso2zCsFw==",
+            "dev": true,
+            "dependencies": {
+                "@fluidframework/common-utils": "^1.1.1",
+                "@fluidframework/server-services-client": "^0.1038.4001",
+                "@fluidframework/server-services-core": "^0.1038.4001",
+                "@fluidframework/server-services-telemetry": "^0.1038.4001",
+                "assert": "^2.0.0",
+                "async": "^3.2.2",
+                "events": "^3.1.0",
+                "lodash": "^4.17.21"
+            }
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-local-server": {
+            "version": "0.1038.4001",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.4001.tgz",
+            "integrity": "sha512-FIlNUc9Ncul/5qzP+VyU53TJj8fxX7KZ1lweswZYalleRZwiqFA4Y+NbWRRWM0iJ1z8hvhyRZblG3iNrpGl04A==",
+            "dev": true,
+            "dependencies": {
+                "@fluidframework/common-utils": "^1.1.1",
+                "@fluidframework/protocol-definitions": "^1.1.0",
+                "@fluidframework/server-lambdas": "^0.1038.4001",
+                "@fluidframework/server-memory-orderer": "^0.1038.4001",
+                "@fluidframework/server-services-client": "^0.1038.4001",
+                "@fluidframework/server-services-core": "^0.1038.4001",
+                "@fluidframework/server-services-telemetry": "^0.1038.4001",
+                "@fluidframework/server-test-utils": "^0.1038.4001",
+                "debug": "^4.1.1",
+                "events": "^3.1.0",
+                "jsrsasign": "^10.5.25",
+                "uuid": "^8.3.1"
+            }
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-memory-orderer": {
+            "version": "0.1038.4001",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.4001.tgz",
+            "integrity": "sha512-fdzTCLFRh8QfyY17MnB22/o8x2XEX1+wZrm+dn+1Av+ZVe/+ZhfdX5LsQCMKYv+X5mgAauNmC/12mQE4H6jvsQ==",
+            "dev": true,
+            "dependencies": {
+                "@fluidframework/common-utils": "^1.1.1",
+                "@fluidframework/protocol-base": "^0.1038.4001",
+                "@fluidframework/protocol-definitions": "^1.1.0",
+                "@fluidframework/server-lambdas": "^0.1038.4001",
+                "@fluidframework/server-services-client": "^0.1038.4001",
+                "@fluidframework/server-services-core": "^0.1038.4001",
+                "@fluidframework/server-services-telemetry": "^0.1038.4001",
+                "@types/debug": "^4.1.5",
+                "@types/double-ended-queue": "^2.1.0",
+                "@types/lodash": "^4.14.118",
+                "@types/node": "^14.18.0",
+                "@types/ws": "^6.0.1",
+                "assert": "^2.0.0",
+                "debug": "^4.1.1",
+                "double-ended-queue": "^2.1.0-0",
+                "events": "^3.1.0",
+                "lodash": "^4.17.21",
+                "sillyname": "^0.1.0",
+                "uuid": "^8.3.1",
+                "ws": "^7.4.6"
+            }
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-client": {
+            "version": "0.1038.4001",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
+            "integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+            "dev": true,
+            "dependencies": {
+                "@fluidframework/common-utils": "^1.1.1",
+                "@fluidframework/gitresources": "^0.1038.4001",
+                "@fluidframework/protocol-base": "^0.1038.4001",
+                "@fluidframework/protocol-definitions": "^1.1.0",
+                "axios": "^0.26.0",
+                "crc-32": "1.2.0",
+                "debug": "^4.1.1",
+                "json-stringify-safe": "^5.0.1",
+                "jsrsasign": "^10.5.25",
+                "jwt-decode": "^3.0.0",
+                "querystring": "^0.2.0",
+                "sillyname": "^0.1.0",
+                "uuid": "^8.3.1"
+            }
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-core": {
+            "version": "0.1038.4001",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.4001.tgz",
+            "integrity": "sha512-nuZ9ebvyeIoRdlpQQpBNGkawKtc2/tHKbc8CHbMZRMh7F7kwYUtoHd/J8powb9eUcg5IHDmXx1l+PQRbQX4vCg==",
+            "dev": true,
+            "dependencies": {
+                "@fluidframework/common-utils": "^1.1.1",
+                "@fluidframework/gitresources": "^0.1038.4001",
+                "@fluidframework/protocol-definitions": "^1.1.0",
+                "@fluidframework/server-services-client": "^0.1038.4001",
+                "@fluidframework/server-services-telemetry": "^0.1038.4001",
+                "@types/nconf": "^0.10.2",
+                "@types/node": "^14.18.0",
+                "debug": "^4.1.1",
+                "events": "^3.1.0",
+                "nconf": "^0.12.0"
+            }
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-shared": {
+            "version": "0.1038.4001",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.4001.tgz",
+            "integrity": "sha512-vDRB2G/Xnuhan+Ri0Eg5JMKfsm7hxstCXdEyQhzJzC7+bw66wts+ZIsEsn4Ha/3KkxblF/RSW3lBhrYpxii3cQ==",
+            "dev": true,
+            "dependencies": {
+                "@fluidframework/common-utils": "^1.1.1",
+                "@fluidframework/gitresources": "^0.1038.4001",
+                "@fluidframework/protocol-base": "^0.1038.4001",
+                "@fluidframework/protocol-definitions": "^1.1.0",
+                "@fluidframework/server-services-client": "^0.1038.4001",
+                "@fluidframework/server-services-core": "^0.1038.4001",
+                "@fluidframework/server-services-telemetry": "^0.1038.4001",
+                "@socket.io/redis-adapter": "^7.2.0",
+                "body-parser": "^1.17.1",
+                "debug": "^4.1.1",
+                "events": "^3.1.0",
+                "ioredis": "^4.24.2",
+                "lodash": "^4.17.21",
+                "nconf": "^0.12.0",
+                "notepack.io": "^2.3.0",
+                "querystring": "^0.2.0",
+                "socket.io": "^4.5.3",
+                "socket.io-adapter": "^2.4.0",
+                "socket.io-parser": "^4.2.1",
+                "uuid": "^8.3.1",
+                "winston": "^3.6.0"
+            }
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-telemetry": {
+            "version": "0.1038.4001",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.4001.tgz",
+            "integrity": "sha512-2leJhB04+71RTmC5ShRXm/4FWng9tLn9dlrUAjApZH4RlUJAx1JGsvo/5JU1tIbpUutMHUle2IpWyfu/RV+S5g==",
+            "dev": true,
+            "dependencies": {
+                "@fluidframework/common-utils": "^1.1.1",
+                "json-stringify-safe": "^5.0.1",
+                "path-browserify": "^1.0.1",
+                "serialize-error": "^8.1.0",
+                "uuid": "^8.3.1"
+            }
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-utils": {
+            "version": "0.1038.4001",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.4001.tgz",
+            "integrity": "sha512-K7X/0mlonDAu0pPIgTz8U9nLwRSbJY2oBpFPwpkp1UtE6SU02jx2ZzraT9epDmOl3EXeS1rHzA+mbvBSe1aFMg==",
+            "dev": true,
+            "dependencies": {
+                "@fluidframework/protocol-definitions": "^1.1.0",
+                "@fluidframework/server-services-client": "^0.1038.4001",
+                "@fluidframework/server-services-core": "^0.1038.4001",
+                "@fluidframework/server-services-telemetry": "^0.1038.4001",
+                "debug": "^4.1.1",
+                "express": "^4.17.3",
+                "ioredis": "^4.24.2",
+                "json-stringify-safe": "^5.0.1",
+                "jsonwebtoken": "^9.0.0",
+                "morgan": "^1.8.1",
+                "nconf": "^0.12.0",
+                "serialize-error": "^8.1.0",
+                "sillyname": "^0.1.0",
+                "split": "^1.0.0",
+                "uuid": "^8.3.1",
+                "winston": "^3.6.0",
+                "winston-transport": "^4.5.0"
+            }
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-test-utils": {
+            "version": "0.1038.4001",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.4001.tgz",
+            "integrity": "sha512-qrLp5H1UUPIJSEHlzZ1iYlPFJCQrd2WnmoafxnQIg0mfU1ZE8XUlG5MKUg8bT9pWsCoEGJDiOkkRHaq+WXupjQ==",
+            "dev": true,
+            "dependencies": {
+                "@fluidframework/common-utils": "^1.1.1",
+                "@fluidframework/gitresources": "^0.1038.4001",
+                "@fluidframework/protocol-base": "^0.1038.4001",
+                "@fluidframework/protocol-definitions": "^1.1.0",
+                "@fluidframework/server-services-client": "^0.1038.4001",
+                "@fluidframework/server-services-core": "^0.1038.4001",
+                "@fluidframework/server-services-telemetry": "^0.1038.4001",
+                "assert": "^2.0.0",
+                "debug": "^4.1.1",
+                "events": "^3.1.0",
+                "lodash": "^4.17.21",
+                "string-hash": "^1.1.3",
+                "uuid": "^8.3.1"
+            }
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/@types/node": {
+            "version": "14.18.63",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+            "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+            "dev": true
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/@types/semver": {
+            "version": "6.2.5",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.5.tgz",
+            "integrity": "sha512-NAxro9/RqWXTqdSjccDZAjA4nXK+6zRun+HvibYJfGy8TQhpOC7Vv6v2rlHYKrT0Q8jGGoNRd/xVdHRIQRNlFQ==",
+            "dev": true
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/denque": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+            "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/ioredis": {
+            "version": "4.28.5",
+            "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
+            "integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+            "dev": true,
+            "dependencies": {
+                "cluster-key-slot": "^1.1.0",
+                "debug": "^4.3.1",
+                "denque": "^1.1.0",
+                "lodash.defaults": "^4.2.0",
+                "lodash.flatten": "^4.4.0",
+                "lodash.isarguments": "^3.1.0",
+                "p-map": "^2.1.0",
+                "redis-commands": "1.7.0",
+                "redis-errors": "^1.2.0",
+                "redis-parser": "^3.0.0",
+                "standard-as-callback": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/ioredis"
+            }
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/split": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+            "dev": true,
+            "dependencies": {
+                "through": "2"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/tinylicious": {
+            "version": "0.4.94771",
+            "resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
+            "integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
+            "dev": true,
+            "dependencies": {
+                "@fluidframework/common-utils": "^1.0.0",
+                "@fluidframework/gitresources": "^0.1038.1000",
+                "@fluidframework/protocol-base": "^0.1038.1000",
+                "@fluidframework/protocol-definitions": "^1.0.0",
+                "@fluidframework/server-lambdas": "^0.1038.1000",
+                "@fluidframework/server-local-server": "^0.1038.1000",
+                "@fluidframework/server-memory-orderer": "^0.1038.1000",
+                "@fluidframework/server-services-client": "^0.1038.1000",
+                "@fluidframework/server-services-core": "^0.1038.1000",
+                "@fluidframework/server-services-shared": "^0.1038.1000",
+                "@fluidframework/server-services-telemetry": "^0.1038.1000",
+                "@fluidframework/server-services-utils": "^0.1038.1000",
+                "@fluidframework/server-test-utils": "^0.1038.1000",
+                "agentkeepalive": "^4.2.1",
+                "axios": "^0.26.0",
+                "body-parser": "^1.17.1",
+                "charwise": "^3.0.1",
+                "compression": "^1.7.2",
+                "cookie-parser": "^1.4.3",
+                "cors": "^2.8.4",
+                "detect-port": "^1.3.0",
+                "express": "^4.16.3",
+                "isomorphic-git": "^1.8.2",
+                "json-stringify-safe": "^5.0.1",
+                "level": "^8.0.0",
+                "level-sublevel": "6.6.4",
+                "lodash": "^4.17.21",
+                "morgan": "^1.8.1",
+                "nconf": "^0.12.0",
+                "socket.io": "^4.5.0",
+                "split": "^1.0.0",
+                "uuid": "^8.3.2",
+                "winston": "^3.6.0"
+            },
+            "bin": {
+                "tinylicious": "dist/index.js"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@fluidframework/azure-local-service/node_modules/ws": {
+            "version": "7.5.9",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+            "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@fluidframework/build-common": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.0.tgz",
@@ -2183,402 +2589,6 @@
                 "uuid": "^8.3.1"
             }
         },
-        "node_modules/@fluidframework/server-lambdas": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-1.0.1.tgz",
-            "integrity": "sha512-lwVKg4dVDvbNH4ckj328z5cNu1plHhArzIMP3kpl8T94L6OubqsJ8vf3g46Wab/SjwltHC41p/wWigJapXZjqA==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-base": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "@fluidframework/server-lambdas-driver": "^1.0.1",
-                "@fluidframework/server-services-client": "^1.0.1",
-                "@fluidframework/server-services-core": "^1.0.1",
-                "@fluidframework/server-services-telemetry": "^1.0.1",
-                "@types/semver": "^7.5.0",
-                "assert": "^2.0.0",
-                "async": "^3.2.2",
-                "axios": "^0.26.0",
-                "buffer": "^6.0.3",
-                "double-ended-queue": "^2.1.0-0",
-                "events": "^3.1.0",
-                "json-stringify-safe": "^5.0.1",
-                "lodash": "^4.17.21",
-                "nconf": "^0.12.0",
-                "semver": "^7.5.3",
-                "sha.js": "^2.4.11",
-                "uuid": "^8.3.1"
-            }
-        },
-        "node_modules/@fluidframework/server-lambdas-driver": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-1.0.1.tgz",
-            "integrity": "sha512-TfQ7rz2/6pW6Rq5CbGBu9ShiSKyOHg2pXX0cUVHtnuuUPsWTxQDWlVilYukyG0uxHJfE3ZDU3R1QgnWUQQmGgg==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/server-services-client": "^1.0.1",
-                "@fluidframework/server-services-core": "^1.0.1",
-                "@fluidframework/server-services-telemetry": "^1.0.1",
-                "assert": "^2.0.0",
-                "async": "^3.2.2",
-                "events": "^3.1.0",
-                "lodash": "^4.17.21",
-                "nconf": "^0.12.0",
-                "serialize-error": "^8.1.0"
-            }
-        },
-        "node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/common-utils": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-            "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1",
-                "@types/events": "^3.0.0",
-                "base64-js": "^1.5.1",
-                "buffer": "^6.0.3",
-                "events": "^3.1.0",
-                "lodash": "^4.17.21",
-                "sha.js": "^2.4.11"
-            }
-        },
-        "node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/gitresources": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-            "integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-            "dev": true
-        },
-        "node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-base": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-            "integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "events": "^3.1.0"
-            }
-        },
-        "node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-definitions": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-            "integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1"
-            }
-        },
-        "node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/server-services-client": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-            "integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-base": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "axios": "^0.26.0",
-                "crc-32": "1.2.0",
-                "debug": "^4.1.1",
-                "json-stringify-safe": "^5.0.1",
-                "jsrsasign": "^10.5.25",
-                "jwt-decode": "^3.0.0",
-                "querystring": "^0.2.0",
-                "sillyname": "^0.1.0",
-                "uuid": "^8.3.1"
-            }
-        },
-        "node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/common-utils": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-            "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1",
-                "@types/events": "^3.0.0",
-                "base64-js": "^1.5.1",
-                "buffer": "^6.0.3",
-                "events": "^3.1.0",
-                "lodash": "^4.17.21",
-                "sha.js": "^2.4.11"
-            }
-        },
-        "node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/gitresources": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-            "integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-            "dev": true
-        },
-        "node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-base": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-            "integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "events": "^3.1.0"
-            }
-        },
-        "node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-definitions": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-            "integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1"
-            }
-        },
-        "node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/server-services-client": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-            "integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-base": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "axios": "^0.26.0",
-                "crc-32": "1.2.0",
-                "debug": "^4.1.1",
-                "json-stringify-safe": "^5.0.1",
-                "jsrsasign": "^10.5.25",
-                "jwt-decode": "^3.0.0",
-                "querystring": "^0.2.0",
-                "sillyname": "^0.1.0",
-                "uuid": "^8.3.1"
-            }
-        },
-        "node_modules/@fluidframework/server-lambdas/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@fluidframework/server-lambdas/node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@fluidframework/server-local-server": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-1.0.1.tgz",
-            "integrity": "sha512-494H0PYNa6aqngyq/M46K7wlY7NHdIx1B4qcfRCRQmjJZrD9GPza3FHt2/426teBQ93F6SOKkBrMw2vbmoUUGg==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "@fluidframework/server-lambdas": "^1.0.1",
-                "@fluidframework/server-memory-orderer": "^1.0.1",
-                "@fluidframework/server-services-client": "^1.0.1",
-                "@fluidframework/server-services-core": "^1.0.1",
-                "@fluidframework/server-services-telemetry": "^1.0.1",
-                "@fluidframework/server-test-utils": "^1.0.1",
-                "debug": "^4.1.1",
-                "events": "^3.1.0",
-                "jsrsasign": "^10.5.25",
-                "uuid": "^8.3.1"
-            }
-        },
-        "node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/common-utils": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-            "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1",
-                "@types/events": "^3.0.0",
-                "base64-js": "^1.5.1",
-                "buffer": "^6.0.3",
-                "events": "^3.1.0",
-                "lodash": "^4.17.21",
-                "sha.js": "^2.4.11"
-            }
-        },
-        "node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/gitresources": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-            "integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-            "dev": true
-        },
-        "node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-base": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-            "integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "events": "^3.1.0"
-            }
-        },
-        "node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-definitions": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-            "integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1"
-            }
-        },
-        "node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/server-services-client": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-            "integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-base": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "axios": "^0.26.0",
-                "crc-32": "1.2.0",
-                "debug": "^4.1.1",
-                "json-stringify-safe": "^5.0.1",
-                "jsrsasign": "^10.5.25",
-                "jwt-decode": "^3.0.0",
-                "querystring": "^0.2.0",
-                "sillyname": "^0.1.0",
-                "uuid": "^8.3.1"
-            }
-        },
-        "node_modules/@fluidframework/server-memory-orderer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-1.0.1.tgz",
-            "integrity": "sha512-zUuNICwyKC7OTSl/W9MSiwplSccnRHVmRpdxImCe5qVs+VSK1jHuIGiIzCkt6dlVNMu3WHyUXmrKCLmhJZmFeQ==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/protocol-base": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "@fluidframework/server-lambdas": "^1.0.1",
-                "@fluidframework/server-services-client": "^1.0.1",
-                "@fluidframework/server-services-core": "^1.0.1",
-                "@fluidframework/server-services-telemetry": "^1.0.1",
-                "@types/debug": "^4.1.5",
-                "@types/double-ended-queue": "^2.1.0",
-                "@types/lodash": "^4.14.118",
-                "@types/node": "^16.18.16",
-                "@types/ws": "^6.0.1",
-                "assert": "^2.0.0",
-                "debug": "^4.1.1",
-                "double-ended-queue": "^2.1.0-0",
-                "events": "^3.1.0",
-                "lodash": "^4.17.21",
-                "sillyname": "^0.1.0",
-                "uuid": "^8.3.1",
-                "ws": "^7.4.6"
-            }
-        },
-        "node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/common-utils": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-            "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1",
-                "@types/events": "^3.0.0",
-                "base64-js": "^1.5.1",
-                "buffer": "^6.0.3",
-                "events": "^3.1.0",
-                "lodash": "^4.17.21",
-                "sha.js": "^2.4.11"
-            }
-        },
-        "node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/gitresources": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-            "integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-            "dev": true
-        },
-        "node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-base": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-            "integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "events": "^3.1.0"
-            }
-        },
-        "node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-definitions": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-            "integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1"
-            }
-        },
-        "node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/server-services-client": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-            "integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-base": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "axios": "^0.26.0",
-                "crc-32": "1.2.0",
-                "debug": "^4.1.1",
-                "json-stringify-safe": "^5.0.1",
-                "jsrsasign": "^10.5.25",
-                "jwt-decode": "^3.0.0",
-                "querystring": "^0.2.0",
-                "sillyname": "^0.1.0",
-                "uuid": "^8.3.1"
-            }
-        },
-        "node_modules/@fluidframework/server-memory-orderer/node_modules/ws": {
-            "version": "7.5.9",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-            "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=8.3.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@fluidframework/server-services-client": {
             "version": "0.1036.5001",
             "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5001.tgz",
@@ -2593,392 +2603,6 @@
                 "debug": "^4.1.1",
                 "json-stringify-safe": "^5.0.1",
                 "jsrsasign": "^10.2.0",
-                "jwt-decode": "^3.0.0",
-                "querystring": "^0.2.0",
-                "sillyname": "^0.1.0",
-                "uuid": "^8.3.1"
-            }
-        },
-        "node_modules/@fluidframework/server-services-core": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-1.0.1.tgz",
-            "integrity": "sha512-/Lb5ZZxb4aHtzLH3p+lrboi6TW/WD0I53di8FI4rMmn5AM7+h69BolPW7nume52t3HUi1I2Mnqhx1W8FKV8BbA==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "@fluidframework/server-services-client": "^1.0.1",
-                "@fluidframework/server-services-telemetry": "^1.0.1",
-                "@types/nconf": "^0.10.2",
-                "@types/node": "^16.18.16",
-                "debug": "^4.1.1",
-                "events": "^3.1.0",
-                "nconf": "^0.12.0"
-            }
-        },
-        "node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/common-utils": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-            "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1",
-                "@types/events": "^3.0.0",
-                "base64-js": "^1.5.1",
-                "buffer": "^6.0.3",
-                "events": "^3.1.0",
-                "lodash": "^4.17.21",
-                "sha.js": "^2.4.11"
-            }
-        },
-        "node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/gitresources": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-            "integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-            "dev": true
-        },
-        "node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-base": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-            "integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "events": "^3.1.0"
-            }
-        },
-        "node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-definitions": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-            "integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1"
-            }
-        },
-        "node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/server-services-client": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-            "integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-base": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "axios": "^0.26.0",
-                "crc-32": "1.2.0",
-                "debug": "^4.1.1",
-                "json-stringify-safe": "^5.0.1",
-                "jsrsasign": "^10.5.25",
-                "jwt-decode": "^3.0.0",
-                "querystring": "^0.2.0",
-                "sillyname": "^0.1.0",
-                "uuid": "^8.3.1"
-            }
-        },
-        "node_modules/@fluidframework/server-services-shared": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-1.0.1.tgz",
-            "integrity": "sha512-Z+IyqWHUk/y0aZ5cUXUoehcOiIr4qw1VkDR5i+1rnLntCRkPKk7h6FFXcWo+OBmI7D3AJOKZagMr6npezIPEmQ==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-base": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "@fluidframework/server-services-client": "^1.0.1",
-                "@fluidframework/server-services-core": "^1.0.1",
-                "@fluidframework/server-services-telemetry": "^1.0.1",
-                "@socket.io/redis-adapter": "^7.2.0",
-                "body-parser": "^1.17.1",
-                "debug": "^4.1.1",
-                "events": "^3.1.0",
-                "ioredis": "^5.2.3",
-                "lodash": "^4.17.21",
-                "nconf": "^0.12.0",
-                "notepack.io": "^2.3.0",
-                "querystring": "^0.2.0",
-                "serialize-error": "^8.1.0",
-                "socket.io": "^4.5.3",
-                "socket.io-adapter": "^2.4.0",
-                "socket.io-parser": "^4.2.1",
-                "uuid": "^8.3.1",
-                "winston": "^3.6.0"
-            }
-        },
-        "node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/common-utils": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-            "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1",
-                "@types/events": "^3.0.0",
-                "base64-js": "^1.5.1",
-                "buffer": "^6.0.3",
-                "events": "^3.1.0",
-                "lodash": "^4.17.21",
-                "sha.js": "^2.4.11"
-            }
-        },
-        "node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/gitresources": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-            "integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-            "dev": true
-        },
-        "node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-base": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-            "integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "events": "^3.1.0"
-            }
-        },
-        "node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-definitions": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-            "integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1"
-            }
-        },
-        "node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/server-services-client": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-            "integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-base": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "axios": "^0.26.0",
-                "crc-32": "1.2.0",
-                "debug": "^4.1.1",
-                "json-stringify-safe": "^5.0.1",
-                "jsrsasign": "^10.5.25",
-                "jwt-decode": "^3.0.0",
-                "querystring": "^0.2.0",
-                "sillyname": "^0.1.0",
-                "uuid": "^8.3.1"
-            }
-        },
-        "node_modules/@fluidframework/server-services-telemetry": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-1.0.1.tgz",
-            "integrity": "sha512-qeNtIr5mnkDS5hwD9t+2kcmsRK4zxdAtR+F0j0/rZ/pBWuaVmJI6YiKC5HzWTuszW5F1VDpGnul0M8HEWyhrgQ==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "json-stringify-safe": "^5.0.1",
-                "path-browserify": "^1.0.1",
-                "serialize-error": "^8.1.0",
-                "uuid": "^8.3.1"
-            }
-        },
-        "node_modules/@fluidframework/server-services-telemetry/node_modules/@fluidframework/common-utils": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-            "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1",
-                "@types/events": "^3.0.0",
-                "base64-js": "^1.5.1",
-                "buffer": "^6.0.3",
-                "events": "^3.1.0",
-                "lodash": "^4.17.21",
-                "sha.js": "^2.4.11"
-            }
-        },
-        "node_modules/@fluidframework/server-services-utils": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-1.0.1.tgz",
-            "integrity": "sha512-MzoonbJ/EQMbPi+m7/TZxWqyYzs1wxOdtN/Fe4FkaKOcHJjXR1e33iBw3YTkMQR9W8Z8E3WfSe6UVmzNDNH1TQ==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "@fluidframework/server-services-client": "^1.0.1",
-                "@fluidframework/server-services-core": "^1.0.1",
-                "@fluidframework/server-services-telemetry": "^1.0.1",
-                "debug": "^4.1.1",
-                "express": "^4.17.3",
-                "ioredis": "^5.2.3",
-                "json-stringify-safe": "^5.0.1",
-                "jsonwebtoken": "^9.0.0",
-                "morgan": "^1.8.1",
-                "nconf": "^0.12.0",
-                "serialize-error": "^8.1.0",
-                "sillyname": "^0.1.0",
-                "split": "^1.0.0",
-                "uuid": "^8.3.1",
-                "winston": "^3.6.0",
-                "winston-transport": "^4.5.0"
-            }
-        },
-        "node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/common-utils": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-            "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1",
-                "@types/events": "^3.0.0",
-                "base64-js": "^1.5.1",
-                "buffer": "^6.0.3",
-                "events": "^3.1.0",
-                "lodash": "^4.17.21",
-                "sha.js": "^2.4.11"
-            }
-        },
-        "node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/gitresources": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-            "integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-            "dev": true
-        },
-        "node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-base": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-            "integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "events": "^3.1.0"
-            }
-        },
-        "node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-definitions": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-            "integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1"
-            }
-        },
-        "node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/server-services-client": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-            "integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-base": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "axios": "^0.26.0",
-                "crc-32": "1.2.0",
-                "debug": "^4.1.1",
-                "json-stringify-safe": "^5.0.1",
-                "jsrsasign": "^10.5.25",
-                "jwt-decode": "^3.0.0",
-                "querystring": "^0.2.0",
-                "sillyname": "^0.1.0",
-                "uuid": "^8.3.1"
-            }
-        },
-        "node_modules/@fluidframework/server-services-utils/node_modules/split": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-            "dev": true,
-            "dependencies": {
-                "through": "2"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/@fluidframework/server-test-utils": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-1.0.1.tgz",
-            "integrity": "sha512-+2ZP2pU4eq3KY5EySJhcwyAZqy9WojPhirA+fNUPKblT0fmeAn2ks6mF3d98fcxwqjMPb+5UPLRWDf7/+i1/Aw==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-base": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "@fluidframework/server-services-client": "^1.0.1",
-                "@fluidframework/server-services-core": "^1.0.1",
-                "@fluidframework/server-services-telemetry": "^1.0.1",
-                "assert": "^2.0.0",
-                "debug": "^4.1.1",
-                "events": "^3.1.0",
-                "lodash": "^4.17.21",
-                "string-hash": "^1.1.3",
-                "uuid": "^8.3.1"
-            }
-        },
-        "node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/common-utils": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-            "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1",
-                "@types/events": "^3.0.0",
-                "base64-js": "^1.5.1",
-                "buffer": "^6.0.3",
-                "events": "^3.1.0",
-                "lodash": "^4.17.21",
-                "sha.js": "^2.4.11"
-            }
-        },
-        "node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/gitresources": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-            "integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-            "dev": true
-        },
-        "node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-base": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-            "integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "events": "^3.1.0"
-            }
-        },
-        "node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-definitions": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-            "integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1"
-            }
-        },
-        "node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/server-services-client": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-            "integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-base": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "axios": "^0.26.0",
-                "crc-32": "1.2.0",
-                "debug": "^4.1.1",
-                "json-stringify-safe": "^5.0.1",
-                "jsrsasign": "^10.5.25",
                 "jwt-decode": "^3.0.0",
                 "querystring": "^0.2.0",
                 "sillyname": "^0.1.0",
@@ -3082,12 +2706,6 @@
             "dependencies": {
                 "@hapi/hoek": "^9.0.0"
             }
-        },
-        "node_modules/@ioredis/commands": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-            "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
-            "dev": true
         },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -4204,12 +3822,6 @@
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
             "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-            "dev": true
-        },
-        "node_modules/@types/semver": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.2.tgz",
-            "integrity": "sha512-7aqorHYgdNO4DM36stTiGO3DvKoex9TQRwsJU6vMaFGyqpBA1MNZkz+PG3gaNUPpTAOYhT1WR7M1JyA3fbS9Cw==",
             "dev": true
         },
         "node_modules/@types/send": {
@@ -6320,15 +5932,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/denque": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-            "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
         "node_modules/depd": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -8222,30 +7825,6 @@
             "dev": true,
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/ioredis": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
-            "integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
-            "dev": true,
-            "dependencies": {
-                "@ioredis/commands": "^1.1.1",
-                "cluster-key-slot": "^1.1.0",
-                "debug": "^4.3.4",
-                "denque": "^2.1.0",
-                "lodash.defaults": "^4.2.0",
-                "lodash.isarguments": "^3.1.0",
-                "redis-errors": "^1.2.0",
-                "redis-parser": "^3.0.0",
-                "standard-as-callback": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=12.22.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/ioredis"
             }
         },
         "node_modules/ip": {
@@ -11041,6 +10620,12 @@
             "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
             "dev": true
         },
+        "node_modules/lodash.flatten": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+            "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+            "dev": true
+        },
         "node_modules/lodash.includes": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -12602,6 +12187,12 @@
                 "node": ">= 10.13.0"
             }
         },
+        "node_modules/redis-commands": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+            "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
+            "dev": true
+        },
         "node_modules/redis-errors": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
@@ -14028,128 +13619,6 @@
             "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
             "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
             "dev": true
-        },
-        "node_modules/tinylicious": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-1.0.0.tgz",
-            "integrity": "sha512-ACL8mEKT5LPbFyAXCDjYWqi3vcNef7y2ABMnU3O4jK1cRuEn0MywH7ppMM5ZrMgtSMMsJAINcWxZjpq3ndH8hg==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.0",
-                "@fluidframework/protocol-base": "^1.0.0",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "@fluidframework/server-lambdas": "^1.0.0",
-                "@fluidframework/server-local-server": "^1.0.0",
-                "@fluidframework/server-memory-orderer": "^1.0.0",
-                "@fluidframework/server-services-client": "^1.0.0",
-                "@fluidframework/server-services-core": "^1.0.0",
-                "@fluidframework/server-services-shared": "^1.0.0",
-                "@fluidframework/server-services-telemetry": "^1.0.0",
-                "@fluidframework/server-services-utils": "^1.0.0",
-                "@fluidframework/server-test-utils": "^1.0.0",
-                "agentkeepalive": "^4.2.1",
-                "axios": "^0.26.0",
-                "body-parser": "^1.17.1",
-                "charwise": "^3.0.1",
-                "compression": "^1.7.2",
-                "cookie-parser": "^1.4.3",
-                "cors": "^2.8.4",
-                "detect-port": "^1.3.0",
-                "express": "^4.17.3",
-                "isomorphic-git": "^1.8.2",
-                "json-stringify-safe": "^5.0.1",
-                "level": "^8.0.0",
-                "level-sublevel": "6.6.4",
-                "lodash": "^4.17.21",
-                "morgan": "^1.8.1",
-                "nconf": "^0.12.0",
-                "socket.io": "^4.5.0",
-                "split": "^1.0.0",
-                "uuid": "^8.3.2",
-                "winston": "^3.6.0"
-            },
-            "bin": {
-                "tinylicious": "dist/index.js"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/tinylicious/node_modules/@fluidframework/common-utils": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-            "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1",
-                "@types/events": "^3.0.0",
-                "base64-js": "^1.5.1",
-                "buffer": "^6.0.3",
-                "events": "^3.1.0",
-                "lodash": "^4.17.21",
-                "sha.js": "^2.4.11"
-            }
-        },
-        "node_modules/tinylicious/node_modules/@fluidframework/gitresources": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-            "integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-            "dev": true
-        },
-        "node_modules/tinylicious/node_modules/@fluidframework/protocol-base": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-            "integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "events": "^3.1.0"
-            }
-        },
-        "node_modules/tinylicious/node_modules/@fluidframework/protocol-definitions": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-            "integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1"
-            }
-        },
-        "node_modules/tinylicious/node_modules/@fluidframework/server-services-client": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-            "integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^1.0.1",
-                "@fluidframework/protocol-base": "^1.0.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "axios": "^0.26.0",
-                "crc-32": "1.2.0",
-                "debug": "^4.1.1",
-                "json-stringify-safe": "^5.0.1",
-                "jsrsasign": "^10.5.25",
-                "jwt-decode": "^3.0.0",
-                "querystring": "^0.2.0",
-                "sillyname": "^0.1.0",
-                "uuid": "^8.3.1"
-            }
-        },
-        "node_modules/tinylicious/node_modules/split": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-            "dev": true,
-            "dependencies": {
-                "through": "2"
-            },
-            "engines": {
-                "node": "*"
-            }
         },
         "node_modules/tmpl": {
             "version": "1.0.5",

--- a/multi-framework-diceroller/package-lock.json
+++ b/multi-framework-diceroller/package-lock.json
@@ -19,7 +19,6 @@
             "devDependencies": {
                 "@babel/core": "^7.15.5",
                 "@babel/preset-env": "^7.15.0",
-                "@fluidframework/azure-local-service": "^1.1.0",
                 "@fluidframework/build-common": "^2.0.0",
                 "babel-loader": "^8.2.2",
                 "clean-webpack-plugin": "^3.0.0",
@@ -1763,26 +1762,6 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
-        "node_modules/@colors/colors": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-            "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.1.90"
-            }
-        },
-        "node_modules/@dabh/diagnostics": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-            "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
-            "dev": true,
-            "dependencies": {
-                "colorspace": "1.1.x",
-                "enabled": "2.0.x",
-                "kuler": "^2.0.0"
-            }
-        },
         "node_modules/@discoveryjs/json-ext": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -1813,412 +1792,6 @@
                 "@fluidframework/synthesize": "^1.3.7",
                 "@fluidframework/view-interfaces": "^1.3.7",
                 "uuid": "^8.3.1"
-            }
-        },
-        "node_modules/@fluidframework/azure-local-service": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-1.1.1.tgz",
-            "integrity": "sha512-gvk+qy8RytXBQaZ554OREszHGN73W3FmgpfwV+aXeOOP5RWLMPSvkPoac5K9gcUYN+nAFbRs517c055yucP9ug==",
-            "dev": true,
-            "dependencies": {
-                "tinylicious": "^0.4.89251"
-            },
-            "bin": {
-                "azure-local-service": "dist/index.js"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/common-utils": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-            "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1",
-                "@types/events": "^3.0.0",
-                "base64-js": "^1.5.1",
-                "buffer": "^6.0.3",
-                "events": "^3.1.0",
-                "lodash": "^4.17.21",
-                "sha.js": "^2.4.11"
-            }
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/gitresources": {
-            "version": "0.1038.4001",
-            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
-            "integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
-            "dev": true
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-base": {
-            "version": "0.1038.4001",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
-            "integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^0.1038.4001",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "events": "^3.1.0",
-                "lodash": "^4.17.21"
-            }
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-definitions": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-            "integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1"
-            }
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas": {
-            "version": "0.1038.4001",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.4001.tgz",
-            "integrity": "sha512-rERfgXK5DXGJvxADjotkAZssKgp3ZxW6u7yUekrDnFDkXtbCW1Gcq+EwvjHTEyhsOp30YBnD0Z39xnZy4zEZRw==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^0.1038.4001",
-                "@fluidframework/protocol-base": "^0.1038.4001",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "@fluidframework/server-lambdas-driver": "^0.1038.4001",
-                "@fluidframework/server-services-client": "^0.1038.4001",
-                "@fluidframework/server-services-core": "^0.1038.4001",
-                "@fluidframework/server-services-telemetry": "^0.1038.4001",
-                "@types/semver": "^6.0.1",
-                "assert": "^2.0.0",
-                "async": "^3.2.2",
-                "axios": "^0.26.0",
-                "buffer": "^6.0.3",
-                "double-ended-queue": "^2.1.0-0",
-                "events": "^3.1.0",
-                "json-stringify-safe": "^5.0.1",
-                "lodash": "^4.17.21",
-                "nconf": "^0.12.0",
-                "semver": "^6.3.0",
-                "sha.js": "^2.4.11",
-                "uuid": "^8.3.1"
-            }
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas-driver": {
-            "version": "0.1038.4001",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.4001.tgz",
-            "integrity": "sha512-qRs+vMbSS9aPx7vr3XemvER5DeY/nsJ5ZkcL3UDjUOxvLZxbOAD6C6JeH3Zgzc/jc8bqshcxai/u7qso2zCsFw==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/server-services-client": "^0.1038.4001",
-                "@fluidframework/server-services-core": "^0.1038.4001",
-                "@fluidframework/server-services-telemetry": "^0.1038.4001",
-                "assert": "^2.0.0",
-                "async": "^3.2.2",
-                "events": "^3.1.0",
-                "lodash": "^4.17.21"
-            }
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-local-server": {
-            "version": "0.1038.4001",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.4001.tgz",
-            "integrity": "sha512-FIlNUc9Ncul/5qzP+VyU53TJj8fxX7KZ1lweswZYalleRZwiqFA4Y+NbWRRWM0iJ1z8hvhyRZblG3iNrpGl04A==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "@fluidframework/server-lambdas": "^0.1038.4001",
-                "@fluidframework/server-memory-orderer": "^0.1038.4001",
-                "@fluidframework/server-services-client": "^0.1038.4001",
-                "@fluidframework/server-services-core": "^0.1038.4001",
-                "@fluidframework/server-services-telemetry": "^0.1038.4001",
-                "@fluidframework/server-test-utils": "^0.1038.4001",
-                "debug": "^4.1.1",
-                "events": "^3.1.0",
-                "jsrsasign": "^10.5.25",
-                "uuid": "^8.3.1"
-            }
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-memory-orderer": {
-            "version": "0.1038.4001",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.4001.tgz",
-            "integrity": "sha512-fdzTCLFRh8QfyY17MnB22/o8x2XEX1+wZrm+dn+1Av+ZVe/+ZhfdX5LsQCMKYv+X5mgAauNmC/12mQE4H6jvsQ==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/protocol-base": "^0.1038.4001",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "@fluidframework/server-lambdas": "^0.1038.4001",
-                "@fluidframework/server-services-client": "^0.1038.4001",
-                "@fluidframework/server-services-core": "^0.1038.4001",
-                "@fluidframework/server-services-telemetry": "^0.1038.4001",
-                "@types/debug": "^4.1.5",
-                "@types/double-ended-queue": "^2.1.0",
-                "@types/lodash": "^4.14.118",
-                "@types/node": "^14.18.0",
-                "@types/ws": "^6.0.1",
-                "assert": "^2.0.0",
-                "debug": "^4.1.1",
-                "double-ended-queue": "^2.1.0-0",
-                "events": "^3.1.0",
-                "lodash": "^4.17.21",
-                "sillyname": "^0.1.0",
-                "uuid": "^8.3.1",
-                "ws": "^7.4.6"
-            }
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-client": {
-            "version": "0.1038.4001",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
-            "integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^0.1038.4001",
-                "@fluidframework/protocol-base": "^0.1038.4001",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "axios": "^0.26.0",
-                "crc-32": "1.2.0",
-                "debug": "^4.1.1",
-                "json-stringify-safe": "^5.0.1",
-                "jsrsasign": "^10.5.25",
-                "jwt-decode": "^3.0.0",
-                "querystring": "^0.2.0",
-                "sillyname": "^0.1.0",
-                "uuid": "^8.3.1"
-            }
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-core": {
-            "version": "0.1038.4001",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.4001.tgz",
-            "integrity": "sha512-nuZ9ebvyeIoRdlpQQpBNGkawKtc2/tHKbc8CHbMZRMh7F7kwYUtoHd/J8powb9eUcg5IHDmXx1l+PQRbQX4vCg==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^0.1038.4001",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "@fluidframework/server-services-client": "^0.1038.4001",
-                "@fluidframework/server-services-telemetry": "^0.1038.4001",
-                "@types/nconf": "^0.10.2",
-                "@types/node": "^14.18.0",
-                "debug": "^4.1.1",
-                "events": "^3.1.0",
-                "nconf": "^0.12.0"
-            }
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-shared": {
-            "version": "0.1038.4001",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.4001.tgz",
-            "integrity": "sha512-vDRB2G/Xnuhan+Ri0Eg5JMKfsm7hxstCXdEyQhzJzC7+bw66wts+ZIsEsn4Ha/3KkxblF/RSW3lBhrYpxii3cQ==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^0.1038.4001",
-                "@fluidframework/protocol-base": "^0.1038.4001",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "@fluidframework/server-services-client": "^0.1038.4001",
-                "@fluidframework/server-services-core": "^0.1038.4001",
-                "@fluidframework/server-services-telemetry": "^0.1038.4001",
-                "@socket.io/redis-adapter": "^7.2.0",
-                "body-parser": "^1.17.1",
-                "debug": "^4.1.1",
-                "events": "^3.1.0",
-                "ioredis": "^4.24.2",
-                "lodash": "^4.17.21",
-                "nconf": "^0.12.0",
-                "notepack.io": "^2.3.0",
-                "querystring": "^0.2.0",
-                "socket.io": "^4.5.3",
-                "socket.io-adapter": "^2.4.0",
-                "socket.io-parser": "^4.2.1",
-                "uuid": "^8.3.1",
-                "winston": "^3.6.0"
-            }
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-telemetry": {
-            "version": "0.1038.4001",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.4001.tgz",
-            "integrity": "sha512-2leJhB04+71RTmC5ShRXm/4FWng9tLn9dlrUAjApZH4RlUJAx1JGsvo/5JU1tIbpUutMHUle2IpWyfu/RV+S5g==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "json-stringify-safe": "^5.0.1",
-                "path-browserify": "^1.0.1",
-                "serialize-error": "^8.1.0",
-                "uuid": "^8.3.1"
-            }
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-utils": {
-            "version": "0.1038.4001",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.4001.tgz",
-            "integrity": "sha512-K7X/0mlonDAu0pPIgTz8U9nLwRSbJY2oBpFPwpkp1UtE6SU02jx2ZzraT9epDmOl3EXeS1rHzA+mbvBSe1aFMg==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "@fluidframework/server-services-client": "^0.1038.4001",
-                "@fluidframework/server-services-core": "^0.1038.4001",
-                "@fluidframework/server-services-telemetry": "^0.1038.4001",
-                "debug": "^4.1.1",
-                "express": "^4.17.3",
-                "ioredis": "^4.24.2",
-                "json-stringify-safe": "^5.0.1",
-                "jsonwebtoken": "^9.0.0",
-                "morgan": "^1.8.1",
-                "nconf": "^0.12.0",
-                "serialize-error": "^8.1.0",
-                "sillyname": "^0.1.0",
-                "split": "^1.0.0",
-                "uuid": "^8.3.1",
-                "winston": "^3.6.0",
-                "winston-transport": "^4.5.0"
-            }
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-test-utils": {
-            "version": "0.1038.4001",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.4001.tgz",
-            "integrity": "sha512-qrLp5H1UUPIJSEHlzZ1iYlPFJCQrd2WnmoafxnQIg0mfU1ZE8XUlG5MKUg8bT9pWsCoEGJDiOkkRHaq+WXupjQ==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.1.1",
-                "@fluidframework/gitresources": "^0.1038.4001",
-                "@fluidframework/protocol-base": "^0.1038.4001",
-                "@fluidframework/protocol-definitions": "^1.1.0",
-                "@fluidframework/server-services-client": "^0.1038.4001",
-                "@fluidframework/server-services-core": "^0.1038.4001",
-                "@fluidframework/server-services-telemetry": "^0.1038.4001",
-                "assert": "^2.0.0",
-                "debug": "^4.1.1",
-                "events": "^3.1.0",
-                "lodash": "^4.17.21",
-                "string-hash": "^1.1.3",
-                "uuid": "^8.3.1"
-            }
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/@types/node": {
-            "version": "14.18.63",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-            "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-            "dev": true
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/@types/semver": {
-            "version": "6.2.5",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.5.tgz",
-            "integrity": "sha512-NAxro9/RqWXTqdSjccDZAjA4nXK+6zRun+HvibYJfGy8TQhpOC7Vv6v2rlHYKrT0Q8jGGoNRd/xVdHRIQRNlFQ==",
-            "dev": true
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/denque": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-            "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/ioredis": {
-            "version": "4.28.5",
-            "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
-            "integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
-            "dev": true,
-            "dependencies": {
-                "cluster-key-slot": "^1.1.0",
-                "debug": "^4.3.1",
-                "denque": "^1.1.0",
-                "lodash.defaults": "^4.2.0",
-                "lodash.flatten": "^4.4.0",
-                "lodash.isarguments": "^3.1.0",
-                "p-map": "^2.1.0",
-                "redis-commands": "1.7.0",
-                "redis-errors": "^1.2.0",
-                "redis-parser": "^3.0.0",
-                "standard-as-callback": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/ioredis"
-            }
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/split": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-            "dev": true,
-            "dependencies": {
-                "through": "2"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/tinylicious": {
-            "version": "0.4.94771",
-            "resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
-            "integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
-            "dev": true,
-            "dependencies": {
-                "@fluidframework/common-utils": "^1.0.0",
-                "@fluidframework/gitresources": "^0.1038.1000",
-                "@fluidframework/protocol-base": "^0.1038.1000",
-                "@fluidframework/protocol-definitions": "^1.0.0",
-                "@fluidframework/server-lambdas": "^0.1038.1000",
-                "@fluidframework/server-local-server": "^0.1038.1000",
-                "@fluidframework/server-memory-orderer": "^0.1038.1000",
-                "@fluidframework/server-services-client": "^0.1038.1000",
-                "@fluidframework/server-services-core": "^0.1038.1000",
-                "@fluidframework/server-services-shared": "^0.1038.1000",
-                "@fluidframework/server-services-telemetry": "^0.1038.1000",
-                "@fluidframework/server-services-utils": "^0.1038.1000",
-                "@fluidframework/server-test-utils": "^0.1038.1000",
-                "agentkeepalive": "^4.2.1",
-                "axios": "^0.26.0",
-                "body-parser": "^1.17.1",
-                "charwise": "^3.0.1",
-                "compression": "^1.7.2",
-                "cookie-parser": "^1.4.3",
-                "cors": "^2.8.4",
-                "detect-port": "^1.3.0",
-                "express": "^4.16.3",
-                "isomorphic-git": "^1.8.2",
-                "json-stringify-safe": "^5.0.1",
-                "level": "^8.0.0",
-                "level-sublevel": "6.6.4",
-                "lodash": "^4.17.21",
-                "morgan": "^1.8.1",
-                "nconf": "^0.12.0",
-                "socket.io": "^4.5.0",
-                "split": "^1.0.0",
-                "uuid": "^8.3.2",
-                "winston": "^3.6.0"
-            },
-            "bin": {
-                "tinylicious": "dist/index.js"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@fluidframework/azure-local-service/node_modules/ws": {
-            "version": "7.5.9",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-            "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=8.3.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@fluidframework/build-common": {
@@ -3503,27 +3076,6 @@
             "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
             "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
         },
-        "node_modules/@socket.io/redis-adapter": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-7.2.0.tgz",
-            "integrity": "sha512-/r6oF6Myz0K9uatB/pfCi0BhKg/KRMh1OokrqcjlNz6aq40WiXdFLRbHJQuwGHq/KvB+D6141K+IynbVxZGvhw==",
-            "dev": true,
-            "dependencies": {
-                "debug": "~4.3.1",
-                "notepack.io": "~2.2.0",
-                "socket.io-adapter": "^2.4.0",
-                "uid2": "0.0.3"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/@socket.io/redis-adapter/node_modules/notepack.io": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.2.0.tgz",
-            "integrity": "sha512-9b5w3t5VSH6ZPosoYnyDONnUTF8o0UkBw7JLA6eBlYJWyGT1Q3vQa8Hmuj1/X6RYvHjjygBDgw6fJhe0JEojfw==",
-            "dev": true
-        },
         "node_modules/@tootallnate/quickjs-emscripten": {
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -3608,36 +3160,6 @@
                 "@types/express-serve-static-core": "*",
                 "@types/node": "*"
             }
-        },
-        "node_modules/@types/cookie": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-            "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-            "dev": true
-        },
-        "node_modules/@types/cors": {
-            "version": "2.8.14",
-            "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.14.tgz",
-            "integrity": "sha512-RXHUvNWYICtbP6s18PnOCaqToK8y14DnLd75c6HfyKf228dxy7pHNOQkxPtvXKp/hINFMDjbYzsj63nnpPMSRQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/debug": {
-            "version": "4.1.8",
-            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
-            "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/ms": "*"
-            }
-        },
-        "node_modules/@types/double-ended-queue": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@types/double-ended-queue/-/double-ended-queue-2.1.3.tgz",
-            "integrity": "sha512-PWBSlai2jeSM3xOlr4JPI0oDiGFLVkVvylJ1nK1+oK9V/RiBIqDy8vCtsk+gOQN/I1gU6O1cR1OHheBanFdbCQ==",
-            "dev": true
         },
         "node_modules/@types/eslint": {
             "version": "8.44.2",
@@ -3764,12 +3286,6 @@
             "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
             "dev": true
         },
-        "node_modules/@types/lodash": {
-            "version": "4.14.198",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.198.tgz",
-            "integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg==",
-            "dev": true
-        },
         "node_modules/@types/mime": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -3780,18 +3296,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
             "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-            "dev": true
-        },
-        "node_modules/@types/ms": {
-            "version": "0.7.31",
-            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-            "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
-            "dev": true
-        },
-        "node_modules/@types/nconf": {
-            "version": "0.10.3",
-            "resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.3.tgz",
-            "integrity": "sha512-leyIuBk/rMIp9114FlPRkc/cQG+/JzCz1Afx3BD+CwK2ep3ZRxoC843V1rqnE2pC/jRRjANWhuVBEn4clCwlug==",
             "dev": true
         },
         "node_modules/@types/node": {
@@ -3881,12 +3385,6 @@
             "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
             "dev": true
         },
-        "node_modules/@types/triple-beam": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.3.tgz",
-            "integrity": "sha512-6tOUG+nVHn0cJbVp25JFayS5UE6+xlbcNF9Lo9mU7U0zk3zeUShZied4YEQZjy1JBF043FSkdXw8YkUJuVtB5g==",
-            "dev": true
-        },
         "node_modules/@types/uglify-js": {
             "version": "3.17.1",
             "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.17.1.tgz",
@@ -3928,15 +3426,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/@types/ws": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
-            "integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "*"
             }
         },
         "node_modules/@types/yargs": {
@@ -4279,47 +3768,6 @@
                 "node": ">=6.5"
             }
         },
-        "node_modules/abstract-level": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
-            "integrity": "sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==",
-            "dev": true,
-            "dependencies": {
-                "buffer": "^6.0.3",
-                "catering": "^2.1.0",
-                "is-buffer": "^2.0.5",
-                "level-supports": "^4.0.0",
-                "level-transcoder": "^1.0.1",
-                "module-error": "^1.0.1",
-                "queue-microtask": "^1.2.3"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/abstract-level/node_modules/is-buffer": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-            "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/accepts": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -4354,15 +3802,6 @@
                 "acorn": "^8"
             }
         },
-        "node_modules/address": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/address/-/address-1.2.1.tgz",
-            "integrity": "sha512-B+6bi5D34+fDYENiH5qOlA0cV2rAGKuWZ9LeyUUehbXy8e0VS9e498yO0Jeeh+iM+6KbfudHTFjXw2MmJD4QRA==",
-            "dev": true,
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
         "node_modules/agent-base": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
@@ -4373,29 +3812,6 @@
             },
             "engines": {
                 "node": ">= 14"
-            }
-        },
-        "node_modules/agentkeepalive": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
-            "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
-            "dev": true,
-            "dependencies": {
-                "debug": "^4.1.0",
-                "depd": "^1.1.2",
-                "humanize-ms": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 8.0.0"
-            }
-        },
-        "node_modules/agentkeepalive/node_modules/depd": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-            "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.6"
             }
         },
         "node_modules/ajv": {
@@ -4583,19 +3999,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/assert": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
-            "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "is-nan": "^1.3.2",
-                "object-is": "^1.1.5",
-                "object.assign": "^4.1.4",
-                "util": "^0.12.5"
-            }
-        },
         "node_modules/ast-types": {
             "version": "0.13.4",
             "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -4608,35 +4011,11 @@
                 "node": ">=4"
             }
         },
-        "node_modules/async": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-            "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-            "dev": true
-        },
-        "node_modules/async-lock": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz",
-            "integrity": "sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ==",
-            "dev": true
-        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "dev": true
-        },
-        "node_modules/available-typed-arrays": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/axios": {
             "version": "0.26.1",
@@ -4896,33 +4275,6 @@
                 }
             ]
         },
-        "node_modules/base64id": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-            "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-            "dev": true,
-            "engines": {
-                "node": "^4.5.0 || >= 5.9"
-            }
-        },
-        "node_modules/basic-auth": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-            "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-            "dev": true,
-            "dependencies": {
-                "safe-buffer": "5.1.2"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/basic-auth/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
-        },
         "node_modules/basic-ftp": {
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
@@ -5050,18 +4402,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/browser-level": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
-            "integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
-            "dev": true,
-            "dependencies": {
-                "abstract-level": "^1.0.2",
-                "catering": "^2.1.1",
-                "module-error": "^1.0.2",
-                "run-parallel-limit": "^1.1.0"
-            }
-        },
         "node_modules/browserslist": {
             "version": "4.21.4",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
@@ -5130,12 +4470,6 @@
                 "node": "*"
             }
         },
-        "node_modules/buffer-equal-constant-time": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-            "dev": true
-        },
         "node_modules/buffer-from": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -5149,25 +4483,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/bytewise": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-            "integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
-            "dev": true,
-            "dependencies": {
-                "bytewise-core": "^1.2.2",
-                "typewise": "^1.0.3"
-            }
-        },
-        "node_modules/bytewise-core": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-            "integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
-            "dev": true,
-            "dependencies": {
-                "typewise-core": "^1.2"
             }
         },
         "node_modules/call-bind": {
@@ -5225,15 +4540,6 @@
                 }
             ]
         },
-        "node_modules/catering": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
-            "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/chalk": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -5255,12 +4561,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/charwise": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz",
-            "integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw==",
-            "dev": true
         },
         "node_modules/check-more-types": {
             "version": "2.24.0",
@@ -5331,23 +4631,6 @@
             "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
             "dev": true
         },
-        "node_modules/classic-level": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.2.0.tgz",
-            "integrity": "sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==",
-            "dev": true,
-            "hasInstallScript": true,
-            "dependencies": {
-                "abstract-level": "^1.0.2",
-                "catering": "^2.1.0",
-                "module-error": "^1.0.1",
-                "napi-macros": "~2.0.0",
-                "node-gyp-build": "^4.3.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/clean-css": {
             "version": "4.2.4",
             "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
@@ -5359,12 +4642,6 @@
             "engines": {
                 "node": ">= 4.0"
             }
-        },
-        "node_modules/clean-git-ref": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
-            "integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
-            "dev": true
         },
         "node_modules/clean-webpack-plugin": {
             "version": "3.0.0",
@@ -5410,15 +4687,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/cluster-key-slot": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
-            "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5435,16 +4703,6 @@
             "integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
             "dev": true
         },
-        "node_modules/color": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-            "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^1.9.3",
-                "color-string": "^1.6.0"
-            }
-        },
         "node_modules/color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -5458,31 +4716,11 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
-        "node_modules/color-string": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-            "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "^1.0.0",
-                "simple-swizzle": "^0.2.2"
-            }
-        },
         "node_modules/colorette": {
             "version": "2.0.19",
             "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
             "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
             "dev": true
-        },
-        "node_modules/colorspace": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-            "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-            "dev": true,
-            "dependencies": {
-                "color": "^3.1.3",
-                "text-hex": "1.0.x"
-            }
         },
         "node_modules/combined-stream": {
             "version": "1.0.8",
@@ -5612,28 +4850,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/cookie-parser": {
-            "version": "1.4.6",
-            "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-            "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
-            "dev": true,
-            "dependencies": {
-                "cookie": "0.4.1",
-                "cookie-signature": "1.0.6"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/cookie-parser/node_modules/cookie": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-            "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "node_modules/cookie-signature": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -5658,19 +4874,6 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "dev": true
-        },
-        "node_modules/cors": {
-            "version": "2.8.5",
-            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-            "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-            "dev": true,
-            "dependencies": {
-                "object-assign": "^4",
-                "vary": "^1"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
         },
         "node_modules/cosmiconfig": {
             "version": "8.3.6",
@@ -5824,21 +5027,6 @@
                 }
             }
         },
-        "node_modules/decompress-response": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-            "dev": true,
-            "dependencies": {
-                "mimic-response": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/dedent": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -5966,20 +5154,6 @@
             "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
             "dev": true
         },
-        "node_modules/detect-port": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
-            "integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
-            "dev": true,
-            "dependencies": {
-                "address": "^1.0.1",
-                "debug": "4"
-            },
-            "bin": {
-                "detect": "bin/detect-port.js",
-                "detect-port": "bin/detect-port.js"
-            }
-        },
         "node_modules/devtools-protocol": {
             "version": "0.0.1159816",
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1159816.tgz",
@@ -5994,12 +5168,6 @@
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
-        },
-        "node_modules/diff3": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-            "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
-            "dev": true
         },
         "node_modules/dns-equal": {
             "version": "1.0.0",
@@ -6104,15 +5272,6 @@
             "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
             "dev": true
         },
-        "node_modules/ecdsa-sig-formatter": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-            "dev": true,
-            "dependencies": {
-                "safe-buffer": "^5.0.1"
-            }
-        },
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -6151,12 +5310,6 @@
                 "node": ">= 4"
             }
         },
-        "node_modules/enabled": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-            "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
-            "dev": true
-        },
         "node_modules/encodeurl": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -6173,27 +5326,6 @@
             "dev": true,
             "dependencies": {
                 "once": "^1.4.0"
-            }
-        },
-        "node_modules/engine.io": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.2.tgz",
-            "integrity": "sha512-IXsMcGpw/xRfjra46sVZVHiSWo/nJ/3g1337q9KNXtS6YRzbW5yIzTCb9DjhrBe7r3GZQR0I4+nq+4ODk5g/cA==",
-            "dev": true,
-            "dependencies": {
-                "@types/cookie": "^0.4.1",
-                "@types/cors": "^2.8.12",
-                "@types/node": ">=10.0.0",
-                "accepts": "~1.3.4",
-                "base64id": "2.0.0",
-                "cookie": "~0.4.1",
-                "cors": "~2.8.5",
-                "debug": "~4.3.1",
-                "engine.io-parser": "~5.2.1",
-                "ws": "~8.11.0"
-            },
-            "engines": {
-                "node": ">=10.2.0"
             }
         },
         "node_modules/engine.io-client": {
@@ -6234,36 +5366,6 @@
             "integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
             "engines": {
                 "node": ">=10.0.0"
-            }
-        },
-        "node_modules/engine.io/node_modules/cookie": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-            "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/engine.io/node_modules/ws": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-            "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/enhanced-resolve": {
@@ -6307,18 +5409,6 @@
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/errno": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
-            "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-            "dev": true,
-            "dependencies": {
-                "prr": "~1.0.1"
-            },
-            "bin": {
-                "errno": "cli.js"
             }
         },
         "node_modules/error-ex": {
@@ -6785,12 +5875,6 @@
                 "pend": "~1.2.0"
             }
         },
-        "node_modules/fecha": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-            "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
-            "dev": true
-        },
         "node_modules/fill-range": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -6997,12 +6081,6 @@
                 "@fluidframework/sequence": "^1.3.7"
             }
         },
-        "node_modules/fn.name": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-            "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-            "dev": true
-        },
         "node_modules/follow-redirects": {
             "version": "1.15.2",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
@@ -7020,15 +6098,6 @@
                 "debug": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/for-each": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-            "dev": true,
-            "dependencies": {
-                "is-callable": "^1.1.3"
             }
         },
         "node_modules/form-data": {
@@ -7344,18 +6413,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gopd": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-            "dev": true,
-            "dependencies": {
-                "get-intrinsic": "^1.1.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/graceful-fs": {
@@ -7681,15 +6738,6 @@
                 "node": ">=10.17.0"
             }
         },
-        "node_modules/humanize-ms": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-            "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "^2.0.0"
-            }
-        },
         "node_modules/iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -7720,15 +6768,6 @@
                     "url": "https://feross.org/support"
                 }
             ]
-        },
-        "node_modules/ignore": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-            "dev": true,
-            "engines": {
-                "node": ">= 4"
-            }
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
@@ -7840,22 +6879,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/is-arguments": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-arrayish": {
@@ -7985,21 +7008,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/is-generator-function": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-            "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-            "dev": true,
-            "dependencies": {
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-glob": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -8010,22 +7018,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-nan": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-            "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.0",
-                "define-properties": "^1.1.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-negative-zero": {
@@ -8191,21 +7183,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-typed-array": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
-            "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
-            "dev": true,
-            "dependencies": {
-                "which-typed-array": "^1.1.11"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-weakref": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -8258,45 +7235,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/isomorphic-git": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.21.0.tgz",
-            "integrity": "sha512-ZqCAUM63CYepA3fB8H7NVyPSiOkgzIbQ7T+QPrm9xtYgQypN9JUJ5uLMjB5iTfomdJf3mdm6aSxjZwnT6ubvEA==",
-            "dev": true,
-            "dependencies": {
-                "async-lock": "^1.1.0",
-                "clean-git-ref": "^2.0.1",
-                "crc-32": "^1.2.0",
-                "diff3": "0.0.3",
-                "ignore": "^5.1.4",
-                "minimisted": "^2.0.0",
-                "pako": "^1.0.10",
-                "pify": "^4.0.1",
-                "readable-stream": "^3.4.0",
-                "sha.js": "^2.4.9",
-                "simple-get": "^4.0.1"
-            },
-            "bin": {
-                "isogit": "cli.cjs"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/isomorphic-git/node_modules/readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "dev": true,
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/istanbul-lib-coverage": {
@@ -10299,82 +9237,12 @@
                 "graceful-fs": "^4.1.6"
             }
         },
-        "node_modules/jsonwebtoken": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-            "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-            "dev": true,
-            "dependencies": {
-                "jws": "^3.2.2",
-                "lodash.includes": "^4.3.0",
-                "lodash.isboolean": "^3.0.3",
-                "lodash.isinteger": "^4.0.4",
-                "lodash.isnumber": "^3.0.3",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.isstring": "^4.0.1",
-                "lodash.once": "^4.0.0",
-                "ms": "^2.1.1",
-                "semver": "^7.5.4"
-            },
-            "engines": {
-                "node": ">=12",
-                "npm": ">=6"
-            }
-        },
-        "node_modules/jsonwebtoken/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/jsonwebtoken/node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/jsrsasign": {
             "version": "10.8.6",
             "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.8.6.tgz",
             "integrity": "sha512-bQmbVtsfbgaKBTWCKiDCPlUPbdlRIK/FzSwT3BzIgZl/cU6TqXu6pZJsCI/dJVrZ9Gir5GC4woqw9shH/v7MBw==",
             "funding": {
                 "url": "https://github.com/kjur/jsrsasign#donations"
-            }
-        },
-        "node_modules/jwa": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-            "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-            "dev": true,
-            "dependencies": {
-                "buffer-equal-constant-time": "1.0.1",
-                "ecdsa-sig-formatter": "1.0.11",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/jws": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-            "dev": true,
-            "dependencies": {
-                "jwa": "^1.4.1",
-                "safe-buffer": "^5.0.1"
             }
         },
         "node_modules/jwt-decode": {
@@ -10400,12 +9268,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/kuler": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-            "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-            "dev": true
-        },
         "node_modules/launch-editor": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.0.tgz",
@@ -10423,134 +9285,6 @@
             "dev": true,
             "engines": {
                 "node": "> 0.8"
-            }
-        },
-        "node_modules/level": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/level/-/level-8.0.0.tgz",
-            "integrity": "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==",
-            "dev": true,
-            "dependencies": {
-                "browser-level": "^1.0.1",
-                "classic-level": "^1.2.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/level"
-            }
-        },
-        "node_modules/level-codec": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
-            "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
-            "dev": true,
-            "dependencies": {
-                "buffer": "^5.6.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/level-codec/node_modules/buffer": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
-            }
-        },
-        "node_modules/level-errors": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-            "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-            "dev": true,
-            "dependencies": {
-                "errno": "~0.1.1"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/level-iterator-stream": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
-            "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
-            "dev": true,
-            "dependencies": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.5",
-                "xtend": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/level-post": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
-            "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
-            "dev": true,
-            "dependencies": {
-                "ltgt": "^2.1.2"
-            }
-        },
-        "node_modules/level-sublevel": {
-            "version": "6.6.4",
-            "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.4.tgz",
-            "integrity": "sha512-pcCrTUOiO48+Kp6F1+UAzF/OtWqLcQVTVF39HLdZ3RO8XBoXt+XVPKZO1vVr1aUoxHZA9OtD2e1v7G+3S5KFDA==",
-            "dev": true,
-            "dependencies": {
-                "bytewise": "~1.1.0",
-                "level-codec": "^9.0.0",
-                "level-errors": "^2.0.0",
-                "level-iterator-stream": "^2.0.3",
-                "ltgt": "~2.1.1",
-                "pull-defer": "^0.2.2",
-                "pull-level": "^2.0.3",
-                "pull-stream": "^3.6.8",
-                "typewiselite": "~1.0.0",
-                "xtend": "~4.0.0"
-            }
-        },
-        "node_modules/level-supports": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
-            "integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/level-transcoder": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
-            "integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
-            "dev": true,
-            "dependencies": {
-                "buffer": "^6.0.3",
-                "module-error": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/leven": {
@@ -10614,86 +9348,6 @@
             "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
             "dev": true
         },
-        "node_modules/lodash.defaults": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-            "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-            "dev": true
-        },
-        "node_modules/lodash.flatten": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-            "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-            "dev": true
-        },
-        "node_modules/lodash.includes": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-            "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-            "dev": true
-        },
-        "node_modules/lodash.isarguments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-            "dev": true
-        },
-        "node_modules/lodash.isboolean": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-            "dev": true
-        },
-        "node_modules/lodash.isinteger": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-            "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-            "dev": true
-        },
-        "node_modules/lodash.isnumber": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-            "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-            "dev": true
-        },
-        "node_modules/lodash.isplainobject": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-            "dev": true
-        },
-        "node_modules/lodash.isstring": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-            "dev": true
-        },
-        "node_modules/lodash.once": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-            "dev": true
-        },
-        "node_modules/logform": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/logform/-/logform-2.5.1.tgz",
-            "integrity": "sha512-9FyqAm9o9NKKfiAKfZoYo9bGXXuwMkxQiQttkT4YjjVtQVIQtK6LmVtlxmCaFswo6N4AfEkHqZTV0taDtPotNg==",
-            "dev": true,
-            "dependencies": {
-                "@colors/colors": "1.5.0",
-                "@types/triple-beam": "^1.3.2",
-                "fecha": "^4.2.0",
-                "ms": "^2.1.1",
-                "safe-stable-stringify": "^2.3.1",
-                "triple-beam": "^1.3.0"
-            }
-        },
-        "node_modules/looper": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
-            "integrity": "sha512-6DzMHJcjbQX/UPHc1rRCBfKlLwDkvuGZ715cIR36wSdYqWXFT35uLXq5P/2orl3tz+t+VOVPxw4yPinQlUDGDQ==",
-            "dev": true
-        },
         "node_modules/loose-envify": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -10722,12 +9376,6 @@
             "engines": {
                 "node": ">=12"
             }
-        },
-        "node_modules/ltgt": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
-            "integrity": "sha512-5VjHC5GsENtIi5rbJd+feEpDKhfr7j0odoUR2Uh978g+2p93nd5o34cTjQWohXsPsCZeqoDnIqEf88mPCe0Pfw==",
-            "dev": true
         },
         "node_modules/magic-string": {
             "version": "0.25.9",
@@ -10864,18 +9512,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/mimic-response": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/minimalistic-assert": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -10903,15 +9539,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/minimisted": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
-            "integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
-            "dev": true,
-            "dependencies": {
-                "minimist": "^1.2.5"
-            }
-        },
         "node_modules/mitt": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -10935,58 +9562,6 @@
             "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
             "dev": true
-        },
-        "node_modules/module-error": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
-            "integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/morgan": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-            "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
-            "dev": true,
-            "dependencies": {
-                "basic-auth": "~2.0.1",
-                "debug": "2.6.9",
-                "depd": "~2.0.0",
-                "on-finished": "~2.3.0",
-                "on-headers": "~1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/morgan/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/morgan/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true
-        },
-        "node_modules/morgan/node_modules/on-finished": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-            "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-            "dev": true,
-            "dependencies": {
-                "ee-first": "1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
         },
         "node_modules/ms": {
             "version": "2.1.2",
@@ -11017,79 +9592,11 @@
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
-        "node_modules/napi-macros": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
-            "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
-            "dev": true
-        },
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
-        },
-        "node_modules/nconf": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.0.tgz",
-            "integrity": "sha512-T3fZPw3c7Dfrz8JBQEbEcZJ2s8f7cUMpKuyBtsGQe0b71pcXx6gNh4oti2xh5dxB+gO9ufNfISBlGvvWtfyMcA==",
-            "dev": true,
-            "dependencies": {
-                "async": "^3.0.0",
-                "ini": "^2.0.0",
-                "secure-keys": "^1.0.0",
-                "yargs": "^16.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
-        "node_modules/nconf/node_modules/cliui": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-            "dev": true,
-            "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "wrap-ansi": "^7.0.0"
-            }
-        },
-        "node_modules/nconf/node_modules/ini": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-            "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/nconf/node_modules/yargs": {
-            "version": "16.2.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-            "dev": true,
-            "dependencies": {
-                "cliui": "^7.0.2",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.0",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^20.2.2"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/nconf/node_modules/yargs-parser": {
-            "version": "20.2.9",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            }
         },
         "node_modules/negotiator": {
             "version": "0.6.3",
@@ -11153,17 +9660,6 @@
                 "node": ">= 6.13.0"
             }
         },
-        "node_modules/node-gyp-build": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-            "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
-            "dev": true,
-            "bin": {
-                "node-gyp-build": "bin.js",
-                "node-gyp-build-optional": "optional.js",
-                "node-gyp-build-test": "build-test.js"
-            }
-        },
         "node_modules/node-int64": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -11183,12 +9679,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/notepack.io": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.3.0.tgz",
-            "integrity": "sha512-9RiFDxeydHsWOqdthRUck2Kd4UW2NzVd2xxOulZiQ9mvge6ElsHXLpwD3HEJyql6sFEnEn/eMO7HSdS0M5mWkA==",
-            "dev": true
         },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
@@ -11226,22 +9716,6 @@
             "version": "1.12.2",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
             "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/object-is": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-            "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -11325,15 +9799,6 @@
             "dev": true,
             "dependencies": {
                 "wrappy": "1"
-            }
-        },
-        "node_modules/one-time": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-            "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-            "dev": true,
-            "dependencies": {
-                "fn.name": "1.x.x"
             }
         },
         "node_modules/onetime": {
@@ -11467,12 +9932,6 @@
             "engines": {
                 "node": ">= 14"
             }
-        },
-        "node_modules/pako": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-            "dev": true
         },
         "node_modules/param-case": {
             "version": "3.0.4",
@@ -11835,12 +10294,6 @@
             "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
             "dev": true
         },
-        "node_modules/prr": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-            "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-            "dev": true
-        },
         "node_modules/ps-tree": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
@@ -11854,64 +10307,6 @@
             },
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/pull-cat": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
-            "integrity": "sha512-i3w+xZ3DCtTVz8S62hBOuNLRHqVDsHMNZmgrZsjPnsxXUgbWtXEee84lo1XswE7W2a3WHyqsNuDJTjVLAQR8xg==",
-            "dev": true
-        },
-        "node_modules/pull-defer": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
-            "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA==",
-            "dev": true
-        },
-        "node_modules/pull-level": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
-            "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
-            "dev": true,
-            "dependencies": {
-                "level-post": "^1.0.7",
-                "pull-cat": "^1.1.9",
-                "pull-live": "^1.0.1",
-                "pull-pushable": "^2.0.0",
-                "pull-stream": "^3.4.0",
-                "pull-window": "^2.1.4",
-                "stream-to-pull-stream": "^1.7.1"
-            }
-        },
-        "node_modules/pull-live": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
-            "integrity": "sha512-tkNz1QT5gId8aPhV5+dmwoIiA1nmfDOzJDlOOUpU5DNusj6neNd3EePybJ5+sITr2FwyCs/FVpx74YMCfc8YeA==",
-            "dev": true,
-            "dependencies": {
-                "pull-cat": "^1.1.9",
-                "pull-stream": "^3.4.0"
-            }
-        },
-        "node_modules/pull-pushable": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
-            "integrity": "sha512-M7dp95enQ2kaHvfCt2+DJfyzgCSpWVR2h2kWYnVsW6ZpxQBx5wOu0QWOvQPVoPnBLUZYitYP2y7HyHkLQNeGXg==",
-            "dev": true
-        },
-        "node_modules/pull-stream": {
-            "version": "3.6.14",
-            "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
-            "integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew==",
-            "dev": true
-        },
-        "node_modules/pull-window": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
-            "integrity": "sha512-cbDzN76BMlcGG46OImrgpkMf/VkCnupj8JhsrpBw3aWBM9ye345aYnqitmZCgauBkc0HbbRRn9hCnsa3k2FNUg==",
-            "dev": true,
-            "dependencies": {
-                "looper": "^2.0.0"
             }
         },
         "node_modules/pump": {
@@ -12043,26 +10438,6 @@
             "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
             "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
         },
-        "node_modules/queue-microtask": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
         "node_modules/queue-tick": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
@@ -12185,33 +10560,6 @@
             },
             "engines": {
                 "node": ">= 10.13.0"
-            }
-        },
-        "node_modules/redis-commands": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-            "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
-            "dev": true
-        },
-        "node_modules/redis-errors": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-            "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/redis-parser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-            "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-            "dev": true,
-            "dependencies": {
-                "redis-errors": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/regenerate": {
@@ -12455,29 +10803,6 @@
                 "rimraf": "bin.js"
             }
         },
-        "node_modules/run-parallel-limit": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
-            "integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "queue-microtask": "^1.2.2"
-            }
-        },
         "node_modules/rxjs": {
             "version": "7.8.1",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -12520,15 +10845,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/safe-stable-stringify": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-            "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -12561,12 +10877,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             }
-        },
-        "node_modules/secure-keys": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
-            "integrity": "sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg==",
-            "dev": true
         },
         "node_modules/select-hose": {
             "version": "2.0.0",
@@ -12638,33 +10948,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
-        },
-        "node_modules/serialize-error": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
-            "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
-            "dev": true,
-            "dependencies": {
-                "type-fest": "^0.20.2"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/serialize-error/node_modules/type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
         },
         "node_modules/serialize-javascript": {
             "version": "6.0.1",
@@ -12852,66 +11135,6 @@
             "resolved": "https://registry.npmjs.org/sillyname/-/sillyname-0.1.0.tgz",
             "integrity": "sha512-GWA0Zont13ov+cMNw4T7nU4SCyW8jdhD3vjA5+qs8jr+09sCPxOf+FPS5zE0c9pYlCwD+NU/CiMimY462lgG9g=="
         },
-        "node_modules/simple-concat": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
-        "node_modules/simple-get": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "decompress-response": "^6.0.0",
-                "once": "^1.3.1",
-                "simple-concat": "^1.0.0"
-            }
-        },
-        "node_modules/simple-swizzle": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-            "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-            "dev": true,
-            "dependencies": {
-                "is-arrayish": "^0.3.1"
-            }
-        },
-        "node_modules/simple-swizzle/node_modules/is-arrayish": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-            "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-            "dev": true
-        },
         "node_modules/sisteransi": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -12935,54 +11158,6 @@
             "engines": {
                 "node": ">= 6.0.0",
                 "npm": ">= 3.0.0"
-            }
-        },
-        "node_modules/socket.io": {
-            "version": "4.7.2",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.2.tgz",
-            "integrity": "sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==",
-            "dev": true,
-            "dependencies": {
-                "accepts": "~1.3.4",
-                "base64id": "~2.0.0",
-                "cors": "~2.8.5",
-                "debug": "~4.3.2",
-                "engine.io": "~6.5.2",
-                "socket.io-adapter": "~2.5.2",
-                "socket.io-parser": "~4.2.4"
-            },
-            "engines": {
-                "node": ">=10.2.0"
-            }
-        },
-        "node_modules/socket.io-adapter": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
-            "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
-            "dev": true,
-            "dependencies": {
-                "ws": "~8.11.0"
-            }
-        },
-        "node_modules/socket.io-adapter/node_modules/ws": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-            "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/socket.io-client": {
@@ -13175,15 +11350,6 @@
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
             "dev": true
         },
-        "node_modules/stack-trace": {
-            "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-            "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-            "dev": true,
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/stack-utils": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -13204,12 +11370,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/standard-as-callback": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-            "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
-            "dev": true
         },
         "node_modules/start-server-and-test": {
             "version": "2.0.0",
@@ -13253,22 +11413,6 @@
                 "duplexer": "~0.1.1"
             }
         },
-        "node_modules/stream-to-pull-stream": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
-            "integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
-            "dev": true,
-            "dependencies": {
-                "looper": "^3.0.0",
-                "pull-stream": "^3.2.3"
-            }
-        },
-        "node_modules/stream-to-pull-stream/node_modules/looper": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-            "integrity": "sha512-LJ9wplN/uSn72oJRsXTx+snxPet5c8XiZmOKCm906NVYu+ag6SB6vUcnJcWxgnl2NfbIyeobAn7Bwv6xRj2XJg==",
-            "dev": true
-        },
         "node_modules/streamx": {
             "version": "2.15.1",
             "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.1.tgz",
@@ -13292,12 +11436,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
-        },
-        "node_modules/string-hash": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-            "integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
             "dev": true
         },
         "node_modules/string-length": {
@@ -13602,12 +11740,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/text-hex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-            "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-            "dev": true
-        },
         "node_modules/through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -13669,15 +11801,6 @@
                 "tree-kill": "cli.js"
             }
         },
-        "node_modules/triple-beam": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
-            "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
         "node_modules/tslib": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -13717,33 +11840,6 @@
             "engines": {
                 "node": ">= 0.6"
             }
-        },
-        "node_modules/typewise": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-            "integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
-            "dev": true,
-            "dependencies": {
-                "typewise-core": "^1.2.0"
-            }
-        },
-        "node_modules/typewise-core": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-            "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
-            "dev": true
-        },
-        "node_modules/typewiselite": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
-            "integrity": "sha512-J9alhjVHupW3Wfz6qFRGgQw0N3gr8hOkw6zm7FZ6UR1Cse/oD9/JVok7DNE9TT9IbciDHX2Ex9+ksE6cRmtymw==",
-            "dev": true
-        },
-        "node_modules/uid2": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-            "integrity": "sha512-5gSP1liv10Gjp8cMEnFd6shzkL/D6W1uhXSFNCxDC+YI8+L8wkCYCbJ7n77Ezb4wE/xzMogecE+DtamEe9PZjg==",
-            "dev": true
         },
         "node_modules/unbox-primitive": {
             "version": "1.0.2",
@@ -13925,19 +12021,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/util": {
-            "version": "0.12.5",
-            "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-            "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-            "dev": true,
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "is-arguments": "^1.0.4",
-                "is-generator-function": "^1.0.7",
-                "is-typed-array": "^1.1.3",
-                "which-typed-array": "^1.1.2"
             }
         },
         "node_modules/util-deprecate": {
@@ -14513,94 +12596,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/which-typed-array": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
-            "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
-            "dev": true,
-            "dependencies": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/wildcard": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
             "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
             "dev": true
-        },
-        "node_modules/winston": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/winston/-/winston-3.10.0.tgz",
-            "integrity": "sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==",
-            "dev": true,
-            "dependencies": {
-                "@colors/colors": "1.5.0",
-                "@dabh/diagnostics": "^2.0.2",
-                "async": "^3.2.3",
-                "is-stream": "^2.0.0",
-                "logform": "^2.4.0",
-                "one-time": "^1.0.0",
-                "readable-stream": "^3.4.0",
-                "safe-stable-stringify": "^2.3.1",
-                "stack-trace": "0.0.x",
-                "triple-beam": "^1.3.0",
-                "winston-transport": "^4.5.0"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/winston-transport": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
-            "integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
-            "dev": true,
-            "dependencies": {
-                "logform": "^2.3.2",
-                "readable-stream": "^3.6.0",
-                "triple-beam": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 6.4.0"
-            }
-        },
-        "node_modules/winston-transport/node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/winston/node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
@@ -14704,15 +12704,6 @@
             "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/xtend": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.4"
             }
         },
         "node_modules/y18n": {

--- a/multi-framework-diceroller/package.json
+++ b/multi-framework-diceroller/package.json
@@ -35,7 +35,6 @@
     "devDependencies": {
         "@babel/core": "^7.15.5",
         "@babel/preset-env": "^7.15.0",
-        "@fluidframework/azure-local-service": "^1.1.0",
         "@fluidframework/build-common": "^2.0.0",
         "babel-loader": "^8.2.2",
         "clean-webpack-plugin": "^3.0.0",

--- a/multi-framework-diceroller/package.json
+++ b/multi-framework-diceroller/package.json
@@ -20,7 +20,7 @@
         "prettier": "prettier --check . --ignore-path ./.prettierignore",
         "prettier:fix": "prettier --write . --ignore-path ./.prettierignore",
         "start": "webpack serve",
-        "start:server": "npx tinylicious",
+        "start:server": "npx @fluidframework/azure-local-service",
         "test": "start-server-and-test start:server 7070 test:jest",
         "test:jest": "jest"
     },
@@ -35,6 +35,7 @@
     "devDependencies": {
         "@babel/core": "^7.15.5",
         "@babel/preset-env": "^7.15.0",
+        "@fluidframework/azure-local-service": "^1.1.0",
         "@fluidframework/build-common": "^2.0.0",
         "babel-loader": "^8.2.2",
         "clean-webpack-plugin": "^3.0.0",
@@ -45,7 +46,6 @@
         "prettier": "^2.7.1",
         "puppeteer": "^21.0.0",
         "start-server-and-test": "^2.0.0",
-        "tinylicious": "^1.0.0",
         "webpack": "^5.88.2",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^4.15.1"

--- a/node-demo/README.md
+++ b/node-demo/README.md
@@ -5,10 +5,10 @@ Connected clients generate random numbers and display the result of any changes 
 
 ## Getting started
 
-Run Tinylicious server in the background:
+Run `@fluidframework/azure-local-service` server in the background:
 
 ```bash
-npx tinylicious
+npx @fluidframework/azure-local-service
 ```
 
 Open a new terminal and run the client:

--- a/node-demo/package-lock.json
+++ b/node-demo/package-lock.json
@@ -15,14 +15,14 @@
 				"readline-sync": "^1.4.10"
 			},
 			"devDependencies": {
+				"@fluidframework/azure-local-service": "^1.1.0",
 				"@fluidframework/build-common": "^2.0.0",
 				"chai": "^4.3.7",
 				"mocha": "^10.1.0",
 				"mocha-junit-reporter": "^2.2.1",
 				"sinon": "^14.0.2",
 				"sinon-chai": "^3.7.0",
-				"start-server-and-test": "^2.0.0",
-				"tinylicious": "^1.0.0"
+				"start-server-and-test": "^2.0.0"
 			},
 			"engines": {
 				"node": ">=18.0.0"
@@ -69,6 +69,421 @@
 				"@fluidframework/synthesize": "^1.3.7",
 				"@fluidframework/view-interfaces": "^1.3.7",
 				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-1.1.1.tgz",
+			"integrity": "sha512-gvk+qy8RytXBQaZ554OREszHGN73W3FmgpfwV+aXeOOP5RWLMPSvkPoac5K9gcUYN+nAFbRs517c055yucP9ug==",
+			"dev": true,
+			"dependencies": {
+				"tinylicious": "^0.4.89251"
+			},
+			"bin": {
+				"azure-local-service": "dist/index.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/common-utils": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@types/events": "^3.0.0",
+				"base64-js": "^1.5.1",
+				"buffer": "^6.0.3",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sha.js": "^2.4.11"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/gitresources": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
+			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-base": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
+			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-definitions": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.4001.tgz",
+			"integrity": "sha512-rERfgXK5DXGJvxADjotkAZssKgp3ZxW6u7yUekrDnFDkXtbCW1Gcq+EwvjHTEyhsOp30YBnD0Z39xnZy4zEZRw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas-driver": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/semver": "^6.0.1",
+				"assert": "^2.0.0",
+				"async": "^3.2.2",
+				"axios": "^0.26.0",
+				"buffer": "^6.0.3",
+				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
+				"json-stringify-safe": "^5.0.1",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"semver": "^6.3.0",
+				"sha.js": "^2.4.11",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas-driver": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.4001.tgz",
+			"integrity": "sha512-qRs+vMbSS9aPx7vr3XemvER5DeY/nsJ5ZkcL3UDjUOxvLZxbOAD6C6JeH3Zgzc/jc8bqshcxai/u7qso2zCsFw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"assert": "^2.0.0",
+				"async": "^3.2.2",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-local-server": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.4001.tgz",
+			"integrity": "sha512-FIlNUc9Ncul/5qzP+VyU53TJj8fxX7KZ1lweswZYalleRZwiqFA4Y+NbWRRWM0iJ1z8hvhyRZblG3iNrpGl04A==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^0.1038.4001",
+				"@fluidframework/server-memory-orderer": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@fluidframework/server-test-utils": "^0.1038.4001",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"jsrsasign": "^10.5.25",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-memory-orderer": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.4001.tgz",
+			"integrity": "sha512-fdzTCLFRh8QfyY17MnB22/o8x2XEX1+wZrm+dn+1Av+ZVe/+ZhfdX5LsQCMKYv+X5mgAauNmC/12mQE4H6jvsQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/debug": "^4.1.5",
+				"@types/double-ended-queue": "^2.1.0",
+				"@types/lodash": "^4.14.118",
+				"@types/node": "^14.18.0",
+				"@types/ws": "^6.0.1",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1",
+				"ws": "^7.4.6"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-client": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
+			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"axios": "^0.26.0",
+				"crc-32": "1.2.0",
+				"debug": "^4.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"jsrsasign": "^10.5.25",
+				"jwt-decode": "^3.0.0",
+				"querystring": "^0.2.0",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-core": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.4001.tgz",
+			"integrity": "sha512-nuZ9ebvyeIoRdlpQQpBNGkawKtc2/tHKbc8CHbMZRMh7F7kwYUtoHd/J8powb9eUcg5IHDmXx1l+PQRbQX4vCg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/nconf": "^0.10.2",
+				"@types/node": "^14.18.0",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"nconf": "^0.12.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-shared": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.4001.tgz",
+			"integrity": "sha512-vDRB2G/Xnuhan+Ri0Eg5JMKfsm7hxstCXdEyQhzJzC7+bw66wts+ZIsEsn4Ha/3KkxblF/RSW3lBhrYpxii3cQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@socket.io/redis-adapter": "^7.2.0",
+				"body-parser": "^1.17.1",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"ioredis": "^4.24.2",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"notepack.io": "^2.3.0",
+				"querystring": "^0.2.0",
+				"socket.io": "^4.5.3",
+				"socket.io-adapter": "^2.4.0",
+				"socket.io-parser": "^4.2.1",
+				"uuid": "^8.3.1",
+				"winston": "^3.6.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-telemetry": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.4001.tgz",
+			"integrity": "sha512-2leJhB04+71RTmC5ShRXm/4FWng9tLn9dlrUAjApZH4RlUJAx1JGsvo/5JU1tIbpUutMHUle2IpWyfu/RV+S5g==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"path-browserify": "^1.0.1",
+				"serialize-error": "^8.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-utils": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.4001.tgz",
+			"integrity": "sha512-K7X/0mlonDAu0pPIgTz8U9nLwRSbJY2oBpFPwpkp1UtE6SU02jx2ZzraT9epDmOl3EXeS1rHzA+mbvBSe1aFMg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"debug": "^4.1.1",
+				"express": "^4.17.3",
+				"ioredis": "^4.24.2",
+				"json-stringify-safe": "^5.0.1",
+				"jsonwebtoken": "^9.0.0",
+				"morgan": "^1.8.1",
+				"nconf": "^0.12.0",
+				"serialize-error": "^8.1.0",
+				"sillyname": "^0.1.0",
+				"split": "^1.0.0",
+				"uuid": "^8.3.1",
+				"winston": "^3.6.0",
+				"winston-transport": "^4.5.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-test-utils": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.4001.tgz",
+			"integrity": "sha512-qrLp5H1UUPIJSEHlzZ1iYlPFJCQrd2WnmoafxnQIg0mfU1ZE8XUlG5MKUg8bT9pWsCoEGJDiOkkRHaq+WXupjQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"string-hash": "^1.1.3",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@types/node": {
+			"version": "14.18.63",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@types/semver": {
+			"version": "6.2.5",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.5.tgz",
+			"integrity": "sha512-NAxro9/RqWXTqdSjccDZAjA4nXK+6zRun+HvibYJfGy8TQhpOC7Vv6v2rlHYKrT0Q8jGGoNRd/xVdHRIQRNlFQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/denque": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/ioredis": {
+			"version": "4.28.5",
+			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
+			"integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+			"dev": true,
+			"dependencies": {
+				"cluster-key-slot": "^1.1.0",
+				"debug": "^4.3.1",
+				"denque": "^1.1.0",
+				"lodash.defaults": "^4.2.0",
+				"lodash.flatten": "^4.4.0",
+				"lodash.isarguments": "^3.1.0",
+				"p-map": "^2.1.0",
+				"redis-commands": "1.7.0",
+				"redis-errors": "^1.2.0",
+				"redis-parser": "^3.0.0",
+				"standard-as-callback": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ioredis"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/split": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"dev": true,
+			"dependencies": {
+				"through": "2"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/tinylicious": {
+			"version": "0.4.94771",
+			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
+			"integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.0.0",
+				"@fluidframework/gitresources": "^0.1038.1000",
+				"@fluidframework/protocol-base": "^0.1038.1000",
+				"@fluidframework/protocol-definitions": "^1.0.0",
+				"@fluidframework/server-lambdas": "^0.1038.1000",
+				"@fluidframework/server-local-server": "^0.1038.1000",
+				"@fluidframework/server-memory-orderer": "^0.1038.1000",
+				"@fluidframework/server-services-client": "^0.1038.1000",
+				"@fluidframework/server-services-core": "^0.1038.1000",
+				"@fluidframework/server-services-shared": "^0.1038.1000",
+				"@fluidframework/server-services-telemetry": "^0.1038.1000",
+				"@fluidframework/server-services-utils": "^0.1038.1000",
+				"@fluidframework/server-test-utils": "^0.1038.1000",
+				"agentkeepalive": "^4.2.1",
+				"axios": "^0.26.0",
+				"body-parser": "^1.17.1",
+				"charwise": "^3.0.1",
+				"compression": "^1.7.2",
+				"cookie-parser": "^1.4.3",
+				"cors": "^2.8.4",
+				"detect-port": "^1.3.0",
+				"express": "^4.16.3",
+				"isomorphic-git": "^1.8.2",
+				"json-stringify-safe": "^5.0.1",
+				"level": "^8.0.0",
+				"level-sublevel": "6.6.4",
+				"lodash": "^4.17.21",
+				"morgan": "^1.8.1",
+				"nconf": "^0.12.0",
+				"socket.io": "^4.5.0",
+				"split": "^1.0.0",
+				"uuid": "^8.3.2",
+				"winston": "^3.6.0"
+			},
+			"bin": {
+				"tinylicious": "dist/index.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/ws": {
+			"version": "7.5.9",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.3.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@fluidframework/build-common": {
@@ -439,375 +854,6 @@
 				"uuid": "^8.3.1"
 			}
 		},
-		"node_modules/@fluidframework/server-lambdas": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-1.0.1.tgz",
-			"integrity": "sha512-lwVKg4dVDvbNH4ckj328z5cNu1plHhArzIMP3kpl8T94L6OubqsJ8vf3g46Wab/SjwltHC41p/wWigJapXZjqA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas-driver": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/semver": "^7.5.0",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"axios": "^0.26.0",
-				"buffer": "^6.0.3",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"semver": "^7.5.3",
-				"sha.js": "^2.4.11",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-1.0.1.tgz",
-			"integrity": "sha512-TfQ7rz2/6pW6Rq5CbGBu9ShiSKyOHg2pXX0cUVHtnuuUPsWTxQDWlVilYukyG0uxHJfE3ZDU3R1QgnWUQQmGgg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-1.0.1.tgz",
-			"integrity": "sha512-494H0PYNa6aqngyq/M46K7wlY7NHdIx1B4qcfRCRQmjJZrD9GPza3FHt2/426teBQ93F6SOKkBrMw2vbmoUUGg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.1",
-				"@fluidframework/server-memory-orderer": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@fluidframework/server-test-utils": "^1.0.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"jsrsasign": "^10.5.25",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-1.0.1.tgz",
-			"integrity": "sha512-zUuNICwyKC7OTSl/W9MSiwplSccnRHVmRpdxImCe5qVs+VSK1jHuIGiIzCkt6dlVNMu3WHyUXmrKCLmhJZmFeQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/debug": "^4.1.5",
-				"@types/double-ended-queue": "^2.1.0",
-				"@types/lodash": "^4.14.118",
-				"@types/node": "^16.18.16",
-				"@types/ws": "^6.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1",
-				"ws": "^7.4.6"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/ws": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@fluidframework/server-services-client": {
 			"version": "0.1036.5001",
 			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5001.tgz",
@@ -822,392 +868,6 @@
 				"debug": "^4.1.1",
 				"json-stringify-safe": "^5.0.1",
 				"jsrsasign": "^10.2.0",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-1.0.1.tgz",
-			"integrity": "sha512-/Lb5ZZxb4aHtzLH3p+lrboi6TW/WD0I53di8FI4rMmn5AM7+h69BolPW7nume52t3HUi1I2Mnqhx1W8FKV8BbA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/nconf": "^0.10.2",
-				"@types/node": "^16.18.16",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"nconf": "^0.12.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-1.0.1.tgz",
-			"integrity": "sha512-Z+IyqWHUk/y0aZ5cUXUoehcOiIr4qw1VkDR5i+1rnLntCRkPKk7h6FFXcWo+OBmI7D3AJOKZagMr6npezIPEmQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@socket.io/redis-adapter": "^7.2.0",
-				"body-parser": "^1.17.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"ioredis": "^5.2.3",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"notepack.io": "^2.3.0",
-				"querystring": "^0.2.0",
-				"serialize-error": "^8.1.0",
-				"socket.io": "^4.5.3",
-				"socket.io-adapter": "^2.4.0",
-				"socket.io-parser": "^4.2.1",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-telemetry": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-1.0.1.tgz",
-			"integrity": "sha512-qeNtIr5mnkDS5hwD9t+2kcmsRK4zxdAtR+F0j0/rZ/pBWuaVmJI6YiKC5HzWTuszW5F1VDpGnul0M8HEWyhrgQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"path-browserify": "^1.0.1",
-				"serialize-error": "^8.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-telemetry/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-1.0.1.tgz",
-			"integrity": "sha512-MzoonbJ/EQMbPi+m7/TZxWqyYzs1wxOdtN/Fe4FkaKOcHJjXR1e33iBw3YTkMQR9W8Z8E3WfSe6UVmzNDNH1TQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"debug": "^4.1.1",
-				"express": "^4.17.3",
-				"ioredis": "^5.2.3",
-				"json-stringify-safe": "^5.0.1",
-				"jsonwebtoken": "^9.0.0",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0",
-				"sillyname": "^0.1.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0",
-				"winston-transport": "^4.5.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-1.0.1.tgz",
-			"integrity": "sha512-+2ZP2pU4eq3KY5EySJhcwyAZqy9WojPhirA+fNUPKblT0fmeAn2ks6mF3d98fcxwqjMPb+5UPLRWDf7/+i1/Aw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"string-hash": "^1.1.3",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
 				"jwt-decode": "^3.0.0",
 				"querystring": "^0.2.0",
 				"sillyname": "^0.1.0",
@@ -1311,12 +971,6 @@
 			"dependencies": {
 				"@hapi/hoek": "^9.0.0"
 			}
-		},
-		"node_modules/@ioredis/commands": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-			"integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
-			"dev": true
 		},
 		"node_modules/@sideway/address": {
 			"version": "4.1.4",
@@ -1466,12 +1120,6 @@
 			"version": "16.18.59",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.59.tgz",
 			"integrity": "sha512-PJ1w2cNeKUEdey4LiPra0ZuxZFOGvetswE8qHRriV/sUkL5Al4tTmPV9D2+Y/TPIxTHHgxTfRjZVKWhPw/ORhQ==",
-			"dev": true
-		},
-		"node_modules/@types/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==",
 			"dev": true
 		},
 		"node_modules/@types/triple-beam": {
@@ -2437,15 +2085,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/denque": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-			"integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
 		"node_modules/depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3281,30 +2920,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/ioredis": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
-			"integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
-			"dev": true,
-			"dependencies": {
-				"@ioredis/commands": "^1.1.1",
-				"cluster-key-slot": "^1.1.0",
-				"debug": "^4.3.4",
-				"denque": "^2.1.0",
-				"lodash.defaults": "^4.2.0",
-				"lodash.isarguments": "^3.1.0",
-				"redis-errors": "^1.2.0",
-				"redis-parser": "^3.0.0",
-				"standard-as-callback": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=12.22.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ioredis"
-			}
-		},
 		"node_modules/ipaddr.js": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -3816,6 +3431,12 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
 			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+			"dev": true
+		},
+		"node_modules/lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
 			"dev": true
 		},
 		"node_modules/lodash.get": {
@@ -4510,6 +4131,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/p-map": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/pako": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -4847,6 +4477,12 @@
 			"engines": {
 				"node": ">= 0.8.0"
 			}
+		},
+		"node_modules/redis-commands": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
+			"dev": true
 		},
 		"node_modules/redis-errors": {
 			"version": "1.2.0",
@@ -5436,128 +5072,6 @@
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
 			"dev": true
-		},
-		"node_modules/tinylicious": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-1.0.0.tgz",
-			"integrity": "sha512-ACL8mEKT5LPbFyAXCDjYWqi3vcNef7y2ABMnU3O4jK1cRuEn0MywH7ppMM5ZrMgtSMMsJAINcWxZjpq3ndH8hg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.0",
-				"@fluidframework/protocol-base": "^1.0.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.0",
-				"@fluidframework/server-local-server": "^1.0.0",
-				"@fluidframework/server-memory-orderer": "^1.0.0",
-				"@fluidframework/server-services-client": "^1.0.0",
-				"@fluidframework/server-services-core": "^1.0.0",
-				"@fluidframework/server-services-shared": "^1.0.0",
-				"@fluidframework/server-services-telemetry": "^1.0.0",
-				"@fluidframework/server-services-utils": "^1.0.0",
-				"@fluidframework/server-test-utils": "^1.0.0",
-				"agentkeepalive": "^4.2.1",
-				"axios": "^0.26.0",
-				"body-parser": "^1.17.1",
-				"charwise": "^3.0.1",
-				"compression": "^1.7.2",
-				"cookie-parser": "^1.4.3",
-				"cors": "^2.8.4",
-				"detect-port": "^1.3.0",
-				"express": "^4.17.3",
-				"isomorphic-git": "^1.8.2",
-				"json-stringify-safe": "^5.0.1",
-				"level": "^8.0.0",
-				"level-sublevel": "6.6.4",
-				"lodash": "^4.17.21",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"socket.io": "^4.5.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.2",
-				"winston": "^3.6.0"
-			},
-			"bin": {
-				"tinylicious": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/tinylicious/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",

--- a/node-demo/package-lock.json
+++ b/node-demo/package-lock.json
@@ -21,10 +21,31 @@
 				"mocha-junit-reporter": "^2.2.1",
 				"sinon": "^14.0.2",
 				"sinon-chai": "^3.7.0",
-				"start-server-and-test": "^2.0.0"
+				"start-server-and-test": "^2.0.0",
+				"tinylicious": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=16.18.38"
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@colors/colors": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.1.90"
+			}
+		},
+		"node_modules/@dabh/diagnostics": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+			"integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+			"dev": true,
+			"dependencies": {
+				"colorspace": "1.1.x",
+				"enabled": "2.0.x",
+				"kuler": "^2.0.0"
 			}
 		},
 		"node_modules/@fluidframework/aqueduct": {
@@ -418,6 +439,375 @@
 				"uuid": "^8.3.1"
 			}
 		},
+		"node_modules/@fluidframework/server-lambdas": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-1.0.1.tgz",
+			"integrity": "sha512-lwVKg4dVDvbNH4ckj328z5cNu1plHhArzIMP3kpl8T94L6OubqsJ8vf3g46Wab/SjwltHC41p/wWigJapXZjqA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas-driver": "^1.0.1",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"@types/semver": "^7.5.0",
+				"assert": "^2.0.0",
+				"async": "^3.2.2",
+				"axios": "^0.26.0",
+				"buffer": "^6.0.3",
+				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
+				"json-stringify-safe": "^5.0.1",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"semver": "^7.5.3",
+				"sha.js": "^2.4.11",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/server-lambdas-driver": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-1.0.1.tgz",
+			"integrity": "sha512-TfQ7rz2/6pW6Rq5CbGBu9ShiSKyOHg2pXX0cUVHtnuuUPsWTxQDWlVilYukyG0uxHJfE3ZDU3R1QgnWUQQmGgg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"assert": "^2.0.0",
+				"async": "^3.2.2",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"serialize-error": "^8.1.0"
+			}
+		},
+		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/common-utils": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@types/events": "^3.0.0",
+				"base64-js": "^1.5.1",
+				"buffer": "^6.0.3",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sha.js": "^2.4.11"
+			}
+		},
+		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/gitresources": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"events": "^3.1.0"
+			}
+		},
+		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-definitions": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1"
+			}
+		},
+		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/server-services-client": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"axios": "^0.26.0",
+				"crc-32": "1.2.0",
+				"debug": "^4.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"jsrsasign": "^10.5.25",
+				"jwt-decode": "^3.0.0",
+				"querystring": "^0.2.0",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/common-utils": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@types/events": "^3.0.0",
+				"base64-js": "^1.5.1",
+				"buffer": "^6.0.3",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sha.js": "^2.4.11"
+			}
+		},
+		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/gitresources": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"events": "^3.1.0"
+			}
+		},
+		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-definitions": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1"
+			}
+		},
+		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/server-services-client": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"axios": "^0.26.0",
+				"crc-32": "1.2.0",
+				"debug": "^4.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"jsrsasign": "^10.5.25",
+				"jwt-decode": "^3.0.0",
+				"querystring": "^0.2.0",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/server-local-server": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-1.0.1.tgz",
+			"integrity": "sha512-494H0PYNa6aqngyq/M46K7wlY7NHdIx1B4qcfRCRQmjJZrD9GPza3FHt2/426teBQ93F6SOKkBrMw2vbmoUUGg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^1.0.1",
+				"@fluidframework/server-memory-orderer": "^1.0.1",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"@fluidframework/server-test-utils": "^1.0.1",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"jsrsasign": "^10.5.25",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/common-utils": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@types/events": "^3.0.0",
+				"base64-js": "^1.5.1",
+				"buffer": "^6.0.3",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sha.js": "^2.4.11"
+			}
+		},
+		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/gitresources": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"events": "^3.1.0"
+			}
+		},
+		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-definitions": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1"
+			}
+		},
+		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/server-services-client": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"axios": "^0.26.0",
+				"crc-32": "1.2.0",
+				"debug": "^4.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"jsrsasign": "^10.5.25",
+				"jwt-decode": "^3.0.0",
+				"querystring": "^0.2.0",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/server-memory-orderer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-1.0.1.tgz",
+			"integrity": "sha512-zUuNICwyKC7OTSl/W9MSiwplSccnRHVmRpdxImCe5qVs+VSK1jHuIGiIzCkt6dlVNMu3WHyUXmrKCLmhJZmFeQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/protocol-base": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^1.0.1",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"@types/debug": "^4.1.5",
+				"@types/double-ended-queue": "^2.1.0",
+				"@types/lodash": "^4.14.118",
+				"@types/node": "^16.18.16",
+				"@types/ws": "^6.0.1",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1",
+				"ws": "^7.4.6"
+			}
+		},
+		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/common-utils": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@types/events": "^3.0.0",
+				"base64-js": "^1.5.1",
+				"buffer": "^6.0.3",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sha.js": "^2.4.11"
+			}
+		},
+		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/gitresources": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"events": "^3.1.0"
+			}
+		},
+		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-definitions": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1"
+			}
+		},
+		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/server-services-client": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"axios": "^0.26.0",
+				"crc-32": "1.2.0",
+				"debug": "^4.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"jsrsasign": "^10.5.25",
+				"jwt-decode": "^3.0.0",
+				"querystring": "^0.2.0",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/server-memory-orderer/node_modules/ws": {
+			"version": "7.5.9",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.3.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@fluidframework/server-services-client": {
 			"version": "0.1036.5001",
 			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5001.tgz",
@@ -432,6 +822,392 @@
 				"debug": "^4.1.1",
 				"json-stringify-safe": "^5.0.1",
 				"jsrsasign": "^10.2.0",
+				"jwt-decode": "^3.0.0",
+				"querystring": "^0.2.0",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/server-services-core": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-1.0.1.tgz",
+			"integrity": "sha512-/Lb5ZZxb4aHtzLH3p+lrboi6TW/WD0I53di8FI4rMmn5AM7+h69BolPW7nume52t3HUi1I2Mnqhx1W8FKV8BbA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"@types/nconf": "^0.10.2",
+				"@types/node": "^16.18.16",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"nconf": "^0.12.0"
+			}
+		},
+		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/common-utils": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@types/events": "^3.0.0",
+				"base64-js": "^1.5.1",
+				"buffer": "^6.0.3",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sha.js": "^2.4.11"
+			}
+		},
+		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/gitresources": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"events": "^3.1.0"
+			}
+		},
+		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-definitions": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1"
+			}
+		},
+		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/server-services-client": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"axios": "^0.26.0",
+				"crc-32": "1.2.0",
+				"debug": "^4.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"jsrsasign": "^10.5.25",
+				"jwt-decode": "^3.0.0",
+				"querystring": "^0.2.0",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/server-services-shared": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-1.0.1.tgz",
+			"integrity": "sha512-Z+IyqWHUk/y0aZ5cUXUoehcOiIr4qw1VkDR5i+1rnLntCRkPKk7h6FFXcWo+OBmI7D3AJOKZagMr6npezIPEmQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"@socket.io/redis-adapter": "^7.2.0",
+				"body-parser": "^1.17.1",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"ioredis": "^5.2.3",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"notepack.io": "^2.3.0",
+				"querystring": "^0.2.0",
+				"serialize-error": "^8.1.0",
+				"socket.io": "^4.5.3",
+				"socket.io-adapter": "^2.4.0",
+				"socket.io-parser": "^4.2.1",
+				"uuid": "^8.3.1",
+				"winston": "^3.6.0"
+			}
+		},
+		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/common-utils": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@types/events": "^3.0.0",
+				"base64-js": "^1.5.1",
+				"buffer": "^6.0.3",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sha.js": "^2.4.11"
+			}
+		},
+		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/gitresources": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"events": "^3.1.0"
+			}
+		},
+		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-definitions": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1"
+			}
+		},
+		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/server-services-client": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"axios": "^0.26.0",
+				"crc-32": "1.2.0",
+				"debug": "^4.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"jsrsasign": "^10.5.25",
+				"jwt-decode": "^3.0.0",
+				"querystring": "^0.2.0",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/server-services-telemetry": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-1.0.1.tgz",
+			"integrity": "sha512-qeNtIr5mnkDS5hwD9t+2kcmsRK4zxdAtR+F0j0/rZ/pBWuaVmJI6YiKC5HzWTuszW5F1VDpGnul0M8HEWyhrgQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"path-browserify": "^1.0.1",
+				"serialize-error": "^8.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/server-services-telemetry/node_modules/@fluidframework/common-utils": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@types/events": "^3.0.0",
+				"base64-js": "^1.5.1",
+				"buffer": "^6.0.3",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sha.js": "^2.4.11"
+			}
+		},
+		"node_modules/@fluidframework/server-services-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-1.0.1.tgz",
+			"integrity": "sha512-MzoonbJ/EQMbPi+m7/TZxWqyYzs1wxOdtN/Fe4FkaKOcHJjXR1e33iBw3YTkMQR9W8Z8E3WfSe6UVmzNDNH1TQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"debug": "^4.1.1",
+				"express": "^4.17.3",
+				"ioredis": "^5.2.3",
+				"json-stringify-safe": "^5.0.1",
+				"jsonwebtoken": "^9.0.0",
+				"morgan": "^1.8.1",
+				"nconf": "^0.12.0",
+				"serialize-error": "^8.1.0",
+				"sillyname": "^0.1.0",
+				"split": "^1.0.0",
+				"uuid": "^8.3.1",
+				"winston": "^3.6.0",
+				"winston-transport": "^4.5.0"
+			}
+		},
+		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/common-utils": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@types/events": "^3.0.0",
+				"base64-js": "^1.5.1",
+				"buffer": "^6.0.3",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sha.js": "^2.4.11"
+			}
+		},
+		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/gitresources": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"events": "^3.1.0"
+			}
+		},
+		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-definitions": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1"
+			}
+		},
+		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/server-services-client": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"axios": "^0.26.0",
+				"crc-32": "1.2.0",
+				"debug": "^4.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"jsrsasign": "^10.5.25",
+				"jwt-decode": "^3.0.0",
+				"querystring": "^0.2.0",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/server-services-utils/node_modules/split": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"dev": true,
+			"dependencies": {
+				"through": "2"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@fluidframework/server-test-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-1.0.1.tgz",
+			"integrity": "sha512-+2ZP2pU4eq3KY5EySJhcwyAZqy9WojPhirA+fNUPKblT0fmeAn2ks6mF3d98fcxwqjMPb+5UPLRWDf7/+i1/Aw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^1.0.1",
+				"@fluidframework/server-services-core": "^1.0.1",
+				"@fluidframework/server-services-telemetry": "^1.0.1",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"string-hash": "^1.1.3",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/common-utils": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@types/events": "^3.0.0",
+				"base64-js": "^1.5.1",
+				"buffer": "^6.0.3",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sha.js": "^2.4.11"
+			}
+		},
+		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/gitresources": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"events": "^3.1.0"
+			}
+		},
+		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-definitions": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1"
+			}
+		},
+		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/server-services-client": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"axios": "^0.26.0",
+				"crc-32": "1.2.0",
+				"debug": "^4.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"jsrsasign": "^10.5.25",
 				"jwt-decode": "^3.0.0",
 				"querystring": "^0.2.0",
 				"sillyname": "^0.1.0",
@@ -536,6 +1312,12 @@
 				"@hapi/hoek": "^9.0.0"
 			}
 		},
+		"node_modules/@ioredis/commands": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+			"integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+			"dev": true
+		},
 		"node_modules/@sideway/address": {
 			"version": "4.1.4",
 			"resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -606,10 +1388,106 @@
 			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
 			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
 		},
+		"node_modules/@socket.io/redis-adapter": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-7.2.0.tgz",
+			"integrity": "sha512-/r6oF6Myz0K9uatB/pfCi0BhKg/KRMh1OokrqcjlNz6aq40WiXdFLRbHJQuwGHq/KvB+D6141K+IynbVxZGvhw==",
+			"dev": true,
+			"dependencies": {
+				"debug": "~4.3.1",
+				"notepack.io": "~2.2.0",
+				"socket.io-adapter": "^2.4.0",
+				"uid2": "0.0.3"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/@socket.io/redis-adapter/node_modules/notepack.io": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.2.0.tgz",
+			"integrity": "sha512-9b5w3t5VSH6ZPosoYnyDONnUTF8o0UkBw7JLA6eBlYJWyGT1Q3vQa8Hmuj1/X6RYvHjjygBDgw6fJhe0JEojfw==",
+			"dev": true
+		},
+		"node_modules/@types/cookie": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+			"integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+			"dev": true
+		},
+		"node_modules/@types/cors": {
+			"version": "2.8.15",
+			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.15.tgz",
+			"integrity": "sha512-n91JxbNLD8eQIuXDIChAN1tCKNWCEgpceU9b7ZMbFA+P+Q4yIeh80jizFLEvolRPc1ES0VdwFlGv+kJTSirogw==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/debug": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.10.tgz",
+			"integrity": "sha512-tOSCru6s732pofZ+sMv9o4o3Zc+Sa8l3bxd/tweTQudFn06vAzb13ZX46Zi6m6EJ+RUbRTHvgQJ1gBtSgkaUYA==",
+			"dev": true,
+			"dependencies": {
+				"@types/ms": "*"
+			}
+		},
+		"node_modules/@types/double-ended-queue": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@types/double-ended-queue/-/double-ended-queue-2.1.5.tgz",
+			"integrity": "sha512-Iyp30YLmx/PFvtmomdZq4i81N6uR/7Le+UFrUbnNVbHboRCcCuOKu64tPXlr2yFOb8Zh4t0SppDxRQ5DM/Hlhg==",
+			"dev": true
+		},
 		"node_modules/@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
 			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+		},
+		"node_modules/@types/lodash": {
+			"version": "4.14.200",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
+			"integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==",
+			"dev": true
+		},
+		"node_modules/@types/ms": {
+			"version": "0.7.33",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.33.tgz",
+			"integrity": "sha512-AuHIyzR5Hea7ij0P9q7vx7xu4z0C28ucwjAZC0ja7JhINyCnOw8/DnvAPQQ9TfOlCtZAmCERKQX9+o1mgQhuOQ==",
+			"dev": true
+		},
+		"node_modules/@types/nconf": {
+			"version": "0.10.5",
+			"resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.5.tgz",
+			"integrity": "sha512-Rig8+FAyg9twg01Ya+aVR+QAakMxcTiO3QcvhY41Rn/m1ZvFIU5fb+D3qxxqIHxrFacQqxeg8c8apzZYZ+dqLA==",
+			"dev": true
+		},
+		"node_modules/@types/node": {
+			"version": "16.18.59",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.59.tgz",
+			"integrity": "sha512-PJ1w2cNeKUEdey4LiPra0ZuxZFOGvetswE8qHRriV/sUkL5Al4tTmPV9D2+Y/TPIxTHHgxTfRjZVKWhPw/ORhQ==",
+			"dev": true
+		},
+		"node_modules/@types/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==",
+			"dev": true
+		},
+		"node_modules/@types/triple-beam": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.4.tgz",
+			"integrity": "sha512-HlJjF3wxV4R2VQkFpKe0YqJLilYNgtRtsqqZtby7RkVsSs+i+vbyzjtUwpFEdUCKcrGzCiEJE7F/0mKjh0sunA==",
+			"dev": true
+		},
+		"node_modules/@types/ws": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
+			"integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/abort-controller": {
 			"version": "3.0.0",
@@ -620,6 +1498,81 @@
 			},
 			"engines": {
 				"node": ">=6.5"
+			}
+		},
+		"node_modules/abstract-level": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
+			"integrity": "sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==",
+			"dev": true,
+			"dependencies": {
+				"buffer": "^6.0.3",
+				"catering": "^2.1.0",
+				"is-buffer": "^2.0.5",
+				"level-supports": "^4.0.0",
+				"level-transcoder": "^1.0.1",
+				"module-error": "^1.0.1",
+				"queue-microtask": "^1.2.3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/abstract-level/node_modules/is-buffer": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/accepts": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+			"integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+			"dev": true,
+			"dependencies": {
+				"mime-types": "~2.1.34",
+				"negotiator": "0.6.3"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/address": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
+			"integrity": "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/agentkeepalive": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+			"integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+			"dev": true,
+			"dependencies": {
+				"humanize-ms": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
 			}
 		},
 		"node_modules/ansi-colors": {
@@ -680,6 +1633,25 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
+		"node_modules/array-flatten": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+			"dev": true
+		},
+		"node_modules/assert": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+			"integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"is-nan": "^1.3.2",
+				"object-is": "^1.1.5",
+				"object.assign": "^4.1.4",
+				"util": "^0.12.5"
+			}
+		},
 		"node_modules/assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -689,11 +1661,35 @@
 				"node": "*"
 			}
 		},
+		"node_modules/async": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+			"dev": true
+		},
+		"node_modules/async-lock": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz",
+			"integrity": "sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ==",
+			"dev": true
+		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"dev": true
+		},
+		"node_modules/available-typed-arrays": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/axios": {
 			"version": "0.26.1",
@@ -728,6 +1724,33 @@
 				}
 			]
 		},
+		"node_modules/base64id": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+			"integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+			"dev": true,
+			"engines": {
+				"node": "^4.5.0 || >= 5.9"
+			}
+		},
+		"node_modules/basic-auth": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+			"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "5.1.2"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/basic-auth/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
+		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -742,6 +1765,60 @@
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
 			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
 			"dev": true
+		},
+		"node_modules/body-parser": {
+			"version": "1.20.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+			"integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+			"dev": true,
+			"dependencies": {
+				"bytes": "3.1.2",
+				"content-type": "~1.0.5",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"destroy": "1.2.0",
+				"http-errors": "2.0.0",
+				"iconv-lite": "0.4.24",
+				"on-finished": "2.4.1",
+				"qs": "6.11.0",
+				"raw-body": "2.5.2",
+				"type-is": "~1.6.18",
+				"unpipe": "1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8",
+				"npm": "1.2.8000 || >= 1.4.16"
+			}
+		},
+		"node_modules/body-parser/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/body-parser/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true
+		},
+		"node_modules/body-parser/node_modules/qs": {
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+			"integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+			"dev": true,
+			"dependencies": {
+				"side-channel": "^1.0.4"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -763,6 +1840,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/browser-level": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
+			"integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
+			"dev": true,
+			"dependencies": {
+				"abstract-level": "^1.0.2",
+				"catering": "^2.1.1",
+				"module-error": "^1.0.2",
+				"run-parallel-limit": "^1.1.0"
 			}
 		},
 		"node_modules/browser-stdout": {
@@ -794,13 +1883,48 @@
 				"ieee754": "^1.2.1"
 			}
 		},
-		"node_modules/call-bind": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"dev": true
+		},
+		"node_modules/bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/bytewise": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+			"integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
+			"dev": true,
 			"dependencies": {
-				"function-bind": "^1.1.1",
-				"get-intrinsic": "^1.0.2"
+				"bytewise-core": "^1.2.2",
+				"typewise": "^1.0.3"
+			}
+		},
+		"node_modules/bytewise-core": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+			"integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
+			"dev": true,
+			"dependencies": {
+				"typewise-core": "^1.2"
+			}
+		},
+		"node_modules/call-bind": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+			"integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+			"dependencies": {
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.1",
+				"set-function-length": "^1.1.1"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -816,6 +1940,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/catering": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
+			"integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/chai": {
@@ -860,6 +1993,12 @@
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/charwise": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz",
+			"integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw==",
+			"dev": true
 		},
 		"node_modules/check-error": {
 			"version": "1.0.2",
@@ -906,6 +2045,29 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/classic-level": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.3.0.tgz",
+			"integrity": "sha512-iwFAJQYtqRTRM0F6L8h4JCt00ZSGdOyqh7yVrhhjrOpFhmBjNlRUey64MCiyo6UmQHMJ+No3c81nujPv+n9yrg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"dependencies": {
+				"abstract-level": "^1.0.2",
+				"catering": "^2.1.0",
+				"module-error": "^1.0.1",
+				"napi-macros": "^2.2.2",
+				"node-gyp-build": "^4.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/clean-git-ref": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
+			"integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
+			"dev": true
+		},
 		"node_modules/cliui": {
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -915,6 +2077,25 @@
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/cluster-key-slot": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+			"integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/color": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^1.9.3",
+				"color-string": "^1.6.0"
 			}
 		},
 		"node_modules/color-convert": {
@@ -935,6 +2116,41 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
+		"node_modules/color-string": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "^1.0.0",
+				"simple-swizzle": "^0.2.2"
+			}
+		},
+		"node_modules/color/node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/color/node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"dev": true
+		},
+		"node_modules/colorspace": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+			"integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+			"dev": true,
+			"dependencies": {
+				"color": "^3.1.3",
+				"text-hex": "1.0.x"
+			}
+		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -947,11 +2163,139 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/compressible": {
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+			"integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+			"dev": true,
+			"dependencies": {
+				"mime-db": ">= 1.43.0 < 2"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/compression": {
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+			"integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+			"dev": true,
+			"dependencies": {
+				"accepts": "~1.3.5",
+				"bytes": "3.0.0",
+				"compressible": "~2.0.16",
+				"debug": "2.6.9",
+				"on-headers": "~1.0.2",
+				"safe-buffer": "5.1.2",
+				"vary": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/compression/node_modules/bytes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+			"integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/compression/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/compression/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true
+		},
+		"node_modules/compression/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
+		},
+		"node_modules/content-disposition": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+			"integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "5.2.1"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/content-type": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+			"integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie-parser": {
+			"version": "1.4.6",
+			"resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+			"integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+			"dev": true,
+			"dependencies": {
+				"cookie": "0.4.1",
+				"cookie-signature": "1.0.6"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/cookie-signature": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+			"dev": true
+		},
+		"node_modules/core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"dev": true
+		},
+		"node_modules/cors": {
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+			"dev": true,
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
 		},
 		"node_modules/crc-32": {
 			"version": "1.2.0",
@@ -1027,6 +2371,21 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"dev": true,
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/deep-eql": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.2.tgz",
@@ -1039,6 +2398,36 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/define-data-property": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+			"integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+			"dependencies": {
+				"get-intrinsic": "^1.2.1",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/define-properties": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.0.1",
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1046,6 +2435,48 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/denque": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+			"integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/destroy": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+			"integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8",
+				"npm": "1.2.8000 || >= 1.4.16"
+			}
+		},
+		"node_modules/detect-port": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
+			"integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
+			"dev": true,
+			"dependencies": {
+				"address": "^1.0.1",
+				"debug": "4"
+			},
+			"bin": {
+				"detect": "bin/detect-port.js",
+				"detect-port": "bin/detect-port.js"
 			}
 		},
 		"node_modules/diff": {
@@ -1056,6 +2487,12 @@
 			"engines": {
 				"node": ">=0.3.1"
 			}
+		},
+		"node_modules/diff3": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+			"dev": true
 		},
 		"node_modules/double-ended-queue": {
 			"version": "2.1.0-0",
@@ -1068,11 +2505,62 @@
 			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
 			"dev": true
 		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+			"dev": true
+		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true
+		},
+		"node_modules/enabled": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+			"dev": true
+		},
+		"node_modules/encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/engine.io": {
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.3.tgz",
+			"integrity": "sha512-IML/R4eG/pUS5w7OfcDE0jKrljWS9nwnEfsxWCIJF5eO6AHo6+Hlv+lQbdlAYsiJPHzUthLm1RUjnBzWOs45cw==",
+			"dev": true,
+			"dependencies": {
+				"@types/cookie": "^0.4.1",
+				"@types/cors": "^2.8.12",
+				"@types/node": ">=10.0.0",
+				"accepts": "~1.3.4",
+				"base64id": "2.0.0",
+				"cookie": "~0.4.1",
+				"cors": "~2.8.5",
+				"debug": "~4.3.1",
+				"engine.io-parser": "~5.2.1",
+				"ws": "~8.11.0"
+			},
+			"engines": {
+				"node": ">=10.2.0"
+			}
 		},
 		"node_modules/engine.io-client": {
 			"version": "6.5.2",
@@ -1094,6 +2582,18 @@
 				"node": ">=10.0.0"
 			}
 		},
+		"node_modules/errno": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+			"integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+			"dev": true,
+			"dependencies": {
+				"prr": "~1.0.1"
+			},
+			"bin": {
+				"errno": "cli.js"
+			}
+		},
 		"node_modules/escalade": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -1102,6 +2602,12 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"dev": true
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
@@ -1113,6 +2619,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/event-stream": {
@@ -1177,6 +2692,138 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/express": {
+			"version": "4.18.2",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+			"integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+			"dev": true,
+			"dependencies": {
+				"accepts": "~1.3.8",
+				"array-flatten": "1.1.1",
+				"body-parser": "1.20.1",
+				"content-disposition": "0.5.4",
+				"content-type": "~1.0.4",
+				"cookie": "0.5.0",
+				"cookie-signature": "1.0.6",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "1.2.0",
+				"fresh": "0.5.2",
+				"http-errors": "2.0.0",
+				"merge-descriptors": "1.0.1",
+				"methods": "~1.1.2",
+				"on-finished": "2.4.1",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "0.1.7",
+				"proxy-addr": "~2.0.7",
+				"qs": "6.11.0",
+				"range-parser": "~1.2.1",
+				"safe-buffer": "5.2.1",
+				"send": "0.18.0",
+				"serve-static": "1.15.0",
+				"setprototypeof": "1.2.0",
+				"statuses": "2.0.1",
+				"type-is": "~1.6.18",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			}
+		},
+		"node_modules/express/node_modules/body-parser": {
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+			"integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+			"dev": true,
+			"dependencies": {
+				"bytes": "3.1.2",
+				"content-type": "~1.0.4",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"destroy": "1.2.0",
+				"http-errors": "2.0.0",
+				"iconv-lite": "0.4.24",
+				"on-finished": "2.4.1",
+				"qs": "6.11.0",
+				"raw-body": "2.5.1",
+				"type-is": "~1.6.18",
+				"unpipe": "1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8",
+				"npm": "1.2.8000 || >= 1.4.16"
+			}
+		},
+		"node_modules/express/node_modules/cookie": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/express/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/express/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true
+		},
+		"node_modules/express/node_modules/path-to-regexp": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+			"integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+			"dev": true
+		},
+		"node_modules/express/node_modules/qs": {
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+			"integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+			"dev": true,
+			"dependencies": {
+				"side-channel": "^1.0.4"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/express/node_modules/raw-body": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+			"integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+			"dev": true,
+			"dependencies": {
+				"bytes": "3.1.2",
+				"http-errors": "2.0.0",
+				"iconv-lite": "0.4.24",
+				"unpipe": "1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/fecha": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+			"dev": true
+		},
 		"node_modules/fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1188,6 +2835,39 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/finalhandler": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+			"integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+			"dev": true,
+			"dependencies": {
+				"debug": "2.6.9",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"on-finished": "2.4.1",
+				"parseurl": "~1.3.3",
+				"statuses": "2.0.1",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/finalhandler/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/finalhandler/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true
 		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
@@ -1227,6 +2907,12 @@
 				"@fluidframework/sequence": "^1.3.7"
 			}
 		},
+		"node_modules/fn.name": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+			"dev": true
+		},
 		"node_modules/follow-redirects": {
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
@@ -1246,6 +2932,15 @@
 				}
 			}
 		},
+		"node_modules/for-each": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+			"dev": true,
+			"dependencies": {
+				"is-callable": "^1.1.3"
+			}
+		},
 		"node_modules/form-data": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -1258,6 +2953,24 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/from": {
@@ -1287,9 +3000,12 @@
 			}
 		},
 		"node_modules/function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
@@ -1310,14 +3026,14 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-			"integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+			"integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
 			"dependencies": {
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
+				"function-bind": "^1.1.2",
 				"has-proto": "^1.0.1",
-				"has-symbols": "^1.0.3"
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -1379,15 +3095,15 @@
 				"node": "*"
 			}
 		},
-		"node_modules/has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+		"node_modules/gopd": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
 			"dependencies": {
-				"function-bind": "^1.1.1"
+				"get-intrinsic": "^1.1.3"
 			},
-			"engines": {
-				"node": ">= 0.4.0"
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/has-flag": {
@@ -1397,6 +3113,17 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+			"integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+			"dependencies": {
+				"get-intrinsic": "^1.2.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/has-proto": {
@@ -1421,6 +3148,32 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+			"dev": true,
+			"dependencies": {
+				"has-symbols": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+			"integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/he": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -1430,6 +3183,22 @@
 				"he": "bin/he"
 			}
 		},
+		"node_modules/http-errors": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+			"integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+			"dev": true,
+			"dependencies": {
+				"depd": "2.0.0",
+				"inherits": "2.0.4",
+				"setprototypeof": "1.2.0",
+				"statuses": "2.0.1",
+				"toidentifier": "1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/human-signals": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -1437,6 +3206,27 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10.17.0"
+			}
+		},
+		"node_modules/humanize-ms": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "^2.0.0"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/ieee754": {
@@ -1458,6 +3248,15 @@
 				}
 			]
 		},
+		"node_modules/ignore": {
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1472,6 +3271,70 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"node_modules/ini": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+			"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/ioredis": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
+			"integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
+			"dev": true,
+			"dependencies": {
+				"@ioredis/commands": "^1.1.1",
+				"cluster-key-slot": "^1.1.0",
+				"debug": "^4.3.4",
+				"denque": "^2.1.0",
+				"lodash.defaults": "^4.2.0",
+				"lodash.isarguments": "^3.1.0",
+				"redis-errors": "^1.2.0",
+				"redis-parser": "^3.0.0",
+				"standard-as-callback": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=12.22.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ioredis"
+			}
+		},
+		"node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/is-arguments": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-arrayish": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+			"dev": true
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
@@ -1491,6 +3354,18 @@
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
 		},
+		"node_modules/is-callable": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1509,6 +3384,21 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/is-generator-function": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+			"integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -1519,6 +3409,22 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-nan": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-number": {
@@ -1551,6 +3457,21 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/is-typed-array": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+			"integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+			"dev": true,
+			"dependencies": {
+				"which-typed-array": "^1.1.11"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-unicode-supported": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -1574,6 +3495,31 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
+		},
+		"node_modules/isomorphic-git": {
+			"version": "1.24.5",
+			"resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.24.5.tgz",
+			"integrity": "sha512-07M4YscftHZJIuw7xZhgWkdFvVjHSBJBsIwWXkxgFCivhb0l8mGNchM7nO2hU27EKSIf0sT4gJivEgLGohWbzA==",
+			"dev": true,
+			"dependencies": {
+				"async-lock": "^1.1.0",
+				"clean-git-ref": "^2.0.1",
+				"crc-32": "^1.2.0",
+				"diff3": "0.0.3",
+				"ignore": "^5.1.4",
+				"minimisted": "^2.0.0",
+				"pako": "^1.0.10",
+				"pify": "^4.0.1",
+				"readable-stream": "^3.4.0",
+				"sha.js": "^2.4.9",
+				"simple-get": "^4.0.1"
+			},
+			"bin": {
+				"isogit": "cli.cjs"
+			},
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/joi": {
 			"version": "17.10.1",
@@ -1605,6 +3551,28 @@
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
 		},
+		"node_modules/jsonwebtoken": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+			"integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+			"dev": true,
+			"dependencies": {
+				"jws": "^3.2.2",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			}
+		},
 		"node_modules/jsrsasign": {
 			"version": "10.8.6",
 			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.8.6.tgz",
@@ -1619,10 +3587,37 @@
 			"integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
 			"dev": true
 		},
+		"node_modules/jwa": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+			"dev": true,
+			"dependencies": {
+				"buffer-equal-constant-time": "1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+			"dev": true,
+			"dependencies": {
+				"jwa": "^1.4.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"node_modules/jwt-decode": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
 			"integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+		},
+		"node_modules/kuler": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+			"dev": true
 		},
 		"node_modules/lazy-ass": {
 			"version": "1.6.0",
@@ -1631,6 +3626,170 @@
 			"dev": true,
 			"engines": {
 				"node": "> 0.8"
+			}
+		},
+		"node_modules/level": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/level/-/level-8.0.0.tgz",
+			"integrity": "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==",
+			"dev": true,
+			"dependencies": {
+				"browser-level": "^1.0.1",
+				"classic-level": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/level"
+			}
+		},
+		"node_modules/level-codec": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+			"integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
+			"dev": true,
+			"dependencies": {
+				"buffer": "^5.6.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/level-codec/node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
+		},
+		"node_modules/level-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+			"integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
+			"dev": true,
+			"dependencies": {
+				"errno": "~0.1.1"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/level-iterator-stream": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
+			"integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.5",
+				"xtend": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/level-iterator-stream/node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true
+		},
+		"node_modules/level-iterator-stream/node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/level-iterator-stream/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
+		},
+		"node_modules/level-iterator-stream/node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/level-post": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
+			"integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
+			"dev": true,
+			"dependencies": {
+				"ltgt": "^2.1.2"
+			}
+		},
+		"node_modules/level-sublevel": {
+			"version": "6.6.4",
+			"resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.4.tgz",
+			"integrity": "sha512-pcCrTUOiO48+Kp6F1+UAzF/OtWqLcQVTVF39HLdZ3RO8XBoXt+XVPKZO1vVr1aUoxHZA9OtD2e1v7G+3S5KFDA==",
+			"dev": true,
+			"dependencies": {
+				"bytewise": "~1.1.0",
+				"level-codec": "^9.0.0",
+				"level-errors": "^2.0.0",
+				"level-iterator-stream": "^2.0.3",
+				"ltgt": "~2.1.1",
+				"pull-defer": "^0.2.2",
+				"pull-level": "^2.0.3",
+				"pull-stream": "^3.6.8",
+				"typewiselite": "~1.0.0",
+				"xtend": "~4.0.0"
+			}
+		},
+		"node_modules/level-supports": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
+			"integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/level-transcoder": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
+			"integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
+			"dev": true,
+			"dependencies": {
+				"buffer": "^6.0.3",
+				"module-error": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/locate-path": {
@@ -1653,10 +3812,64 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
+		"node_modules/lodash.defaults": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+			"dev": true
+		},
 		"node_modules/lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
 			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+			"dev": true
+		},
+		"node_modules/lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+			"dev": true
+		},
+		"node_modules/lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+			"dev": true
+		},
+		"node_modules/lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+			"dev": true
+		},
+		"node_modules/lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+			"dev": true
+		},
+		"node_modules/lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+			"dev": true
+		},
+		"node_modules/lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+			"dev": true
+		},
+		"node_modules/lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+			"dev": true
+		},
+		"node_modules/lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
 			"dev": true
 		},
 		"node_modules/log-symbols": {
@@ -1675,6 +3888,29 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/logform": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
+			"integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
+			"dev": true,
+			"dependencies": {
+				"@colors/colors": "1.6.0",
+				"@types/triple-beam": "^1.3.2",
+				"fecha": "^4.2.0",
+				"ms": "^2.1.1",
+				"safe-stable-stringify": "^2.3.1",
+				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/looper": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
+			"integrity": "sha512-6DzMHJcjbQX/UPHc1rRCBfKlLwDkvuGZ715cIR36wSdYqWXFT35uLXq5P/2orl3tz+t+VOVPxw4yPinQlUDGDQ==",
+			"dev": true
+		},
 		"node_modules/loupe": {
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
@@ -1683,6 +3919,24 @@
 			"dependencies": {
 				"get-func-name": "^2.0.0"
 			}
+		},
+		"node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/ltgt": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
+			"integrity": "sha512-5VjHC5GsENtIi5rbJd+feEpDKhfr7j0odoUR2Uh978g+2p93nd5o34cTjQWohXsPsCZeqoDnIqEf88mPCe0Pfw==",
+			"dev": true
 		},
 		"node_modules/map-stream": {
 			"version": "0.1.0",
@@ -1701,11 +3955,47 @@
 				"is-buffer": "~1.1.6"
 			}
 		},
+		"node_modules/media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
+			"dev": true
+		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true
+		},
+		"node_modules/methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"dev": true,
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
 		},
 		"node_modules/mime-db": {
 			"version": "1.52.0",
@@ -1737,6 +4027,18 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/minimatch": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
@@ -1765,6 +4067,15 @@
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/minimisted": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
+			"integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
+			"dev": true,
+			"dependencies": {
+				"minimist": "^1.2.5"
 			}
 		},
 		"node_modules/mkdirp": {
@@ -1868,6 +4179,58 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"node_modules/module-error": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
+			"integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/morgan": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+			"integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+			"dev": true,
+			"dependencies": {
+				"basic-auth": "~2.0.1",
+				"debug": "2.6.9",
+				"depd": "~2.0.0",
+				"on-finished": "~2.3.0",
+				"on-headers": "~1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/morgan/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/morgan/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true
+		},
+		"node_modules/morgan/node_modules/on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+			"dev": true,
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -1883,6 +4246,36 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/napi-macros": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
+			"integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==",
+			"dev": true
+		},
+		"node_modules/nconf": {
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.1.tgz",
+			"integrity": "sha512-p2cfF+B3XXacQdswUYWZ0w6Vld0832A/tuqjLBu3H1sfUcby4N2oVbGhyuCkZv+t3iY3aiFEj7gZGqax9Q2c1w==",
+			"dev": true,
+			"dependencies": {
+				"async": "^3.0.0",
+				"ini": "^2.0.0",
+				"secure-keys": "^1.0.0",
+				"yargs": "^16.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/negotiator": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/nise": {
@@ -1935,6 +4328,17 @@
 				}
 			}
 		},
+		"node_modules/node-gyp-build": {
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
+			"integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
+			"dev": true,
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
+			}
+		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1943,6 +4347,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/notepack.io": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.3.0.tgz",
+			"integrity": "sha512-9RiFDxeydHsWOqdthRUck2Kd4UW2NzVd2xxOulZiQ9mvge6ElsHXLpwD3HEJyql6sFEnEn/eMO7HSdS0M5mWkA==",
+			"dev": true
 		},
 		"node_modules/npm-run-path": {
 			"version": "4.0.1",
@@ -1956,12 +4366,85 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/object-inspect": {
 			"version": "1.12.3",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
 			"integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object-is": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+			"integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/object.assign": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"has-symbols": "^1.0.3",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/on-finished": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+			"dev": true,
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/on-headers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+			"integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/once": {
@@ -1971,6 +4454,15 @@
 			"dev": true,
 			"dependencies": {
 				"wrappy": "1"
+			}
+		},
+		"node_modules/one-time": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+			"dev": true,
+			"dependencies": {
+				"fn.name": "1.x.x"
 			}
 		},
 		"node_modules/onetime": {
@@ -2016,6 +4508,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"dev": true
+		},
+		"node_modules/parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/path-browserify": {
@@ -2089,6 +4596,15 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/pify": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/prettier": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
@@ -2114,6 +4630,31 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
+		},
+		"node_modules/proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"dev": true,
+			"dependencies": {
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/prr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+			"integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+			"dev": true
+		},
 		"node_modules/ps-tree": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
@@ -2127,6 +4668,64 @@
 			},
 			"engines": {
 				"node": ">= 0.10"
+			}
+		},
+		"node_modules/pull-cat": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
+			"integrity": "sha512-i3w+xZ3DCtTVz8S62hBOuNLRHqVDsHMNZmgrZsjPnsxXUgbWtXEee84lo1XswE7W2a3WHyqsNuDJTjVLAQR8xg==",
+			"dev": true
+		},
+		"node_modules/pull-defer": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
+			"integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA==",
+			"dev": true
+		},
+		"node_modules/pull-level": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
+			"integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
+			"dev": true,
+			"dependencies": {
+				"level-post": "^1.0.7",
+				"pull-cat": "^1.1.9",
+				"pull-live": "^1.0.1",
+				"pull-pushable": "^2.0.0",
+				"pull-stream": "^3.4.0",
+				"pull-window": "^2.1.4",
+				"stream-to-pull-stream": "^1.7.1"
+			}
+		},
+		"node_modules/pull-live": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
+			"integrity": "sha512-tkNz1QT5gId8aPhV5+dmwoIiA1nmfDOzJDlOOUpU5DNusj6neNd3EePybJ5+sITr2FwyCs/FVpx74YMCfc8YeA==",
+			"dev": true,
+			"dependencies": {
+				"pull-cat": "^1.1.9",
+				"pull-stream": "^3.4.0"
+			}
+		},
+		"node_modules/pull-pushable": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
+			"integrity": "sha512-M7dp95enQ2kaHvfCt2+DJfyzgCSpWVR2h2kWYnVsW6ZpxQBx5wOu0QWOvQPVoPnBLUZYitYP2y7HyHkLQNeGXg==",
+			"dev": true
+		},
+		"node_modules/pull-stream": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.7.0.tgz",
+			"integrity": "sha512-Eco+/R004UaCK2qEDE8vGklcTG2OeZSVm1kTUQNrykEjDwcFXDZhygFDsW49DbXyJMEhHeRL3z5cRVqPAhXlIw==",
+			"dev": true
+		},
+		"node_modules/pull-window": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
+			"integrity": "sha512-cbDzN76BMlcGG46OImrgpkMf/VkCnupj8JhsrpBw3aWBM9ye345aYnqitmZCgauBkc0HbbRRn9hCnsa3k2FNUg==",
+			"dev": true,
+			"dependencies": {
+				"looper": "^2.0.0"
 			}
 		},
 		"node_modules/punycode": {
@@ -2162,6 +4761,26 @@
 			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
 			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
 		},
+		"node_modules/queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -2169,6 +4788,44 @@
 			"dev": true,
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
+			}
+		},
+		"node_modules/range-parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/raw-body": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+			"integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+			"dev": true,
+			"dependencies": {
+				"bytes": "3.1.2",
+				"http-errors": "2.0.0",
+				"iconv-lite": "0.4.24",
+				"unpipe": "1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/readdirp": {
@@ -2191,6 +4848,27 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/redis-errors": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+			"integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/redis-parser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+			"integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+			"dev": true,
+			"dependencies": {
+				"redis-errors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -2204,6 +4882,29 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
 			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+		},
+		"node_modules/run-parallel-limit": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
+			"integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"queue-microtask": "^1.2.2"
+			}
 		},
 		"node_modules/rxjs": {
 			"version": "7.8.1",
@@ -2233,6 +4934,102 @@
 				}
 			]
 		},
+		"node_modules/safe-stable-stringify": {
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
+		},
+		"node_modules/secure-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
+			"integrity": "sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg==",
+			"dev": true
+		},
+		"node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/send": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+			"integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+			"dev": true,
+			"dependencies": {
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"destroy": "1.2.0",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"fresh": "0.5.2",
+				"http-errors": "2.0.0",
+				"mime": "1.6.0",
+				"ms": "2.1.3",
+				"on-finished": "2.4.1",
+				"range-parser": "~1.2.1",
+				"statuses": "2.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/send/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/send/node_modules/debug/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true
+		},
+		"node_modules/send/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true
+		},
+		"node_modules/serialize-error": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+			"integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+			"dev": true,
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -2241,6 +5038,41 @@
 			"dependencies": {
 				"randombytes": "^2.1.0"
 			}
+		},
+		"node_modules/serve-static": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+			"integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+			"dev": true,
+			"dependencies": {
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"parseurl": "~1.3.3",
+				"send": "0.18.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/set-function-length": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
+			"integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+			"dependencies": {
+				"define-data-property": "^1.1.1",
+				"get-intrinsic": "^1.2.1",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+			"dev": true
 		},
 		"node_modules/sha.js": {
 			"version": "2.4.11",
@@ -2299,6 +5131,60 @@
 			"resolved": "https://registry.npmjs.org/sillyname/-/sillyname-0.1.0.tgz",
 			"integrity": "sha512-GWA0Zont13ov+cMNw4T7nU4SCyW8jdhD3vjA5+qs8jr+09sCPxOf+FPS5zE0c9pYlCwD+NU/CiMimY462lgG9g=="
 		},
+		"node_modules/simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/simple-get": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"decompress-response": "^6.0.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
+		"node_modules/simple-swizzle": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+			"integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+			"dev": true,
+			"dependencies": {
+				"is-arrayish": "^0.3.1"
+			}
+		},
 		"node_modules/sinon": {
 			"version": "14.0.2",
 			"resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.2.tgz",
@@ -2325,6 +5211,33 @@
 			"peerDependencies": {
 				"chai": "^4.0.0",
 				"sinon": ">=4.0.0"
+			}
+		},
+		"node_modules/socket.io": {
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.2.tgz",
+			"integrity": "sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==",
+			"dev": true,
+			"dependencies": {
+				"accepts": "~1.3.4",
+				"base64id": "~2.0.0",
+				"cors": "~2.8.5",
+				"debug": "~4.3.2",
+				"engine.io": "~6.5.2",
+				"socket.io-adapter": "~2.5.2",
+				"socket.io-parser": "~4.2.4"
+			},
+			"engines": {
+				"node": ">=10.2.0"
+			}
+		},
+		"node_modules/socket.io-adapter": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+			"integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+			"dev": true,
+			"dependencies": {
+				"ws": "~8.11.0"
 			}
 		},
 		"node_modules/socket.io-client": {
@@ -2365,6 +5278,21 @@
 				"node": "*"
 			}
 		},
+		"node_modules/stack-trace": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+			"integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/standard-as-callback": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+			"integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+			"dev": true
+		},
 		"node_modules/start-server-and-test": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-2.0.0.tgz",
@@ -2389,6 +5317,15 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/statuses": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+			"integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/stream-combiner": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
@@ -2397,6 +5334,37 @@
 			"dependencies": {
 				"duplexer": "~0.1.1"
 			}
+		},
+		"node_modules/stream-to-pull-stream": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
+			"integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
+			"dev": true,
+			"dependencies": {
+				"looper": "^3.0.0",
+				"pull-stream": "^3.2.3"
+			}
+		},
+		"node_modules/stream-to-pull-stream/node_modules/looper": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+			"integrity": "sha512-LJ9wplN/uSn72oJRsXTx+snxPet5c8XiZmOKCm906NVYu+ag6SB6vUcnJcWxgnl2NfbIyeobAn7Bwv6xRj2XJg==",
+			"dev": true
+		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/string-hash": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+			"integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
+			"dev": true
 		},
 		"node_modules/string-width": {
 			"version": "4.2.3",
@@ -2457,11 +5425,139 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/text-hex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+			"dev": true
+		},
 		"node_modules/through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
 			"dev": true
+		},
+		"node_modules/tinylicious": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-1.0.0.tgz",
+			"integrity": "sha512-ACL8mEKT5LPbFyAXCDjYWqi3vcNef7y2ABMnU3O4jK1cRuEn0MywH7ppMM5ZrMgtSMMsJAINcWxZjpq3ndH8hg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.0",
+				"@fluidframework/protocol-base": "^1.0.0",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^1.0.0",
+				"@fluidframework/server-local-server": "^1.0.0",
+				"@fluidframework/server-memory-orderer": "^1.0.0",
+				"@fluidframework/server-services-client": "^1.0.0",
+				"@fluidframework/server-services-core": "^1.0.0",
+				"@fluidframework/server-services-shared": "^1.0.0",
+				"@fluidframework/server-services-telemetry": "^1.0.0",
+				"@fluidframework/server-services-utils": "^1.0.0",
+				"@fluidframework/server-test-utils": "^1.0.0",
+				"agentkeepalive": "^4.2.1",
+				"axios": "^0.26.0",
+				"body-parser": "^1.17.1",
+				"charwise": "^3.0.1",
+				"compression": "^1.7.2",
+				"cookie-parser": "^1.4.3",
+				"cors": "^2.8.4",
+				"detect-port": "^1.3.0",
+				"express": "^4.17.3",
+				"isomorphic-git": "^1.8.2",
+				"json-stringify-safe": "^5.0.1",
+				"level": "^8.0.0",
+				"level-sublevel": "6.6.4",
+				"lodash": "^4.17.21",
+				"morgan": "^1.8.1",
+				"nconf": "^0.12.0",
+				"socket.io": "^4.5.0",
+				"split": "^1.0.0",
+				"uuid": "^8.3.2",
+				"winston": "^3.6.0"
+			},
+			"bin": {
+				"tinylicious": "dist/index.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tinylicious/node_modules/@fluidframework/common-utils": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@types/events": "^3.0.0",
+				"base64-js": "^1.5.1",
+				"buffer": "^6.0.3",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sha.js": "^2.4.11"
+			}
+		},
+		"node_modules/tinylicious/node_modules/@fluidframework/gitresources": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
+			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
+			"dev": true
+		},
+		"node_modules/tinylicious/node_modules/@fluidframework/protocol-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
+			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"events": "^3.1.0"
+			}
+		},
+		"node_modules/tinylicious/node_modules/@fluidframework/protocol-definitions": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1"
+			}
+		},
+		"node_modules/tinylicious/node_modules/@fluidframework/server-services-client": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
+			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^1.0.1",
+				"@fluidframework/protocol-base": "^1.0.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"axios": "^0.26.0",
+				"crc-32": "1.2.0",
+				"debug": "^4.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"jsrsasign": "^10.5.25",
+				"jwt-decode": "^3.0.0",
+				"querystring": "^0.2.0",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/tinylicious/node_modules/split": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"dev": true,
+			"dependencies": {
+				"through": "2"
+			},
+			"engines": {
+				"node": "*"
+			}
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -2475,10 +5571,28 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
 		"node_modules/tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+		},
+		"node_modules/triple-beam": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 14.0.0"
+			}
 		},
 		"node_modules/tslib": {
 			"version": "2.6.2",
@@ -2493,6 +5607,67 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/type-is": {
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+			"dev": true,
+			"dependencies": {
+				"media-typer": "0.3.0",
+				"mime-types": "~2.1.24"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/typewise": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+			"integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
+			"dev": true,
+			"dependencies": {
+				"typewise-core": "^1.2.0"
+			}
+		},
+		"node_modules/typewise-core": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+			"integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
+			"dev": true
+		},
+		"node_modules/typewiselite": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
+			"integrity": "sha512-J9alhjVHupW3Wfz6qFRGgQw0N3gr8hOkw6zm7FZ6UR1Cse/oD9/JVok7DNE9TT9IbciDHX2Ex9+ksE6cRmtymw==",
+			"dev": true
+		},
+		"node_modules/uid2": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+			"integrity": "sha512-5gSP1liv10Gjp8cMEnFd6shzkL/D6W1uhXSFNCxDC+YI8+L8wkCYCbJ7n77Ezb4wE/xzMogecE+DtamEe9PZjg==",
+			"dev": true
+		},
+		"node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/url": {
@@ -2513,12 +5688,49 @@
 				"requires-port": "^1.0.0"
 			}
 		},
+		"node_modules/util": {
+			"version": "0.12.5",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"is-arguments": "^1.0.4",
+				"is-generator-function": "^1.0.7",
+				"is-typed-array": "^1.1.3",
+				"which-typed-array": "^1.1.2"
+			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true
+		},
+		"node_modules/utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
 		"node_modules/uuid": {
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
 			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
 			"bin": {
 				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/wait-on": {
@@ -2577,6 +5789,61 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/which-typed-array": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
+			"integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
+			"dev": true,
+			"dependencies": {
+				"available-typed-arrays": "^1.0.5",
+				"call-bind": "^1.0.4",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/winston": {
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
+			"integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
+			"dev": true,
+			"dependencies": {
+				"@colors/colors": "^1.6.0",
+				"@dabh/diagnostics": "^2.0.2",
+				"async": "^3.2.3",
+				"is-stream": "^2.0.0",
+				"logform": "^2.4.0",
+				"one-time": "^1.0.0",
+				"readable-stream": "^3.4.0",
+				"safe-stable-stringify": "^2.3.1",
+				"stack-trace": "0.0.x",
+				"triple-beam": "^1.3.0",
+				"winston-transport": "^4.5.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/winston-transport": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.6.0.tgz",
+			"integrity": "sha512-wbBA9PbPAHxKiygo7ub7BYRiKxms0tpfU2ljtWzb3SjRjv5yl6Ozuy/TkXf00HTAt+Uylo3gSkNwzc4ME0wiIg==",
+			"dev": true,
+			"dependencies": {
+				"logform": "^2.3.2",
+				"readable-stream": "^3.6.0",
+				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/workerpool": {
@@ -2642,6 +5909,15 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4"
+			}
+		},
 		"node_modules/y18n": {
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -2650,6 +5926,12 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		},
 		"node_modules/yargs": {
 			"version": "16.2.0",

--- a/node-demo/package-lock.json
+++ b/node-demo/package-lock.json
@@ -15,7 +15,6 @@
 				"readline-sync": "^1.4.10"
 			},
 			"devDependencies": {
-				"@fluidframework/azure-local-service": "^1.1.0",
 				"@fluidframework/build-common": "^2.0.0",
 				"chai": "^4.3.7",
 				"mocha": "^10.1.0",
@@ -26,26 +25,6 @@
 			},
 			"engines": {
 				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@colors/colors": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
-			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.1.90"
-			}
-		},
-		"node_modules/@dabh/diagnostics": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-			"integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
-			"dev": true,
-			"dependencies": {
-				"colorspace": "1.1.x",
-				"enabled": "2.0.x",
-				"kuler": "^2.0.0"
 			}
 		},
 		"node_modules/@fluidframework/aqueduct": {
@@ -69,421 +48,6 @@
 				"@fluidframework/synthesize": "^1.3.7",
 				"@fluidframework/view-interfaces": "^1.3.7",
 				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-1.1.1.tgz",
-			"integrity": "sha512-gvk+qy8RytXBQaZ554OREszHGN73W3FmgpfwV+aXeOOP5RWLMPSvkPoac5K9gcUYN+nAFbRs517c055yucP9ug==",
-			"dev": true,
-			"dependencies": {
-				"tinylicious": "^0.4.89251"
-			},
-			"bin": {
-				"azure-local-service": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
-			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
-			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.4001.tgz",
-			"integrity": "sha512-rERfgXK5DXGJvxADjotkAZssKgp3ZxW6u7yUekrDnFDkXtbCW1Gcq+EwvjHTEyhsOp30YBnD0Z39xnZy4zEZRw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas-driver": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/semver": "^6.0.1",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"axios": "^0.26.0",
-				"buffer": "^6.0.3",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"semver": "^6.3.0",
-				"sha.js": "^2.4.11",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas-driver": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.4001.tgz",
-			"integrity": "sha512-qRs+vMbSS9aPx7vr3XemvER5DeY/nsJ5ZkcL3UDjUOxvLZxbOAD6C6JeH3Zgzc/jc8bqshcxai/u7qso2zCsFw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-local-server": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.4001.tgz",
-			"integrity": "sha512-FIlNUc9Ncul/5qzP+VyU53TJj8fxX7KZ1lweswZYalleRZwiqFA4Y+NbWRRWM0iJ1z8hvhyRZblG3iNrpGl04A==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.4001",
-				"@fluidframework/server-memory-orderer": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@fluidframework/server-test-utils": "^0.1038.4001",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"jsrsasign": "^10.5.25",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-memory-orderer": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.4001.tgz",
-			"integrity": "sha512-fdzTCLFRh8QfyY17MnB22/o8x2XEX1+wZrm+dn+1Av+ZVe/+ZhfdX5LsQCMKYv+X5mgAauNmC/12mQE4H6jvsQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/debug": "^4.1.5",
-				"@types/double-ended-queue": "^2.1.0",
-				"@types/lodash": "^4.14.118",
-				"@types/node": "^14.18.0",
-				"@types/ws": "^6.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1",
-				"ws": "^7.4.6"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
-			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-core": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.4001.tgz",
-			"integrity": "sha512-nuZ9ebvyeIoRdlpQQpBNGkawKtc2/tHKbc8CHbMZRMh7F7kwYUtoHd/J8powb9eUcg5IHDmXx1l+PQRbQX4vCg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/nconf": "^0.10.2",
-				"@types/node": "^14.18.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"nconf": "^0.12.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-shared": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.4001.tgz",
-			"integrity": "sha512-vDRB2G/Xnuhan+Ri0Eg5JMKfsm7hxstCXdEyQhzJzC7+bw66wts+ZIsEsn4Ha/3KkxblF/RSW3lBhrYpxii3cQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@socket.io/redis-adapter": "^7.2.0",
-				"body-parser": "^1.17.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"ioredis": "^4.24.2",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"notepack.io": "^2.3.0",
-				"querystring": "^0.2.0",
-				"socket.io": "^4.5.3",
-				"socket.io-adapter": "^2.4.0",
-				"socket.io-parser": "^4.2.1",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-telemetry": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.4001.tgz",
-			"integrity": "sha512-2leJhB04+71RTmC5ShRXm/4FWng9tLn9dlrUAjApZH4RlUJAx1JGsvo/5JU1tIbpUutMHUle2IpWyfu/RV+S5g==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"path-browserify": "^1.0.1",
-				"serialize-error": "^8.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-utils": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.4001.tgz",
-			"integrity": "sha512-K7X/0mlonDAu0pPIgTz8U9nLwRSbJY2oBpFPwpkp1UtE6SU02jx2ZzraT9epDmOl3EXeS1rHzA+mbvBSe1aFMg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"debug": "^4.1.1",
-				"express": "^4.17.3",
-				"ioredis": "^4.24.2",
-				"json-stringify-safe": "^5.0.1",
-				"jsonwebtoken": "^9.0.0",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0",
-				"sillyname": "^0.1.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0",
-				"winston-transport": "^4.5.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-test-utils": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.4001.tgz",
-			"integrity": "sha512-qrLp5H1UUPIJSEHlzZ1iYlPFJCQrd2WnmoafxnQIg0mfU1ZE8XUlG5MKUg8bT9pWsCoEGJDiOkkRHaq+WXupjQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"string-hash": "^1.1.3",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@types/node": {
-			"version": "14.18.63",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@types/semver": {
-			"version": "6.2.5",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.5.tgz",
-			"integrity": "sha512-NAxro9/RqWXTqdSjccDZAjA4nXK+6zRun+HvibYJfGy8TQhpOC7Vv6v2rlHYKrT0Q8jGGoNRd/xVdHRIQRNlFQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/denque": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/ioredis": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
-			"integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
-			"dev": true,
-			"dependencies": {
-				"cluster-key-slot": "^1.1.0",
-				"debug": "^4.3.1",
-				"denque": "^1.1.0",
-				"lodash.defaults": "^4.2.0",
-				"lodash.flatten": "^4.4.0",
-				"lodash.isarguments": "^3.1.0",
-				"p-map": "^2.1.0",
-				"redis-commands": "1.7.0",
-				"redis-errors": "^1.2.0",
-				"redis-parser": "^3.0.0",
-				"standard-as-callback": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ioredis"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/tinylicious": {
-			"version": "0.4.94771",
-			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
-			"integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.1000",
-				"@fluidframework/protocol-base": "^0.1038.1000",
-				"@fluidframework/protocol-definitions": "^1.0.0",
-				"@fluidframework/server-lambdas": "^0.1038.1000",
-				"@fluidframework/server-local-server": "^0.1038.1000",
-				"@fluidframework/server-memory-orderer": "^0.1038.1000",
-				"@fluidframework/server-services-client": "^0.1038.1000",
-				"@fluidframework/server-services-core": "^0.1038.1000",
-				"@fluidframework/server-services-shared": "^0.1038.1000",
-				"@fluidframework/server-services-telemetry": "^0.1038.1000",
-				"@fluidframework/server-services-utils": "^0.1038.1000",
-				"@fluidframework/server-test-utils": "^0.1038.1000",
-				"agentkeepalive": "^4.2.1",
-				"axios": "^0.26.0",
-				"body-parser": "^1.17.1",
-				"charwise": "^3.0.1",
-				"compression": "^1.7.2",
-				"cookie-parser": "^1.4.3",
-				"cors": "^2.8.4",
-				"detect-port": "^1.3.0",
-				"express": "^4.16.3",
-				"isomorphic-git": "^1.8.2",
-				"json-stringify-safe": "^5.0.1",
-				"level": "^8.0.0",
-				"level-sublevel": "6.6.4",
-				"lodash": "^4.17.21",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"socket.io": "^4.5.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.2",
-				"winston": "^3.6.0"
-			},
-			"bin": {
-				"tinylicious": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/ws": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@fluidframework/build-common": {
@@ -1042,100 +606,10 @@
 			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
 			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
 		},
-		"node_modules/@socket.io/redis-adapter": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-7.2.0.tgz",
-			"integrity": "sha512-/r6oF6Myz0K9uatB/pfCi0BhKg/KRMh1OokrqcjlNz6aq40WiXdFLRbHJQuwGHq/KvB+D6141K+IynbVxZGvhw==",
-			"dev": true,
-			"dependencies": {
-				"debug": "~4.3.1",
-				"notepack.io": "~2.2.0",
-				"socket.io-adapter": "^2.4.0",
-				"uid2": "0.0.3"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/@socket.io/redis-adapter/node_modules/notepack.io": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.2.0.tgz",
-			"integrity": "sha512-9b5w3t5VSH6ZPosoYnyDONnUTF8o0UkBw7JLA6eBlYJWyGT1Q3vQa8Hmuj1/X6RYvHjjygBDgw6fJhe0JEojfw==",
-			"dev": true
-		},
-		"node_modules/@types/cookie": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-			"integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-			"dev": true
-		},
-		"node_modules/@types/cors": {
-			"version": "2.8.15",
-			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.15.tgz",
-			"integrity": "sha512-n91JxbNLD8eQIuXDIChAN1tCKNWCEgpceU9b7ZMbFA+P+Q4yIeh80jizFLEvolRPc1ES0VdwFlGv+kJTSirogw==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@types/debug": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.10.tgz",
-			"integrity": "sha512-tOSCru6s732pofZ+sMv9o4o3Zc+Sa8l3bxd/tweTQudFn06vAzb13ZX46Zi6m6EJ+RUbRTHvgQJ1gBtSgkaUYA==",
-			"dev": true,
-			"dependencies": {
-				"@types/ms": "*"
-			}
-		},
-		"node_modules/@types/double-ended-queue": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@types/double-ended-queue/-/double-ended-queue-2.1.5.tgz",
-			"integrity": "sha512-Iyp30YLmx/PFvtmomdZq4i81N6uR/7Le+UFrUbnNVbHboRCcCuOKu64tPXlr2yFOb8Zh4t0SppDxRQ5DM/Hlhg==",
-			"dev": true
-		},
 		"node_modules/@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
 			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
-		},
-		"node_modules/@types/lodash": {
-			"version": "4.14.200",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
-			"integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==",
-			"dev": true
-		},
-		"node_modules/@types/ms": {
-			"version": "0.7.33",
-			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.33.tgz",
-			"integrity": "sha512-AuHIyzR5Hea7ij0P9q7vx7xu4z0C28ucwjAZC0ja7JhINyCnOw8/DnvAPQQ9TfOlCtZAmCERKQX9+o1mgQhuOQ==",
-			"dev": true
-		},
-		"node_modules/@types/nconf": {
-			"version": "0.10.5",
-			"resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.5.tgz",
-			"integrity": "sha512-Rig8+FAyg9twg01Ya+aVR+QAakMxcTiO3QcvhY41Rn/m1ZvFIU5fb+D3qxxqIHxrFacQqxeg8c8apzZYZ+dqLA==",
-			"dev": true
-		},
-		"node_modules/@types/node": {
-			"version": "16.18.59",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.59.tgz",
-			"integrity": "sha512-PJ1w2cNeKUEdey4LiPra0ZuxZFOGvetswE8qHRriV/sUkL5Al4tTmPV9D2+Y/TPIxTHHgxTfRjZVKWhPw/ORhQ==",
-			"dev": true
-		},
-		"node_modules/@types/triple-beam": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.4.tgz",
-			"integrity": "sha512-HlJjF3wxV4R2VQkFpKe0YqJLilYNgtRtsqqZtby7RkVsSs+i+vbyzjtUwpFEdUCKcrGzCiEJE7F/0mKjh0sunA==",
-			"dev": true
-		},
-		"node_modules/@types/ws": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
-			"integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
 		},
 		"node_modules/abort-controller": {
 			"version": "3.0.0",
@@ -1146,81 +620,6 @@
 			},
 			"engines": {
 				"node": ">=6.5"
-			}
-		},
-		"node_modules/abstract-level": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
-			"integrity": "sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^6.0.3",
-				"catering": "^2.1.0",
-				"is-buffer": "^2.0.5",
-				"level-supports": "^4.0.0",
-				"level-transcoder": "^1.0.1",
-				"module-error": "^1.0.1",
-				"queue-microtask": "^1.2.3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/abstract-level/node_modules/is-buffer": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/accepts": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-			"integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-			"dev": true,
-			"dependencies": {
-				"mime-types": "~2.1.34",
-				"negotiator": "0.6.3"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/address": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
-			"integrity": "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/agentkeepalive": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
-			"integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
-			"dev": true,
-			"dependencies": {
-				"humanize-ms": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 8.0.0"
 			}
 		},
 		"node_modules/ansi-colors": {
@@ -1281,25 +680,6 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
-		"node_modules/array-flatten": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-			"integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-			"dev": true
-		},
-		"node_modules/assert": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
-			"integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"is-nan": "^1.3.2",
-				"object-is": "^1.1.5",
-				"object.assign": "^4.1.4",
-				"util": "^0.12.5"
-			}
-		},
 		"node_modules/assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -1309,35 +689,11 @@
 				"node": "*"
 			}
 		},
-		"node_modules/async": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-			"dev": true
-		},
-		"node_modules/async-lock": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz",
-			"integrity": "sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ==",
-			"dev": true
-		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"dev": true
-		},
-		"node_modules/available-typed-arrays": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/axios": {
 			"version": "0.26.1",
@@ -1372,33 +728,6 @@
 				}
 			]
 		},
-		"node_modules/base64id": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-			"integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-			"dev": true,
-			"engines": {
-				"node": "^4.5.0 || >= 5.9"
-			}
-		},
-		"node_modules/basic-auth": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-			"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "5.1.2"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/basic-auth/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1413,60 +742,6 @@
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
 			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
 			"dev": true
-		},
-		"node_modules/body-parser": {
-			"version": "1.20.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-			"integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
-			"dev": true,
-			"dependencies": {
-				"bytes": "3.1.2",
-				"content-type": "~1.0.5",
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"destroy": "1.2.0",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"on-finished": "2.4.1",
-				"qs": "6.11.0",
-				"raw-body": "2.5.2",
-				"type-is": "~1.6.18",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8",
-				"npm": "1.2.8000 || >= 1.4.16"
-			}
-		},
-		"node_modules/body-parser/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/body-parser/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true
-		},
-		"node_modules/body-parser/node_modules/qs": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-			"integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-			"dev": true,
-			"dependencies": {
-				"side-channel": "^1.0.4"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -1488,18 +763,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/browser-level": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
-			"integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
-			"dev": true,
-			"dependencies": {
-				"abstract-level": "^1.0.2",
-				"catering": "^2.1.1",
-				"module-error": "^1.0.2",
-				"run-parallel-limit": "^1.1.0"
 			}
 		},
 		"node_modules/browser-stdout": {
@@ -1531,40 +794,6 @@
 				"ieee754": "^1.2.1"
 			}
 		},
-		"node_modules/buffer-equal-constant-time": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-			"dev": true
-		},
-		"node_modules/bytes": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/bytewise": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-			"integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
-			"dev": true,
-			"dependencies": {
-				"bytewise-core": "^1.2.2",
-				"typewise": "^1.0.3"
-			}
-		},
-		"node_modules/bytewise-core": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-			"integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
-			"dev": true,
-			"dependencies": {
-				"typewise-core": "^1.2"
-			}
-		},
 		"node_modules/call-bind": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
@@ -1588,15 +817,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/catering": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
-			"integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/chai": {
@@ -1641,12 +861,6 @@
 			"engines": {
 				"node": "*"
 			}
-		},
-		"node_modules/charwise": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz",
-			"integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw==",
-			"dev": true
 		},
 		"node_modules/check-error": {
 			"version": "1.0.2",
@@ -1693,29 +907,6 @@
 				"fsevents": "~2.3.2"
 			}
 		},
-		"node_modules/classic-level": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.3.0.tgz",
-			"integrity": "sha512-iwFAJQYtqRTRM0F6L8h4JCt00ZSGdOyqh7yVrhhjrOpFhmBjNlRUey64MCiyo6UmQHMJ+No3c81nujPv+n9yrg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"dependencies": {
-				"abstract-level": "^1.0.2",
-				"catering": "^2.1.0",
-				"module-error": "^1.0.1",
-				"napi-macros": "^2.2.2",
-				"node-gyp-build": "^4.3.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/clean-git-ref": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
-			"integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
-			"dev": true
-		},
 		"node_modules/cliui": {
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -1725,25 +916,6 @@
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^7.0.0"
-			}
-		},
-		"node_modules/cluster-key-slot": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
-			"integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/color": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^1.9.3",
-				"color-string": "^1.6.0"
 			}
 		},
 		"node_modules/color-convert": {
@@ -1764,41 +936,6 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
-		"node_modules/color-string": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
-		},
-		"node_modules/color/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/color/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
-		},
-		"node_modules/colorspace": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-			"integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-			"dev": true,
-			"dependencies": {
-				"color": "^3.1.3",
-				"text-hex": "1.0.x"
-			}
-		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1811,139 +948,11 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/compressible": {
-			"version": "2.0.18",
-			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
-			"integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
-			"dev": true,
-			"dependencies": {
-				"mime-db": ">= 1.43.0 < 2"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/compression": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
-			"integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
-			"dev": true,
-			"dependencies": {
-				"accepts": "~1.3.5",
-				"bytes": "3.0.0",
-				"compressible": "~2.0.16",
-				"debug": "2.6.9",
-				"on-headers": "~1.0.2",
-				"safe-buffer": "5.1.2",
-				"vary": "~1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/compression/node_modules/bytes": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-			"integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/compression/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/compression/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true
-		},
-		"node_modules/compression/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
-		},
-		"node_modules/content-disposition": {
-			"version": "0.5.4",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-			"integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "5.2.1"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/content-type": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/cookie": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-			"integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/cookie-parser": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-			"integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
-			"dev": true,
-			"dependencies": {
-				"cookie": "0.4.1",
-				"cookie-signature": "1.0.6"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/cookie-signature": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-			"dev": true
-		},
-		"node_modules/core-util-is": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-			"dev": true
-		},
-		"node_modules/cors": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-			"dev": true,
-			"dependencies": {
-				"object-assign": "^4",
-				"vary": "^1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
 		},
 		"node_modules/crc-32": {
 			"version": "1.2.0",
@@ -2019,21 +1028,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/decompress-response": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-			"dev": true,
-			"dependencies": {
-				"mimic-response": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/deep-eql": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.2.tgz",
@@ -2059,23 +1053,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/define-properties": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-			"dev": true,
-			"dependencies": {
-				"define-data-property": "^1.0.1",
-				"has-property-descriptors": "^1.0.0",
-				"object-keys": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2083,39 +1060,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/depd": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/destroy": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-			"integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8",
-				"npm": "1.2.8000 || >= 1.4.16"
-			}
-		},
-		"node_modules/detect-port": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
-			"integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
-			"dev": true,
-			"dependencies": {
-				"address": "^1.0.1",
-				"debug": "4"
-			},
-			"bin": {
-				"detect": "bin/detect-port.js",
-				"detect-port": "bin/detect-port.js"
 			}
 		},
 		"node_modules/diff": {
@@ -2126,12 +1070,6 @@
 			"engines": {
 				"node": ">=0.3.1"
 			}
-		},
-		"node_modules/diff3": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
-			"dev": true
 		},
 		"node_modules/double-ended-queue": {
 			"version": "2.1.0-0",
@@ -2144,62 +1082,11 @@
 			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
 			"dev": true
 		},
-		"node_modules/ecdsa-sig-formatter": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"node_modules/ee-first": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-			"dev": true
-		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true
-		},
-		"node_modules/enabled": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
-			"dev": true
-		},
-		"node_modules/encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/engine.io": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.3.tgz",
-			"integrity": "sha512-IML/R4eG/pUS5w7OfcDE0jKrljWS9nwnEfsxWCIJF5eO6AHo6+Hlv+lQbdlAYsiJPHzUthLm1RUjnBzWOs45cw==",
-			"dev": true,
-			"dependencies": {
-				"@types/cookie": "^0.4.1",
-				"@types/cors": "^2.8.12",
-				"@types/node": ">=10.0.0",
-				"accepts": "~1.3.4",
-				"base64id": "2.0.0",
-				"cookie": "~0.4.1",
-				"cors": "~2.8.5",
-				"debug": "~4.3.1",
-				"engine.io-parser": "~5.2.1",
-				"ws": "~8.11.0"
-			},
-			"engines": {
-				"node": ">=10.2.0"
-			}
 		},
 		"node_modules/engine.io-client": {
 			"version": "6.5.2",
@@ -2221,18 +1108,6 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/errno": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
-			"integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-			"dev": true,
-			"dependencies": {
-				"prr": "~1.0.1"
-			},
-			"bin": {
-				"errno": "cli.js"
-			}
-		},
 		"node_modules/escalade": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -2241,12 +1116,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/escape-html": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-			"dev": true
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
@@ -2258,15 +1127,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/etag": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/event-stream": {
@@ -2331,138 +1191,6 @@
 				"node": ">=0.8"
 			}
 		},
-		"node_modules/express": {
-			"version": "4.18.2",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-			"integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
-			"dev": true,
-			"dependencies": {
-				"accepts": "~1.3.8",
-				"array-flatten": "1.1.1",
-				"body-parser": "1.20.1",
-				"content-disposition": "0.5.4",
-				"content-type": "~1.0.4",
-				"cookie": "0.5.0",
-				"cookie-signature": "1.0.6",
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "1.2.0",
-				"fresh": "0.5.2",
-				"http-errors": "2.0.0",
-				"merge-descriptors": "1.0.1",
-				"methods": "~1.1.2",
-				"on-finished": "2.4.1",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.7",
-				"qs": "6.11.0",
-				"range-parser": "~1.2.1",
-				"safe-buffer": "5.2.1",
-				"send": "0.18.0",
-				"serve-static": "1.15.0",
-				"setprototypeof": "1.2.0",
-				"statuses": "2.0.1",
-				"type-is": "~1.6.18",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.10.0"
-			}
-		},
-		"node_modules/express/node_modules/body-parser": {
-			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-			"integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-			"dev": true,
-			"dependencies": {
-				"bytes": "3.1.2",
-				"content-type": "~1.0.4",
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"destroy": "1.2.0",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"on-finished": "2.4.1",
-				"qs": "6.11.0",
-				"raw-body": "2.5.1",
-				"type-is": "~1.6.18",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8",
-				"npm": "1.2.8000 || >= 1.4.16"
-			}
-		},
-		"node_modules/express/node_modules/cookie": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/express/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/express/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true
-		},
-		"node_modules/express/node_modules/path-to-regexp": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
-			"dev": true
-		},
-		"node_modules/express/node_modules/qs": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-			"integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-			"dev": true,
-			"dependencies": {
-				"side-channel": "^1.0.4"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/express/node_modules/raw-body": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-			"integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-			"dev": true,
-			"dependencies": {
-				"bytes": "3.1.2",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/fecha": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
-			"dev": true
-		},
 		"node_modules/fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2474,39 +1202,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/finalhandler": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-			"integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
-			"dev": true,
-			"dependencies": {
-				"debug": "2.6.9",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"on-finished": "2.4.1",
-				"parseurl": "~1.3.3",
-				"statuses": "2.0.1",
-				"unpipe": "~1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/finalhandler/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/finalhandler/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true
 		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
@@ -2546,12 +1241,6 @@
 				"@fluidframework/sequence": "^1.3.7"
 			}
 		},
-		"node_modules/fn.name": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-			"dev": true
-		},
 		"node_modules/follow-redirects": {
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
@@ -2571,15 +1260,6 @@
 				}
 			}
 		},
-		"node_modules/for-each": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-			"dev": true,
-			"dependencies": {
-				"is-callable": "^1.1.3"
-			}
-		},
 		"node_modules/form-data": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -2592,24 +1272,6 @@
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/forwarded": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/fresh": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/from": {
@@ -2787,21 +1449,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/has-tostringtag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-			"dev": true,
-			"dependencies": {
-				"has-symbols": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/hasown": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
@@ -2822,22 +1469,6 @@
 				"he": "bin/he"
 			}
 		},
-		"node_modules/http-errors": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-			"integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-			"dev": true,
-			"dependencies": {
-				"depd": "2.0.0",
-				"inherits": "2.0.4",
-				"setprototypeof": "1.2.0",
-				"statuses": "2.0.1",
-				"toidentifier": "1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/human-signals": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -2845,27 +1476,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10.17.0"
-			}
-		},
-		"node_modules/humanize-ms": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "^2.0.0"
-			}
-		},
-		"node_modules/iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/ieee754": {
@@ -2887,15 +1497,6 @@
 				}
 			]
 		},
-		"node_modules/ignore": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
-			"dev": true,
-			"engines": {
-				"node": ">= 4"
-			}
-		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2910,46 +1511,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
-		"node_modules/ini": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-			"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/ipaddr.js": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
-		"node_modules/is-arguments": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-			"dev": true
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
@@ -2969,18 +1530,6 @@
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
 		},
-		"node_modules/is-callable": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2999,21 +1548,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/is-generator-function": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-			"integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-			"dev": true,
-			"dependencies": {
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3024,22 +1558,6 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-nan": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-number": {
@@ -3072,21 +1590,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-typed-array": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
-			"integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
-			"dev": true,
-			"dependencies": {
-				"which-typed-array": "^1.1.11"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-unicode-supported": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -3110,31 +1613,6 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
-		},
-		"node_modules/isomorphic-git": {
-			"version": "1.24.5",
-			"resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.24.5.tgz",
-			"integrity": "sha512-07M4YscftHZJIuw7xZhgWkdFvVjHSBJBsIwWXkxgFCivhb0l8mGNchM7nO2hU27EKSIf0sT4gJivEgLGohWbzA==",
-			"dev": true,
-			"dependencies": {
-				"async-lock": "^1.1.0",
-				"clean-git-ref": "^2.0.1",
-				"crc-32": "^1.2.0",
-				"diff3": "0.0.3",
-				"ignore": "^5.1.4",
-				"minimisted": "^2.0.0",
-				"pako": "^1.0.10",
-				"pify": "^4.0.1",
-				"readable-stream": "^3.4.0",
-				"sha.js": "^2.4.9",
-				"simple-get": "^4.0.1"
-			},
-			"bin": {
-				"isogit": "cli.cjs"
-			},
-			"engines": {
-				"node": ">=12"
-			}
 		},
 		"node_modules/joi": {
 			"version": "17.10.1",
@@ -3166,28 +1644,6 @@
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
 		},
-		"node_modules/jsonwebtoken": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-			"integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-			"dev": true,
-			"dependencies": {
-				"jws": "^3.2.2",
-				"lodash.includes": "^4.3.0",
-				"lodash.isboolean": "^3.0.3",
-				"lodash.isinteger": "^4.0.4",
-				"lodash.isnumber": "^3.0.3",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.isstring": "^4.0.1",
-				"lodash.once": "^4.0.0",
-				"ms": "^2.1.1",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": ">=12",
-				"npm": ">=6"
-			}
-		},
 		"node_modules/jsrsasign": {
 			"version": "10.8.6",
 			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.8.6.tgz",
@@ -3202,37 +1658,10 @@
 			"integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
 			"dev": true
 		},
-		"node_modules/jwa": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-			"dev": true,
-			"dependencies": {
-				"buffer-equal-constant-time": "1.0.1",
-				"ecdsa-sig-formatter": "1.0.11",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"node_modules/jws": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-			"dev": true,
-			"dependencies": {
-				"jwa": "^1.4.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"node_modules/jwt-decode": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
 			"integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
-		},
-		"node_modules/kuler": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-			"dev": true
 		},
 		"node_modules/lazy-ass": {
 			"version": "1.6.0",
@@ -3241,170 +1670,6 @@
 			"dev": true,
 			"engines": {
 				"node": "> 0.8"
-			}
-		},
-		"node_modules/level": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/level/-/level-8.0.0.tgz",
-			"integrity": "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==",
-			"dev": true,
-			"dependencies": {
-				"browser-level": "^1.0.1",
-				"classic-level": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/level"
-			}
-		},
-		"node_modules/level-codec": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
-			"integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^5.6.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/level-codec/node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
-		},
-		"node_modules/level-errors": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-			"integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-			"dev": true,
-			"dependencies": {
-				"errno": "~0.1.1"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/level-iterator-stream": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
-			"integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.5",
-				"xtend": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/level-iterator-stream/node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true
-		},
-		"node_modules/level-iterator-stream/node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-			"dev": true,
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/level-iterator-stream/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"node_modules/level-iterator-stream/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"node_modules/level-post": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
-			"integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
-			"dev": true,
-			"dependencies": {
-				"ltgt": "^2.1.2"
-			}
-		},
-		"node_modules/level-sublevel": {
-			"version": "6.6.4",
-			"resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.4.tgz",
-			"integrity": "sha512-pcCrTUOiO48+Kp6F1+UAzF/OtWqLcQVTVF39HLdZ3RO8XBoXt+XVPKZO1vVr1aUoxHZA9OtD2e1v7G+3S5KFDA==",
-			"dev": true,
-			"dependencies": {
-				"bytewise": "~1.1.0",
-				"level-codec": "^9.0.0",
-				"level-errors": "^2.0.0",
-				"level-iterator-stream": "^2.0.3",
-				"ltgt": "~2.1.1",
-				"pull-defer": "^0.2.2",
-				"pull-level": "^2.0.3",
-				"pull-stream": "^3.6.8",
-				"typewiselite": "~1.0.0",
-				"xtend": "~4.0.0"
-			}
-		},
-		"node_modules/level-supports": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
-			"integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/level-transcoder": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
-			"integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^6.0.3",
-				"module-error": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/locate-path": {
@@ -3427,70 +1692,10 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
-		"node_modules/lodash.defaults": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-			"dev": true
-		},
-		"node_modules/lodash.flatten": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-			"dev": true
-		},
 		"node_modules/lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
 			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-			"dev": true
-		},
-		"node_modules/lodash.includes": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-			"dev": true
-		},
-		"node_modules/lodash.isarguments": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-			"dev": true
-		},
-		"node_modules/lodash.isboolean": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-			"dev": true
-		},
-		"node_modules/lodash.isinteger": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-			"dev": true
-		},
-		"node_modules/lodash.isnumber": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-			"dev": true
-		},
-		"node_modules/lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-			"dev": true
-		},
-		"node_modules/lodash.isstring": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-			"dev": true
-		},
-		"node_modules/lodash.once": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
 			"dev": true
 		},
 		"node_modules/log-symbols": {
@@ -3509,29 +1714,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/logform": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
-			"integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
-			"dev": true,
-			"dependencies": {
-				"@colors/colors": "1.6.0",
-				"@types/triple-beam": "^1.3.2",
-				"fecha": "^4.2.0",
-				"ms": "^2.1.1",
-				"safe-stable-stringify": "^2.3.1",
-				"triple-beam": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/looper": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
-			"integrity": "sha512-6DzMHJcjbQX/UPHc1rRCBfKlLwDkvuGZ715cIR36wSdYqWXFT35uLXq5P/2orl3tz+t+VOVPxw4yPinQlUDGDQ==",
-			"dev": true
-		},
 		"node_modules/loupe": {
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
@@ -3540,24 +1722,6 @@
 			"dependencies": {
 				"get-func-name": "^2.0.0"
 			}
-		},
-		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/ltgt": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
-			"integrity": "sha512-5VjHC5GsENtIi5rbJd+feEpDKhfr7j0odoUR2Uh978g+2p93nd5o34cTjQWohXsPsCZeqoDnIqEf88mPCe0Pfw==",
-			"dev": true
 		},
 		"node_modules/map-stream": {
 			"version": "0.1.0",
@@ -3576,47 +1740,11 @@
 				"is-buffer": "~1.1.6"
 			}
 		},
-		"node_modules/media-typer": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
-			"dev": true
-		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true
-		},
-		"node_modules/methods": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mime": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-			"dev": true,
-			"bin": {
-				"mime": "cli.js"
-			},
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/mime-db": {
 			"version": "1.52.0",
@@ -3648,18 +1776,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/mimic-response": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/minimatch": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
@@ -3688,15 +1804,6 @@
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/minimisted": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
-			"integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
-			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.5"
 			}
 		},
 		"node_modules/mkdirp": {
@@ -3800,58 +1907,6 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
-		"node_modules/module-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
-			"integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/morgan": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-			"integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
-			"dev": true,
-			"dependencies": {
-				"basic-auth": "~2.0.1",
-				"debug": "2.6.9",
-				"depd": "~2.0.0",
-				"on-finished": "~2.3.0",
-				"on-headers": "~1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/morgan/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/morgan/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true
-		},
-		"node_modules/morgan/node_modules/on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-			"dev": true,
-			"dependencies": {
-				"ee-first": "1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3867,36 +1922,6 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-			}
-		},
-		"node_modules/napi-macros": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
-			"integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==",
-			"dev": true
-		},
-		"node_modules/nconf": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.1.tgz",
-			"integrity": "sha512-p2cfF+B3XXacQdswUYWZ0w6Vld0832A/tuqjLBu3H1sfUcby4N2oVbGhyuCkZv+t3iY3aiFEj7gZGqax9Q2c1w==",
-			"dev": true,
-			"dependencies": {
-				"async": "^3.0.0",
-				"ini": "^2.0.0",
-				"secure-keys": "^1.0.0",
-				"yargs": "^16.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
-		"node_modules/negotiator": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/nise": {
@@ -3949,17 +1974,6 @@
 				}
 			}
 		},
-		"node_modules/node-gyp-build": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
-			"integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
-			"dev": true,
-			"bin": {
-				"node-gyp-build": "bin.js",
-				"node-gyp-build-optional": "optional.js",
-				"node-gyp-build-test": "build-test.js"
-			}
-		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -3968,12 +1982,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/notepack.io": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.3.0.tgz",
-			"integrity": "sha512-9RiFDxeydHsWOqdthRUck2Kd4UW2NzVd2xxOulZiQ9mvge6ElsHXLpwD3HEJyql6sFEnEn/eMO7HSdS0M5mWkA==",
-			"dev": true
 		},
 		"node_modules/npm-run-path": {
 			"version": "4.0.1",
@@ -3987,85 +1995,12 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/object-inspect": {
 			"version": "1.12.3",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
 			"integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object-is": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-			"integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/object.assign": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"has-symbols": "^1.0.3",
-				"object-keys": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/on-finished": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-			"dev": true,
-			"dependencies": {
-				"ee-first": "1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/on-headers": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-			"integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/once": {
@@ -4075,15 +2010,6 @@
 			"dev": true,
 			"dependencies": {
 				"wrappy": "1"
-			}
-		},
-		"node_modules/one-time": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-			"dev": true,
-			"dependencies": {
-				"fn.name": "1.x.x"
 			}
 		},
 		"node_modules/onetime": {
@@ -4129,30 +2055,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/p-map": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/pako": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-			"dev": true
-		},
-		"node_modules/parseurl": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/path-browserify": {
@@ -4226,15 +2128,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/pify": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/prettier": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
@@ -4260,31 +2153,6 @@
 				"node": ">=0.8"
 			}
 		},
-		"node_modules/process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
-		},
-		"node_modules/proxy-addr": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-			"dev": true,
-			"dependencies": {
-				"forwarded": "0.2.0",
-				"ipaddr.js": "1.9.1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
-		"node_modules/prr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-			"dev": true
-		},
 		"node_modules/ps-tree": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
@@ -4298,64 +2166,6 @@
 			},
 			"engines": {
 				"node": ">= 0.10"
-			}
-		},
-		"node_modules/pull-cat": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
-			"integrity": "sha512-i3w+xZ3DCtTVz8S62hBOuNLRHqVDsHMNZmgrZsjPnsxXUgbWtXEee84lo1XswE7W2a3WHyqsNuDJTjVLAQR8xg==",
-			"dev": true
-		},
-		"node_modules/pull-defer": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
-			"integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA==",
-			"dev": true
-		},
-		"node_modules/pull-level": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
-			"integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
-			"dev": true,
-			"dependencies": {
-				"level-post": "^1.0.7",
-				"pull-cat": "^1.1.9",
-				"pull-live": "^1.0.1",
-				"pull-pushable": "^2.0.0",
-				"pull-stream": "^3.4.0",
-				"pull-window": "^2.1.4",
-				"stream-to-pull-stream": "^1.7.1"
-			}
-		},
-		"node_modules/pull-live": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
-			"integrity": "sha512-tkNz1QT5gId8aPhV5+dmwoIiA1nmfDOzJDlOOUpU5DNusj6neNd3EePybJ5+sITr2FwyCs/FVpx74YMCfc8YeA==",
-			"dev": true,
-			"dependencies": {
-				"pull-cat": "^1.1.9",
-				"pull-stream": "^3.4.0"
-			}
-		},
-		"node_modules/pull-pushable": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
-			"integrity": "sha512-M7dp95enQ2kaHvfCt2+DJfyzgCSpWVR2h2kWYnVsW6ZpxQBx5wOu0QWOvQPVoPnBLUZYitYP2y7HyHkLQNeGXg==",
-			"dev": true
-		},
-		"node_modules/pull-stream": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.7.0.tgz",
-			"integrity": "sha512-Eco+/R004UaCK2qEDE8vGklcTG2OeZSVm1kTUQNrykEjDwcFXDZhygFDsW49DbXyJMEhHeRL3z5cRVqPAhXlIw==",
-			"dev": true
-		},
-		"node_modules/pull-window": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
-			"integrity": "sha512-cbDzN76BMlcGG46OImrgpkMf/VkCnupj8JhsrpBw3aWBM9ye345aYnqitmZCgauBkc0HbbRRn9hCnsa3k2FNUg==",
-			"dev": true,
-			"dependencies": {
-				"looper": "^2.0.0"
 			}
 		},
 		"node_modules/punycode": {
@@ -4391,26 +2201,6 @@
 			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
 			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
 		},
-		"node_modules/queue-microtask": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -4418,44 +2208,6 @@
 			"dev": true,
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
-			}
-		},
-		"node_modules/range-parser": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/raw-body": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-			"integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-			"dev": true,
-			"dependencies": {
-				"bytes": "3.1.2",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/readdirp": {
@@ -4478,33 +2230,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/redis-commands": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
-			"dev": true
-		},
-		"node_modules/redis-errors": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-			"integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/redis-parser": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-			"integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-			"dev": true,
-			"dependencies": {
-				"redis-errors": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4518,29 +2243,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
 			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
-		},
-		"node_modules/run-parallel-limit": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
-			"integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"queue-microtask": "^1.2.2"
-			}
 		},
 		"node_modules/rxjs": {
 			"version": "7.8.1",
@@ -4570,102 +2272,6 @@
 				}
 			]
 		},
-		"node_modules/safe-stable-stringify": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
-		},
-		"node_modules/secure-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
-			"integrity": "sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg==",
-			"dev": true
-		},
-		"node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/send": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-			"integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
-			"dev": true,
-			"dependencies": {
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"destroy": "1.2.0",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"fresh": "0.5.2",
-				"http-errors": "2.0.0",
-				"mime": "1.6.0",
-				"ms": "2.1.3",
-				"on-finished": "2.4.1",
-				"range-parser": "~1.2.1",
-				"statuses": "2.0.1"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/send/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/send/node_modules/debug/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true
-		},
-		"node_modules/send/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
-		},
-		"node_modules/serialize-error": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
-			"integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
-			"dev": true,
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -4673,21 +2279,6 @@
 			"dev": true,
 			"dependencies": {
 				"randombytes": "^2.1.0"
-			}
-		},
-		"node_modules/serve-static": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-			"integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
-			"dev": true,
-			"dependencies": {
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.3",
-				"send": "0.18.0"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
 			}
 		},
 		"node_modules/set-function-length": {
@@ -4703,12 +2294,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/setprototypeof": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-			"dev": true
 		},
 		"node_modules/sha.js": {
 			"version": "2.4.11",
@@ -4767,60 +2352,6 @@
 			"resolved": "https://registry.npmjs.org/sillyname/-/sillyname-0.1.0.tgz",
 			"integrity": "sha512-GWA0Zont13ov+cMNw4T7nU4SCyW8jdhD3vjA5+qs8jr+09sCPxOf+FPS5zE0c9pYlCwD+NU/CiMimY462lgG9g=="
 		},
-		"node_modules/simple-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/simple-get": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"decompress-response": "^6.0.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
-			}
-		},
-		"node_modules/simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-			"dev": true,
-			"dependencies": {
-				"is-arrayish": "^0.3.1"
-			}
-		},
 		"node_modules/sinon": {
 			"version": "14.0.2",
 			"resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.2.tgz",
@@ -4847,33 +2378,6 @@
 			"peerDependencies": {
 				"chai": "^4.0.0",
 				"sinon": ">=4.0.0"
-			}
-		},
-		"node_modules/socket.io": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.2.tgz",
-			"integrity": "sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==",
-			"dev": true,
-			"dependencies": {
-				"accepts": "~1.3.4",
-				"base64id": "~2.0.0",
-				"cors": "~2.8.5",
-				"debug": "~4.3.2",
-				"engine.io": "~6.5.2",
-				"socket.io-adapter": "~2.5.2",
-				"socket.io-parser": "~4.2.4"
-			},
-			"engines": {
-				"node": ">=10.2.0"
-			}
-		},
-		"node_modules/socket.io-adapter": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
-			"integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
-			"dev": true,
-			"dependencies": {
-				"ws": "~8.11.0"
 			}
 		},
 		"node_modules/socket.io-client": {
@@ -4914,21 +2418,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/stack-trace": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-			"integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/standard-as-callback": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-			"integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
-			"dev": true
-		},
 		"node_modules/start-server-and-test": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-2.0.0.tgz",
@@ -4953,15 +2442,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/statuses": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-			"integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/stream-combiner": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
@@ -4970,37 +2450,6 @@
 			"dependencies": {
 				"duplexer": "~0.1.1"
 			}
-		},
-		"node_modules/stream-to-pull-stream": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
-			"integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
-			"dev": true,
-			"dependencies": {
-				"looper": "^3.0.0",
-				"pull-stream": "^3.2.3"
-			}
-		},
-		"node_modules/stream-to-pull-stream/node_modules/looper": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-			"integrity": "sha512-LJ9wplN/uSn72oJRsXTx+snxPet5c8XiZmOKCm906NVYu+ag6SB6vUcnJcWxgnl2NfbIyeobAn7Bwv6xRj2XJg==",
-			"dev": true
-		},
-		"node_modules/string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.2.0"
-			}
-		},
-		"node_modules/string-hash": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-			"integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
-			"dev": true
 		},
 		"node_modules/string-width": {
 			"version": "4.2.3",
@@ -5061,12 +2510,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/text-hex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-			"dev": true
-		},
 		"node_modules/through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -5085,28 +2528,10 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/toidentifier": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
 		"node_modules/tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-		},
-		"node_modules/triple-beam": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
-			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 14.0.0"
-			}
 		},
 		"node_modules/tslib": {
 			"version": "2.6.2",
@@ -5121,67 +2546,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/type-is": {
-			"version": "1.6.18",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-			"dev": true,
-			"dependencies": {
-				"media-typer": "0.3.0",
-				"mime-types": "~2.1.24"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/typewise": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-			"integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
-			"dev": true,
-			"dependencies": {
-				"typewise-core": "^1.2.0"
-			}
-		},
-		"node_modules/typewise-core": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-			"integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
-			"dev": true
-		},
-		"node_modules/typewiselite": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
-			"integrity": "sha512-J9alhjVHupW3Wfz6qFRGgQw0N3gr8hOkw6zm7FZ6UR1Cse/oD9/JVok7DNE9TT9IbciDHX2Ex9+ksE6cRmtymw==",
-			"dev": true
-		},
-		"node_modules/uid2": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-			"integrity": "sha512-5gSP1liv10Gjp8cMEnFd6shzkL/D6W1uhXSFNCxDC+YI8+L8wkCYCbJ7n77Ezb4wE/xzMogecE+DtamEe9PZjg==",
-			"dev": true
-		},
-		"node_modules/unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/url": {
@@ -5202,49 +2566,12 @@
 				"requires-port": "^1.0.0"
 			}
 		},
-		"node_modules/util": {
-			"version": "0.12.5",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"is-arguments": "^1.0.4",
-				"is-generator-function": "^1.0.7",
-				"is-typed-array": "^1.1.3",
-				"which-typed-array": "^1.1.2"
-			}
-		},
-		"node_modules/util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true
-		},
-		"node_modules/utils-merge": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
 		"node_modules/uuid": {
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
 			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
 			"bin": {
 				"uuid": "dist/bin/uuid"
-			}
-		},
-		"node_modules/vary": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/wait-on": {
@@ -5303,61 +2630,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/which-typed-array": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
-			"integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
-			"dev": true,
-			"dependencies": {
-				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.4",
-				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/winston": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
-			"integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
-			"dev": true,
-			"dependencies": {
-				"@colors/colors": "^1.6.0",
-				"@dabh/diagnostics": "^2.0.2",
-				"async": "^3.2.3",
-				"is-stream": "^2.0.0",
-				"logform": "^2.4.0",
-				"one-time": "^1.0.0",
-				"readable-stream": "^3.4.0",
-				"safe-stable-stringify": "^2.3.1",
-				"stack-trace": "0.0.x",
-				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.5.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/winston-transport": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.6.0.tgz",
-			"integrity": "sha512-wbBA9PbPAHxKiygo7ub7BYRiKxms0tpfU2ljtWzb3SjRjv5yl6Ozuy/TkXf00HTAt+Uylo3gSkNwzc4ME0wiIg==",
-			"dev": true,
-			"dependencies": {
-				"logform": "^2.3.2",
-				"readable-stream": "^3.6.0",
-				"triple-beam": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/workerpool": {
@@ -5423,15 +2695,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.4"
-			}
-		},
 		"node_modules/y18n": {
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -5440,12 +2703,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
 		},
 		"node_modules/yargs": {
 			"version": "16.2.0",

--- a/node-demo/package.json
+++ b/node-demo/package.json
@@ -29,7 +29,6 @@
 		"prettier": "^2.7.1"
 	},
 	"devDependencies": {
-		"@fluidframework/azure-local-service": "^1.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"chai": "^4.3.7",
 		"mocha": "^10.1.0",

--- a/node-demo/package.json
+++ b/node-demo/package.json
@@ -35,6 +35,7 @@
 		"mocha-junit-reporter": "^2.2.1",
 		"sinon": "^14.0.2",
 		"sinon-chai": "^3.7.0",
-		"start-server-and-test": "^2.0.0"
+		"start-server-and-test": "^2.0.0",
+		"tinylicious": "^1.0.0"
 	}
 }

--- a/node-demo/package.json
+++ b/node-demo/package.json
@@ -9,7 +9,7 @@
 		"build": "echo 'Javascript package does not require build'",
 		"ci:test": "npm run test",
 		"start": "node ./src/index.js",
-		"start:server": "npx tinylicious@latest",
+		"start:server": "npx @fluidframework/azure-local-service",
 		"test": "start-server-and-test start:server 7070 test:mocha",
 		"test:mocha": "mocha ./test/*.test.js --config .mocharc.cjs",
 		"format": "npm run prettier:fix",
@@ -29,13 +29,13 @@
 		"prettier": "^2.7.1"
 	},
 	"devDependencies": {
+		"@fluidframework/azure-local-service": "^1.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"chai": "^4.3.7",
 		"mocha": "^10.1.0",
 		"mocha-junit-reporter": "^2.2.1",
 		"sinon": "^14.0.2",
 		"sinon-chai": "^3.7.0",
-		"start-server-and-test": "^2.0.0",
-		"tinylicious": "^1.0.0"
+		"start-server-and-test": "^2.0.0"
 	}
 }

--- a/react-demo/README.md
+++ b/react-demo/README.md
@@ -15,22 +15,22 @@ Concepts you will learn:
 
 In this example you will do the following:
 
-- [@fluid-example/react-demo](#fluid-examplereact-demo)
-	- [Demo introduction](#demo-introduction)
-	- [Use Create React App](#use-create-react-app)
-		- [Using NPM](#using-npm)
-		- [Using Yarn](#using-yarn)
-		- [Start the app](#start-the-app)
-	- [Install Fluid package dependencies](#install-fluid-package-dependencies)
-		- [Using NPM](#using-npm-1)
-		- [Using Yarn](#using-yarn-1)
-	- [Import and initialize Fluid dependencies](#import-and-initialize-fluid-dependencies)
-		- [Configure the service client](#configure-the-service-client)
-	- [Get the Fluid `SharedMap`](#get-the-fluid-sharedmap)
-		- [Get the SharedMap on load](#get-the-sharedmap-on-load)
-		- [Sync Fluid and view data](#sync-fluid-and-view-data)
-	- [Update the view](#update-the-view)
-	- [Next steps](#next-steps)
+-   [@fluid-example/react-demo](#fluid-examplereact-demo)
+    -   [Demo introduction](#demo-introduction)
+    -   [Use Create React App](#use-create-react-app)
+        -   [Using NPM](#using-npm)
+        -   [Using Yarn](#using-yarn)
+        -   [Start the app](#start-the-app)
+    -   [Install Fluid package dependencies](#install-fluid-package-dependencies)
+        -   [Using NPM](#using-npm-1)
+        -   [Using Yarn](#using-yarn-1)
+    -   [Import and initialize Fluid dependencies](#import-and-initialize-fluid-dependencies)
+        -   [Configure the service client](#configure-the-service-client)
+    -   [Get the Fluid `SharedMap`](#get-the-fluid-sharedmap)
+        -   [Get the SharedMap on load](#get-the-sharedmap-on-load)
+        -   [Sync Fluid and view data](#sync-fluid-and-view-data)
+    -   [Update the view](#update-the-view)
+    -   [Next steps](#next-steps)
 
 ## Use Create React App
 

--- a/react-demo/README.md
+++ b/react-demo/README.md
@@ -5,7 +5,7 @@ This is an experimental learning tutorial demonstrating the integration of Fluid
 Concepts you will learn:
 
 1. How to integrate Fluid into a React application
-2. How to run and connect your application to a local Fluid service (Tinylicious)
+2. How to run and connect your application to a local Fluid service (`@fluidframework/azure-local-service`)
 3. How to create and get Fluid Containers and collaborative objects
 4. How to use a [SharedMap distributed data structure (DDS)](https://fluidframework.com/docs/data-structures/map/) to sync data between connected clients
 
@@ -15,22 +15,22 @@ Concepts you will learn:
 
 In this example you will do the following:
 
--   [@fluid-example/react-demo](#fluid-examplereact-demo)
-    -   [Demo introduction](#demo-introduction)
-    -   [Use Create React App](#use-create-react-app)
-        -   [Using NPM](#using-npm)
-        -   [Using Yarn](#using-yarn)
-        -   [Start the app](#start-the-app)
-    -   [Install Fluid package dependencies](#install-fluid-package-dependencies)
-        -   [Using NPM](#using-npm-1)
-        -   [Using Yarn](#using-yarn-1)
-    -   [Import and initialize Fluid dependencies](#import-and-initialize-fluid-dependencies)
-        -   [Configure the service client](#configure-the-service-client)
-    -   [Get the Fluid `SharedMap`](#get-the-fluid-sharedmap)
-        -   [Get the SharedMap on load](#get-the-sharedmap-on-load)
-        -   [Sync Fluid and view data](#sync-fluid-and-view-data)
-    -   [Update the view](#update-the-view)
-    -   [Next steps](#next-steps)
+- [@fluid-example/react-demo](#fluid-examplereact-demo)
+	- [Demo introduction](#demo-introduction)
+	- [Use Create React App](#use-create-react-app)
+		- [Using NPM](#using-npm)
+		- [Using Yarn](#using-yarn)
+		- [Start the app](#start-the-app)
+	- [Install Fluid package dependencies](#install-fluid-package-dependencies)
+		- [Using NPM](#using-npm-1)
+		- [Using Yarn](#using-yarn-1)
+	- [Import and initialize Fluid dependencies](#import-and-initialize-fluid-dependencies)
+		- [Configure the service client](#configure-the-service-client)
+	- [Get the Fluid `SharedMap`](#get-the-fluid-sharedmap)
+		- [Get the SharedMap on load](#get-the-sharedmap-on-load)
+		- [Sync Fluid and view data](#sync-fluid-and-view-data)
+	- [Update the view](#update-the-view)
+	- [Next steps](#next-steps)
 
 ## Use Create React App
 
@@ -50,10 +50,10 @@ cd my-app-name
 
 ### Start the app
 
-The `tinylicious` server will be needed to run this demo locally.
+The `@fluidframework/azure-local-service` server will be needed to run this demo locally.
 
 ```bash
-npx tinylicious
+npx @fluidframework/azure-local-service
 ```
 
 Open up a new terminal tab and start up our React app

--- a/react-demo/package-lock.json
+++ b/react-demo/package-lock.json
@@ -15,6 +15,7 @@
 				"react-dom": "^16.10.2"
 			},
 			"devDependencies": {
+				"@fluidframework/azure-local-service": "^1.1.0",
 				"@fluidframework/build-common": "^2.0.0",
 				"@testing-library/jest-dom": "^5.11.4",
 				"@testing-library/react": "^11.1.0",
@@ -25,8 +26,7 @@
 				"prettier": "^2.7.1",
 				"puppeteer": "^21.0.0",
 				"react-scripts": "^5.0.1",
-				"start-server-and-test": "^2.0.0",
-				"tinylicious": "^1.0.0"
+				"start-server-and-test": "^2.0.0"
 			},
 			"engines": {
 				"node": ">=18.0.0"
@@ -2496,6 +2496,436 @@
 				"uuid": "^8.3.1"
 			}
 		},
+		"node_modules/@fluidframework/azure-local-service": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-1.1.1.tgz",
+			"integrity": "sha512-gvk+qy8RytXBQaZ554OREszHGN73W3FmgpfwV+aXeOOP5RWLMPSvkPoac5K9gcUYN+nAFbRs517c055yucP9ug==",
+			"dev": true,
+			"dependencies": {
+				"tinylicious": "^0.4.89251"
+			},
+			"bin": {
+				"azure-local-service": "dist/index.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/common-utils": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@types/events": "^3.0.0",
+				"base64-js": "^1.5.1",
+				"buffer": "^6.0.3",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sha.js": "^2.4.11"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/gitresources": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
+			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-base": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
+			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-definitions": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.4001.tgz",
+			"integrity": "sha512-rERfgXK5DXGJvxADjotkAZssKgp3ZxW6u7yUekrDnFDkXtbCW1Gcq+EwvjHTEyhsOp30YBnD0Z39xnZy4zEZRw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas-driver": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/semver": "^6.0.1",
+				"assert": "^2.0.0",
+				"async": "^3.2.2",
+				"axios": "^0.26.0",
+				"buffer": "^6.0.3",
+				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
+				"json-stringify-safe": "^5.0.1",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"semver": "^6.3.0",
+				"sha.js": "^2.4.11",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas-driver": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.4001.tgz",
+			"integrity": "sha512-qRs+vMbSS9aPx7vr3XemvER5DeY/nsJ5ZkcL3UDjUOxvLZxbOAD6C6JeH3Zgzc/jc8bqshcxai/u7qso2zCsFw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"assert": "^2.0.0",
+				"async": "^3.2.2",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-local-server": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.4001.tgz",
+			"integrity": "sha512-FIlNUc9Ncul/5qzP+VyU53TJj8fxX7KZ1lweswZYalleRZwiqFA4Y+NbWRRWM0iJ1z8hvhyRZblG3iNrpGl04A==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^0.1038.4001",
+				"@fluidframework/server-memory-orderer": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@fluidframework/server-test-utils": "^0.1038.4001",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"jsrsasign": "^10.5.25",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-memory-orderer": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.4001.tgz",
+			"integrity": "sha512-fdzTCLFRh8QfyY17MnB22/o8x2XEX1+wZrm+dn+1Av+ZVe/+ZhfdX5LsQCMKYv+X5mgAauNmC/12mQE4H6jvsQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/debug": "^4.1.5",
+				"@types/double-ended-queue": "^2.1.0",
+				"@types/lodash": "^4.14.118",
+				"@types/node": "^14.18.0",
+				"@types/ws": "^6.0.1",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1",
+				"ws": "^7.4.6"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-client": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
+			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"axios": "^0.26.0",
+				"crc-32": "1.2.0",
+				"debug": "^4.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"jsrsasign": "^10.5.25",
+				"jwt-decode": "^3.0.0",
+				"querystring": "^0.2.0",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-core": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.4001.tgz",
+			"integrity": "sha512-nuZ9ebvyeIoRdlpQQpBNGkawKtc2/tHKbc8CHbMZRMh7F7kwYUtoHd/J8powb9eUcg5IHDmXx1l+PQRbQX4vCg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/nconf": "^0.10.2",
+				"@types/node": "^14.18.0",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"nconf": "^0.12.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-shared": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.4001.tgz",
+			"integrity": "sha512-vDRB2G/Xnuhan+Ri0Eg5JMKfsm7hxstCXdEyQhzJzC7+bw66wts+ZIsEsn4Ha/3KkxblF/RSW3lBhrYpxii3cQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@socket.io/redis-adapter": "^7.2.0",
+				"body-parser": "^1.17.1",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"ioredis": "^4.24.2",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"notepack.io": "^2.3.0",
+				"querystring": "^0.2.0",
+				"socket.io": "^4.5.3",
+				"socket.io-adapter": "^2.4.0",
+				"socket.io-parser": "^4.2.1",
+				"uuid": "^8.3.1",
+				"winston": "^3.6.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-telemetry": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.4001.tgz",
+			"integrity": "sha512-2leJhB04+71RTmC5ShRXm/4FWng9tLn9dlrUAjApZH4RlUJAx1JGsvo/5JU1tIbpUutMHUle2IpWyfu/RV+S5g==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"path-browserify": "^1.0.1",
+				"serialize-error": "^8.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-utils": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.4001.tgz",
+			"integrity": "sha512-K7X/0mlonDAu0pPIgTz8U9nLwRSbJY2oBpFPwpkp1UtE6SU02jx2ZzraT9epDmOl3EXeS1rHzA+mbvBSe1aFMg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"debug": "^4.1.1",
+				"express": "^4.17.3",
+				"ioredis": "^4.24.2",
+				"json-stringify-safe": "^5.0.1",
+				"jsonwebtoken": "^9.0.0",
+				"morgan": "^1.8.1",
+				"nconf": "^0.12.0",
+				"serialize-error": "^8.1.0",
+				"sillyname": "^0.1.0",
+				"split": "^1.0.0",
+				"uuid": "^8.3.1",
+				"winston": "^3.6.0",
+				"winston-transport": "^4.5.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-test-utils": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.4001.tgz",
+			"integrity": "sha512-qrLp5H1UUPIJSEHlzZ1iYlPFJCQrd2WnmoafxnQIg0mfU1ZE8XUlG5MKUg8bT9pWsCoEGJDiOkkRHaq+WXupjQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"string-hash": "^1.1.3",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@types/node": {
+			"version": "14.18.63",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@types/semver": {
+			"version": "6.2.5",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.5.tgz",
+			"integrity": "sha512-NAxro9/RqWXTqdSjccDZAjA4nXK+6zRun+HvibYJfGy8TQhpOC7Vv6v2rlHYKrT0Q8jGGoNRd/xVdHRIQRNlFQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/denque": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/ioredis": {
+			"version": "4.28.5",
+			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
+			"integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+			"dev": true,
+			"dependencies": {
+				"cluster-key-slot": "^1.1.0",
+				"debug": "^4.3.1",
+				"denque": "^1.1.0",
+				"lodash.defaults": "^4.2.0",
+				"lodash.flatten": "^4.4.0",
+				"lodash.isarguments": "^3.1.0",
+				"p-map": "^2.1.0",
+				"redis-commands": "1.7.0",
+				"redis-errors": "^1.2.0",
+				"redis-parser": "^3.0.0",
+				"standard-as-callback": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ioredis"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/split": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"dev": true,
+			"dependencies": {
+				"through": "2"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/tinylicious": {
+			"version": "0.4.94771",
+			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
+			"integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.0.0",
+				"@fluidframework/gitresources": "^0.1038.1000",
+				"@fluidframework/protocol-base": "^0.1038.1000",
+				"@fluidframework/protocol-definitions": "^1.0.0",
+				"@fluidframework/server-lambdas": "^0.1038.1000",
+				"@fluidframework/server-local-server": "^0.1038.1000",
+				"@fluidframework/server-memory-orderer": "^0.1038.1000",
+				"@fluidframework/server-services-client": "^0.1038.1000",
+				"@fluidframework/server-services-core": "^0.1038.1000",
+				"@fluidframework/server-services-shared": "^0.1038.1000",
+				"@fluidframework/server-services-telemetry": "^0.1038.1000",
+				"@fluidframework/server-services-utils": "^0.1038.1000",
+				"@fluidframework/server-test-utils": "^0.1038.1000",
+				"agentkeepalive": "^4.2.1",
+				"axios": "^0.26.0",
+				"body-parser": "^1.17.1",
+				"charwise": "^3.0.1",
+				"compression": "^1.7.2",
+				"cookie-parser": "^1.4.3",
+				"cors": "^2.8.4",
+				"detect-port": "^1.3.0",
+				"express": "^4.16.3",
+				"isomorphic-git": "^1.8.2",
+				"json-stringify-safe": "^5.0.1",
+				"level": "^8.0.0",
+				"level-sublevel": "6.6.4",
+				"lodash": "^4.17.21",
+				"morgan": "^1.8.1",
+				"nconf": "^0.12.0",
+				"socket.io": "^4.5.0",
+				"split": "^1.0.0",
+				"uuid": "^8.3.2",
+				"winston": "^3.6.0"
+			},
+			"bin": {
+				"tinylicious": "dist/index.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/ws": {
+			"version": "7.5.9",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.3.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@fluidframework/build-common": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.0.tgz",
@@ -2887,486 +3317,6 @@
 				"uuid": "^8.3.1"
 			}
 		},
-		"node_modules/@fluidframework/server-lambdas": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-1.0.1.tgz",
-			"integrity": "sha512-lwVKg4dVDvbNH4ckj328z5cNu1plHhArzIMP3kpl8T94L6OubqsJ8vf3g46Wab/SjwltHC41p/wWigJapXZjqA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas-driver": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/semver": "^7.5.0",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"axios": "^0.26.0",
-				"buffer": "^6.0.3",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"semver": "^7.5.3",
-				"sha.js": "^2.4.11",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-1.0.1.tgz",
-			"integrity": "sha512-TfQ7rz2/6pW6Rq5CbGBu9ShiSKyOHg2pXX0cUVHtnuuUPsWTxQDWlVilYukyG0uxHJfE3ZDU3R1QgnWUQQmGgg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-1.0.1.tgz",
-			"integrity": "sha512-494H0PYNa6aqngyq/M46K7wlY7NHdIx1B4qcfRCRQmjJZrD9GPza3FHt2/426teBQ93F6SOKkBrMw2vbmoUUGg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.1",
-				"@fluidframework/server-memory-orderer": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@fluidframework/server-test-utils": "^1.0.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"jsrsasign": "^10.5.25",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-1.0.1.tgz",
-			"integrity": "sha512-zUuNICwyKC7OTSl/W9MSiwplSccnRHVmRpdxImCe5qVs+VSK1jHuIGiIzCkt6dlVNMu3WHyUXmrKCLmhJZmFeQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/debug": "^4.1.5",
-				"@types/double-ended-queue": "^2.1.0",
-				"@types/lodash": "^4.14.118",
-				"@types/node": "^16.18.16",
-				"@types/ws": "^6.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1",
-				"ws": "^7.4.6"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/ws": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@fluidframework/server-services-client": {
 			"version": "0.1036.5001",
 			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5001.tgz",
@@ -3385,512 +3335,6 @@
 				"querystring": "^0.2.0",
 				"sillyname": "^0.1.0",
 				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-1.0.1.tgz",
-			"integrity": "sha512-/Lb5ZZxb4aHtzLH3p+lrboi6TW/WD0I53di8FI4rMmn5AM7+h69BolPW7nume52t3HUi1I2Mnqhx1W8FKV8BbA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/nconf": "^0.10.2",
-				"@types/node": "^16.18.16",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"nconf": "^0.12.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-1.0.1.tgz",
-			"integrity": "sha512-Z+IyqWHUk/y0aZ5cUXUoehcOiIr4qw1VkDR5i+1rnLntCRkPKk7h6FFXcWo+OBmI7D3AJOKZagMr6npezIPEmQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@socket.io/redis-adapter": "^7.2.0",
-				"body-parser": "^1.17.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"ioredis": "^5.2.3",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"notepack.io": "^2.3.0",
-				"querystring": "^0.2.0",
-				"serialize-error": "^8.1.0",
-				"socket.io": "^4.5.3",
-				"socket.io-adapter": "^2.4.0",
-				"socket.io-parser": "^4.2.1",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-telemetry": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-1.0.1.tgz",
-			"integrity": "sha512-qeNtIr5mnkDS5hwD9t+2kcmsRK4zxdAtR+F0j0/rZ/pBWuaVmJI6YiKC5HzWTuszW5F1VDpGnul0M8HEWyhrgQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"path-browserify": "^1.0.1",
-				"serialize-error": "^8.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-telemetry/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-telemetry/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-1.0.1.tgz",
-			"integrity": "sha512-MzoonbJ/EQMbPi+m7/TZxWqyYzs1wxOdtN/Fe4FkaKOcHJjXR1e33iBw3YTkMQR9W8Z8E3WfSe6UVmzNDNH1TQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"debug": "^4.1.1",
-				"express": "^4.17.3",
-				"ioredis": "^5.2.3",
-				"json-stringify-safe": "^5.0.1",
-				"jsonwebtoken": "^9.0.0",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0",
-				"sillyname": "^0.1.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0",
-				"winston-transport": "^4.5.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-1.0.1.tgz",
-			"integrity": "sha512-+2ZP2pU4eq3KY5EySJhcwyAZqy9WojPhirA+fNUPKblT0fmeAn2ks6mF3d98fcxwqjMPb+5UPLRWDf7/+i1/Aw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"string-hash": "^1.1.3",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
 			}
 		},
 		"node_modules/@fluidframework/shared-object-base": {
@@ -4022,12 +3466,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-			"dev": true
-		},
-		"node_modules/@ioredis/commands": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-			"integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
 			"dev": true
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
@@ -8818,15 +8256,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/denque": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-			"integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
 		"node_modules/depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -8869,6 +8298,20 @@
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
+		},
+		"node_modules/detect-port": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
+			"integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
+			"dev": true,
+			"dependencies": {
+				"address": "^1.0.1",
+				"debug": "4"
+			},
+			"bin": {
+				"detect": "bin/detect-port.js",
+				"detect-port": "bin/detect-port.js"
+			}
 		},
 		"node_modules/detect-port-alt": {
 			"version": "1.1.6",
@@ -12021,30 +11464,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/ioredis": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
-			"integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
-			"dev": true,
-			"dependencies": {
-				"@ioredis/commands": "^1.1.1",
-				"cluster-key-slot": "^1.1.0",
-				"debug": "^4.3.4",
-				"denque": "^2.1.0",
-				"lodash.defaults": "^4.2.0",
-				"lodash.isarguments": "^3.1.0",
-				"redis-errors": "^1.2.0",
-				"redis-parser": "^3.0.0",
-				"standard-as-callback": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=12.22.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ioredis"
 			}
 		},
 		"node_modules/ip": {
@@ -16148,6 +15567,12 @@
 			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
 			"dev": true
 		},
+		"node_modules/lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+			"dev": true
+		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -17238,6 +16663,15 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/p-map": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/p-retry": {
@@ -21042,6 +20476,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/redis-commands": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
+			"dev": true
+		},
 		"node_modules/redis-errors": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
@@ -23224,166 +22664,6 @@
 			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
 			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
 			"dev": true
-		},
-		"node_modules/tinylicious": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-1.0.0.tgz",
-			"integrity": "sha512-ACL8mEKT5LPbFyAXCDjYWqi3vcNef7y2ABMnU3O4jK1cRuEn0MywH7ppMM5ZrMgtSMMsJAINcWxZjpq3ndH8hg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.0",
-				"@fluidframework/protocol-base": "^1.0.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.0",
-				"@fluidframework/server-local-server": "^1.0.0",
-				"@fluidframework/server-memory-orderer": "^1.0.0",
-				"@fluidframework/server-services-client": "^1.0.0",
-				"@fluidframework/server-services-core": "^1.0.0",
-				"@fluidframework/server-services-shared": "^1.0.0",
-				"@fluidframework/server-services-telemetry": "^1.0.0",
-				"@fluidframework/server-services-utils": "^1.0.0",
-				"@fluidframework/server-test-utils": "^1.0.0",
-				"agentkeepalive": "^4.2.1",
-				"axios": "^0.26.0",
-				"body-parser": "^1.17.1",
-				"charwise": "^3.0.1",
-				"compression": "^1.7.2",
-				"cookie-parser": "^1.4.3",
-				"cors": "^2.8.4",
-				"detect-port": "^1.3.0",
-				"express": "^4.17.3",
-				"isomorphic-git": "^1.8.2",
-				"json-stringify-safe": "^5.0.1",
-				"level": "^8.0.0",
-				"level-sublevel": "6.6.4",
-				"lodash": "^4.17.21",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"socket.io": "^4.5.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.2",
-				"winston": "^3.6.0"
-			},
-			"bin": {
-				"tinylicious": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/tinylicious/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/tinylicious/node_modules/detect-port": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
-			"integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
-			"dev": true,
-			"dependencies": {
-				"address": "^1.0.1",
-				"debug": "4"
-			},
-			"bin": {
-				"detect": "bin/detect-port.js",
-				"detect-port": "bin/detect-port.js"
-			}
-		},
-		"node_modules/tinylicious/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
 		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",

--- a/react-demo/package-lock.json
+++ b/react-demo/package-lock.json
@@ -15,7 +15,6 @@
 				"react-dom": "^16.10.2"
 			},
 			"devDependencies": {
-				"@fluidframework/azure-local-service": "^1.1.0",
 				"@fluidframework/build-common": "^2.0.0",
 				"@testing-library/jest-dom": "^5.11.4",
 				"@testing-library/react": "^11.1.0",
@@ -2066,15 +2065,6 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
 		},
-		"node_modules/@colors/colors": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.1.90"
-			}
-		},
 		"node_modules/@csstools/normalize.css": {
 			"version": "12.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
@@ -2361,17 +2351,6 @@
 				"postcss-selector-parser": "^6.0.10"
 			}
 		},
-		"node_modules/@dabh/diagnostics": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-			"integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
-			"dev": true,
-			"dependencies": {
-				"colorspace": "1.1.x",
-				"enabled": "2.0.x",
-				"kuler": "^2.0.0"
-			}
-		},
 		"node_modules/@eslint-community/eslint-utils": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -2494,436 +2473,6 @@
 				"@fluidframework/synthesize": "^1.3.7",
 				"@fluidframework/view-interfaces": "^1.3.7",
 				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-1.1.1.tgz",
-			"integrity": "sha512-gvk+qy8RytXBQaZ554OREszHGN73W3FmgpfwV+aXeOOP5RWLMPSvkPoac5K9gcUYN+nAFbRs517c055yucP9ug==",
-			"dev": true,
-			"dependencies": {
-				"tinylicious": "^0.4.89251"
-			},
-			"bin": {
-				"azure-local-service": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
-			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
-			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.4001.tgz",
-			"integrity": "sha512-rERfgXK5DXGJvxADjotkAZssKgp3ZxW6u7yUekrDnFDkXtbCW1Gcq+EwvjHTEyhsOp30YBnD0Z39xnZy4zEZRw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas-driver": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/semver": "^6.0.1",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"axios": "^0.26.0",
-				"buffer": "^6.0.3",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"semver": "^6.3.0",
-				"sha.js": "^2.4.11",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas-driver": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.4001.tgz",
-			"integrity": "sha512-qRs+vMbSS9aPx7vr3XemvER5DeY/nsJ5ZkcL3UDjUOxvLZxbOAD6C6JeH3Zgzc/jc8bqshcxai/u7qso2zCsFw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-local-server": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.4001.tgz",
-			"integrity": "sha512-FIlNUc9Ncul/5qzP+VyU53TJj8fxX7KZ1lweswZYalleRZwiqFA4Y+NbWRRWM0iJ1z8hvhyRZblG3iNrpGl04A==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.4001",
-				"@fluidframework/server-memory-orderer": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@fluidframework/server-test-utils": "^0.1038.4001",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"jsrsasign": "^10.5.25",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-memory-orderer": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.4001.tgz",
-			"integrity": "sha512-fdzTCLFRh8QfyY17MnB22/o8x2XEX1+wZrm+dn+1Av+ZVe/+ZhfdX5LsQCMKYv+X5mgAauNmC/12mQE4H6jvsQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/debug": "^4.1.5",
-				"@types/double-ended-queue": "^2.1.0",
-				"@types/lodash": "^4.14.118",
-				"@types/node": "^14.18.0",
-				"@types/ws": "^6.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1",
-				"ws": "^7.4.6"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
-			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-core": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.4001.tgz",
-			"integrity": "sha512-nuZ9ebvyeIoRdlpQQpBNGkawKtc2/tHKbc8CHbMZRMh7F7kwYUtoHd/J8powb9eUcg5IHDmXx1l+PQRbQX4vCg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/nconf": "^0.10.2",
-				"@types/node": "^14.18.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"nconf": "^0.12.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-shared": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.4001.tgz",
-			"integrity": "sha512-vDRB2G/Xnuhan+Ri0Eg5JMKfsm7hxstCXdEyQhzJzC7+bw66wts+ZIsEsn4Ha/3KkxblF/RSW3lBhrYpxii3cQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@socket.io/redis-adapter": "^7.2.0",
-				"body-parser": "^1.17.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"ioredis": "^4.24.2",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"notepack.io": "^2.3.0",
-				"querystring": "^0.2.0",
-				"socket.io": "^4.5.3",
-				"socket.io-adapter": "^2.4.0",
-				"socket.io-parser": "^4.2.1",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-telemetry": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.4001.tgz",
-			"integrity": "sha512-2leJhB04+71RTmC5ShRXm/4FWng9tLn9dlrUAjApZH4RlUJAx1JGsvo/5JU1tIbpUutMHUle2IpWyfu/RV+S5g==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"path-browserify": "^1.0.1",
-				"serialize-error": "^8.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-utils": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.4001.tgz",
-			"integrity": "sha512-K7X/0mlonDAu0pPIgTz8U9nLwRSbJY2oBpFPwpkp1UtE6SU02jx2ZzraT9epDmOl3EXeS1rHzA+mbvBSe1aFMg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"debug": "^4.1.1",
-				"express": "^4.17.3",
-				"ioredis": "^4.24.2",
-				"json-stringify-safe": "^5.0.1",
-				"jsonwebtoken": "^9.0.0",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0",
-				"sillyname": "^0.1.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0",
-				"winston-transport": "^4.5.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-test-utils": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.4001.tgz",
-			"integrity": "sha512-qrLp5H1UUPIJSEHlzZ1iYlPFJCQrd2WnmoafxnQIg0mfU1ZE8XUlG5MKUg8bT9pWsCoEGJDiOkkRHaq+WXupjQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"string-hash": "^1.1.3",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@types/node": {
-			"version": "14.18.63",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@types/semver": {
-			"version": "6.2.5",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.5.tgz",
-			"integrity": "sha512-NAxro9/RqWXTqdSjccDZAjA4nXK+6zRun+HvibYJfGy8TQhpOC7Vv6v2rlHYKrT0Q8jGGoNRd/xVdHRIQRNlFQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/denque": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/ioredis": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
-			"integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
-			"dev": true,
-			"dependencies": {
-				"cluster-key-slot": "^1.1.0",
-				"debug": "^4.3.1",
-				"denque": "^1.1.0",
-				"lodash.defaults": "^4.2.0",
-				"lodash.flatten": "^4.4.0",
-				"lodash.isarguments": "^3.1.0",
-				"p-map": "^2.1.0",
-				"redis-commands": "1.7.0",
-				"redis-errors": "^1.2.0",
-				"redis-parser": "^3.0.0",
-				"standard-as-callback": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ioredis"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/tinylicious": {
-			"version": "0.4.94771",
-			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
-			"integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.1000",
-				"@fluidframework/protocol-base": "^0.1038.1000",
-				"@fluidframework/protocol-definitions": "^1.0.0",
-				"@fluidframework/server-lambdas": "^0.1038.1000",
-				"@fluidframework/server-local-server": "^0.1038.1000",
-				"@fluidframework/server-memory-orderer": "^0.1038.1000",
-				"@fluidframework/server-services-client": "^0.1038.1000",
-				"@fluidframework/server-services-core": "^0.1038.1000",
-				"@fluidframework/server-services-shared": "^0.1038.1000",
-				"@fluidframework/server-services-telemetry": "^0.1038.1000",
-				"@fluidframework/server-services-utils": "^0.1038.1000",
-				"@fluidframework/server-test-utils": "^0.1038.1000",
-				"agentkeepalive": "^4.2.1",
-				"axios": "^0.26.0",
-				"body-parser": "^1.17.1",
-				"charwise": "^3.0.1",
-				"compression": "^1.7.2",
-				"cookie-parser": "^1.4.3",
-				"cors": "^2.8.4",
-				"detect-port": "^1.3.0",
-				"express": "^4.16.3",
-				"isomorphic-git": "^1.8.2",
-				"json-stringify-safe": "^5.0.1",
-				"level": "^8.0.0",
-				"level-sublevel": "6.6.4",
-				"lodash": "^4.17.21",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"socket.io": "^4.5.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.2",
-				"winston": "^3.6.0"
-			},
-			"bin": {
-				"tinylicious": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/ws": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@fluidframework/build-common": {
@@ -4284,27 +3833,6 @@
 			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
 			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
 		},
-		"node_modules/@socket.io/redis-adapter": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-7.2.0.tgz",
-			"integrity": "sha512-/r6oF6Myz0K9uatB/pfCi0BhKg/KRMh1OokrqcjlNz6aq40WiXdFLRbHJQuwGHq/KvB+D6141K+IynbVxZGvhw==",
-			"dev": true,
-			"dependencies": {
-				"debug": "~4.3.1",
-				"notepack.io": "~2.2.0",
-				"socket.io-adapter": "^2.4.0",
-				"uid2": "0.0.3"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/@socket.io/redis-adapter/node_modules/notepack.io": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.2.0.tgz",
-			"integrity": "sha512-9b5w3t5VSH6ZPosoYnyDONnUTF8o0UkBw7JLA6eBlYJWyGT1Q3vQa8Hmuj1/X6RYvHjjygBDgw6fJhe0JEojfw==",
-			"dev": true
-		},
 		"node_modules/@surma/rollup-plugin-off-main-thread": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -4808,36 +4336,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/cookie": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-			"integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-			"dev": true
-		},
-		"node_modules/@types/cors": {
-			"version": "2.8.14",
-			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.14.tgz",
-			"integrity": "sha512-RXHUvNWYICtbP6s18PnOCaqToK8y14DnLd75c6HfyKf228dxy7pHNOQkxPtvXKp/hINFMDjbYzsj63nnpPMSRQ==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@types/debug": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
-			"integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
-			"dev": true,
-			"dependencies": {
-				"@types/ms": "*"
-			}
-		},
-		"node_modules/@types/double-ended-queue": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@types/double-ended-queue/-/double-ended-queue-2.1.3.tgz",
-			"integrity": "sha512-PWBSlai2jeSM3xOlr4JPI0oDiGFLVkVvylJ1nK1+oK9V/RiBIqDy8vCtsk+gOQN/I1gU6O1cR1OHheBanFdbCQ==",
-			"dev": true
-		},
 		"node_modules/@types/eslint": {
 			"version": "8.44.2",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.2.tgz",
@@ -4969,28 +4467,10 @@
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
 		},
-		"node_modules/@types/lodash": {
-			"version": "4.14.198",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.198.tgz",
-			"integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg==",
-			"dev": true
-		},
 		"node_modules/@types/mime": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
 			"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-			"dev": true
-		},
-		"node_modules/@types/ms": {
-			"version": "0.7.31",
-			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
-			"dev": true
-		},
-		"node_modules/@types/nconf": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.3.tgz",
-			"integrity": "sha512-leyIuBk/rMIp9114FlPRkc/cQG+/JzCz1Afx3BD+CwK2ep3ZRxoC843V1rqnE2pC/jRRjANWhuVBEn4clCwlug==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -5104,26 +4584,11 @@
 				"@types/jest": "*"
 			}
 		},
-		"node_modules/@types/triple-beam": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.3.tgz",
-			"integrity": "sha512-6tOUG+nVHn0cJbVp25JFayS5UE6+xlbcNF9Lo9mU7U0zk3zeUShZied4YEQZjy1JBF043FSkdXw8YkUJuVtB5g==",
-			"dev": true
-		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.4.tgz",
 			"integrity": "sha512-IDaobHimLQhjwsQ/NMwRVfa/yL7L/wriQPMhw1ZJall0KX6E1oxk29XMDeilW5qTIg5aoiqf5Udy8U/51aNoQQ==",
 			"dev": true
-		},
-		"node_modules/@types/ws": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
-			"integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
 		},
 		"node_modules/@types/yargs": {
 			"version": "17.0.13",
@@ -5599,71 +5064,6 @@
 				"node": ">=6.5"
 			}
 		},
-		"node_modules/abstract-level": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
-			"integrity": "sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^6.0.3",
-				"catering": "^2.1.0",
-				"is-buffer": "^2.0.5",
-				"level-supports": "^4.0.0",
-				"level-transcoder": "^1.0.1",
-				"module-error": "^1.0.1",
-				"queue-microtask": "^1.2.3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/abstract-level/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/abstract-level/node_modules/is-buffer": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -5770,29 +5170,6 @@
 			},
 			"engines": {
 				"node": ">= 14"
-			}
-		},
-		"node_modules/agentkeepalive": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
-			"integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
-			"dev": true,
-			"dependencies": {
-				"debug": "^4.1.0",
-				"depd": "^1.1.2",
-				"humanize-ms": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 8.0.0"
-			}
-		},
-		"node_modules/agentkeepalive/node_modules/depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/ajv": {
@@ -6114,19 +5491,6 @@
 			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
 			"dev": true
 		},
-		"node_modules/assert": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
-			"integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"is-nan": "^1.3.2",
-				"object-is": "^1.1.5",
-				"object.assign": "^4.1.4",
-				"util": "^0.12.5"
-			}
-		},
 		"node_modules/ast-types": {
 			"version": "0.13.4",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -6149,12 +5513,6 @@
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
 			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-			"dev": true
-		},
-		"node_modules/async-lock": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz",
-			"integrity": "sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ==",
 			"dev": true
 		},
 		"node_modules/asynciterator.prototype": {
@@ -6524,33 +5882,6 @@
 				}
 			]
 		},
-		"node_modules/base64id": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-			"integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-			"dev": true,
-			"engines": {
-				"node": "^4.5.0 || >= 5.9"
-			}
-		},
-		"node_modules/basic-auth": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-			"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "5.1.2"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/basic-auth/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
 		"node_modules/basic-ftp": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
@@ -6605,66 +5936,6 @@
 			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
 			"dev": true
 		},
-		"node_modules/body-parser": {
-			"version": "1.20.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-			"integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
-			"dev": true,
-			"dependencies": {
-				"bytes": "3.1.2",
-				"content-type": "~1.0.5",
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"destroy": "1.2.0",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"on-finished": "2.4.1",
-				"qs": "6.11.0",
-				"raw-body": "2.5.2",
-				"type-is": "~1.6.18",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8",
-				"npm": "1.2.8000 || >= 1.4.16"
-			}
-		},
-		"node_modules/body-parser/node_modules/bytes": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/body-parser/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/body-parser/node_modules/iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/body-parser/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true
-		},
 		"node_modules/bonjour-service": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.1.tgz",
@@ -6709,18 +5980,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/browser-level": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
-			"integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
-			"dev": true,
-			"dependencies": {
-				"abstract-level": "^1.0.2",
-				"catering": "^2.1.1",
-				"module-error": "^1.0.2",
-				"run-parallel-limit": "^1.1.0"
 			}
 		},
 		"node_modules/browser-process-hrtime": {
@@ -6803,12 +6062,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/buffer-equal-constant-time": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-			"dev": true
-		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -6834,25 +6087,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/bytewise": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-			"integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
-			"dev": true,
-			"dependencies": {
-				"bytewise-core": "^1.2.2",
-				"typewise": "^1.0.3"
-			}
-		},
-		"node_modules/bytewise-core": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-			"integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
-			"dev": true,
-			"dependencies": {
-				"typewise-core": "^1.2"
 			}
 		},
 		"node_modules/call-bind": {
@@ -6945,15 +6179,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/catering": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
-			"integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/chalk": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -6975,12 +6200,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/charwise": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz",
-			"integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw==",
-			"dev": true
 		},
 		"node_modules/check-more-types": {
 			"version": "2.24.0",
@@ -7069,23 +6288,6 @@
 			"integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
 			"dev": true
 		},
-		"node_modules/classic-level": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.2.0.tgz",
-			"integrity": "sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"dependencies": {
-				"abstract-level": "^1.0.2",
-				"catering": "^2.1.0",
-				"module-error": "^1.0.1",
-				"napi-macros": "~2.0.0",
-				"node-gyp-build": "^4.3.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/clean-css": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
@@ -7097,12 +6299,6 @@
 			"engines": {
 				"node": ">= 10.0"
 			}
-		},
-		"node_modules/clean-git-ref": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
-			"integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
-			"dev": true
 		},
 		"node_modules/cliui": {
 			"version": "8.0.1",
@@ -7116,15 +6312,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/cluster-key-slot": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
-			"integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/co": {
@@ -7219,16 +6406,6 @@
 			"integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
 			"dev": true
 		},
-		"node_modules/color": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^1.9.3",
-				"color-string": "^1.6.0"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7247,31 +6424,6 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
-		"node_modules/color-string": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
-		},
-		"node_modules/color/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/color/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
-		},
 		"node_modules/colord": {
 			"version": "2.9.3",
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
@@ -7283,16 +6435,6 @@
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
 			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
 			"dev": true
-		},
-		"node_modules/colorspace": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-			"integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-			"dev": true,
-			"dependencies": {
-				"color": "^3.1.3",
-				"text-hex": "1.0.x"
-			}
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
@@ -7444,28 +6586,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/cookie-parser": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-			"integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
-			"dev": true,
-			"dependencies": {
-				"cookie": "0.4.1",
-				"cookie-signature": "1.0.6"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/cookie-parser/node_modules/cookie": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-			"integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/cookie-signature": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -7512,19 +6632,6 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"dev": true
-		},
-		"node_modules/cors": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-			"dev": true,
-			"dependencies": {
-				"object-assign": "^4",
-				"vary": "^1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
 		},
 		"node_modules/cosmiconfig": {
 			"version": "7.0.1",
@@ -8119,21 +7226,6 @@
 			"integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
 			"dev": true
 		},
-		"node_modules/decompress-response": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-			"dev": true,
-			"dependencies": {
-				"mimic-response": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -8299,20 +7391,6 @@
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
 		},
-		"node_modules/detect-port": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
-			"integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
-			"dev": true,
-			"dependencies": {
-				"address": "^1.0.1",
-				"debug": "4"
-			},
-			"bin": {
-				"detect": "bin/detect-port.js",
-				"detect-port": "bin/detect-port.js"
-			}
-		},
 		"node_modules/detect-port-alt": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
@@ -8365,12 +7443,6 @@
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
-		},
-		"node_modules/diff3": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
-			"dev": true
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
@@ -8557,15 +7629,6 @@
 			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
 			"dev": true
 		},
-		"node_modules/ecdsa-sig-formatter": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"node_modules/ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -8620,12 +7683,6 @@
 				"node": ">= 4"
 			}
 		},
-		"node_modules/enabled": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
-			"dev": true
-		},
 		"node_modules/encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -8642,27 +7699,6 @@
 			"dev": true,
 			"dependencies": {
 				"once": "^1.4.0"
-			}
-		},
-		"node_modules/engine.io": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.2.tgz",
-			"integrity": "sha512-IXsMcGpw/xRfjra46sVZVHiSWo/nJ/3g1337q9KNXtS6YRzbW5yIzTCb9DjhrBe7r3GZQR0I4+nq+4ODk5g/cA==",
-			"dev": true,
-			"dependencies": {
-				"@types/cookie": "^0.4.1",
-				"@types/cors": "^2.8.12",
-				"@types/node": ">=10.0.0",
-				"accepts": "~1.3.4",
-				"base64id": "2.0.0",
-				"cookie": "~0.4.1",
-				"cors": "~2.8.5",
-				"debug": "~4.3.1",
-				"engine.io-parser": "~5.2.1",
-				"ws": "~8.11.0"
-			},
-			"engines": {
-				"node": ">=10.2.0"
 			}
 		},
 		"node_modules/engine.io-client": {
@@ -8705,36 +7741,6 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/engine.io/node_modules/cookie": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/engine.io/node_modules/ws": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.15.0",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
@@ -8755,18 +7761,6 @@
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/errno": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
-			"integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-			"dev": true,
-			"dependencies": {
-				"prr": "~1.0.1"
-			},
-			"bin": {
-				"errno": "cli.js"
 			}
 		},
 		"node_modules/error-ex": {
@@ -10053,12 +9047,6 @@
 				"pend": "~1.2.0"
 			}
 		},
-		"node_modules/fecha": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
-			"dev": true
-		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -10292,12 +9280,6 @@
 				"@fluidframework/map": "^1.3.7",
 				"@fluidframework/sequence": "^1.3.7"
 			}
-		},
-		"node_modules/fn.name": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-			"dev": true
 		},
 		"node_modules/follow-redirects": {
 			"version": "1.15.2",
@@ -11280,15 +10262,6 @@
 				"node": ">=10.17.0"
 			}
 		},
-		"node_modules/humanize-ms": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "^2.0.0"
-			}
-		},
 		"node_modules/iconv-lite": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -11707,22 +10680,6 @@
 			"integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
 			"dev": true
 		},
-		"node_modules/is-nan": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-negative-zero": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
@@ -11979,31 +10936,6 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
-		},
-		"node_modules/isomorphic-git": {
-			"version": "1.21.0",
-			"resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.21.0.tgz",
-			"integrity": "sha512-ZqCAUM63CYepA3fB8H7NVyPSiOkgzIbQ7T+QPrm9xtYgQypN9JUJ5uLMjB5iTfomdJf3mdm6aSxjZwnT6ubvEA==",
-			"dev": true,
-			"dependencies": {
-				"async-lock": "^1.1.0",
-				"clean-git-ref": "^2.0.1",
-				"crc-32": "^1.2.0",
-				"diff3": "0.0.3",
-				"ignore": "^5.1.4",
-				"minimisted": "^2.0.0",
-				"pako": "^1.0.10",
-				"pify": "^4.0.1",
-				"readable-stream": "^3.4.0",
-				"sha.js": "^2.4.9",
-				"simple-get": "^4.0.1"
-			},
-			"bin": {
-				"isogit": "cli.cjs"
-			},
-			"engines": {
-				"node": ">=12"
-			}
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.0",
@@ -15152,43 +14084,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/jsonwebtoken": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-			"integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-			"dev": true,
-			"dependencies": {
-				"jws": "^3.2.2",
-				"lodash.includes": "^4.3.0",
-				"lodash.isboolean": "^3.0.3",
-				"lodash.isinteger": "^4.0.4",
-				"lodash.isnumber": "^3.0.3",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.isstring": "^4.0.1",
-				"lodash.once": "^4.0.0",
-				"ms": "^2.1.1",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": ">=12",
-				"npm": ">=6"
-			}
-		},
-		"node_modules/jsonwebtoken/node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/jsrsasign": {
 			"version": "10.8.6",
 			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.8.6.tgz",
@@ -15210,27 +14105,6 @@
 			},
 			"engines": {
 				"node": ">=4.0"
-			}
-		},
-		"node_modules/jwa": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-			"dev": true,
-			"dependencies": {
-				"buffer-equal-constant-time": "1.0.1",
-				"ecdsa-sig-formatter": "1.0.11",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"node_modules/jws": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-			"dev": true,
-			"dependencies": {
-				"jwa": "^1.4.1",
-				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/jwt-decode": {
@@ -15274,12 +14148,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/kuler": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-			"dev": true
-		},
 		"node_modules/language-subtag-registry": {
 			"version": "0.3.22",
 			"resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
@@ -15312,170 +14180,6 @@
 			"dev": true,
 			"engines": {
 				"node": "> 0.8"
-			}
-		},
-		"node_modules/level": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/level/-/level-8.0.0.tgz",
-			"integrity": "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==",
-			"dev": true,
-			"dependencies": {
-				"browser-level": "^1.0.1",
-				"classic-level": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/level"
-			}
-		},
-		"node_modules/level-codec": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
-			"integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^5.6.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/level-errors": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-			"integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-			"dev": true,
-			"dependencies": {
-				"errno": "~0.1.1"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/level-iterator-stream": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
-			"integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.5",
-				"xtend": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/level-iterator-stream/node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true
-		},
-		"node_modules/level-iterator-stream/node_modules/readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/level-iterator-stream/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"node_modules/level-iterator-stream/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"node_modules/level-post": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
-			"integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
-			"dev": true,
-			"dependencies": {
-				"ltgt": "^2.1.2"
-			}
-		},
-		"node_modules/level-sublevel": {
-			"version": "6.6.4",
-			"resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.4.tgz",
-			"integrity": "sha512-pcCrTUOiO48+Kp6F1+UAzF/OtWqLcQVTVF39HLdZ3RO8XBoXt+XVPKZO1vVr1aUoxHZA9OtD2e1v7G+3S5KFDA==",
-			"dev": true,
-			"dependencies": {
-				"bytewise": "~1.1.0",
-				"level-codec": "^9.0.0",
-				"level-errors": "^2.0.0",
-				"level-iterator-stream": "^2.0.3",
-				"ltgt": "~2.1.1",
-				"pull-defer": "^0.2.2",
-				"pull-level": "^2.0.3",
-				"pull-stream": "^3.6.8",
-				"typewiselite": "~1.0.0",
-				"xtend": "~4.0.0"
-			}
-		},
-		"node_modules/level-supports": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
-			"integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/level-transcoder": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
-			"integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^6.0.3",
-				"module-error": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/level-transcoder/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
 			}
 		},
 		"node_modules/leven": {
@@ -15561,60 +14265,6 @@
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
 			"dev": true
 		},
-		"node_modules/lodash.defaults": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-			"dev": true
-		},
-		"node_modules/lodash.flatten": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-			"dev": true
-		},
-		"node_modules/lodash.includes": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-			"dev": true
-		},
-		"node_modules/lodash.isarguments": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-			"dev": true
-		},
-		"node_modules/lodash.isboolean": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-			"dev": true
-		},
-		"node_modules/lodash.isinteger": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-			"dev": true
-		},
-		"node_modules/lodash.isnumber": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-			"dev": true
-		},
-		"node_modules/lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-			"dev": true
-		},
-		"node_modules/lodash.isstring": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-			"dev": true
-		},
 		"node_modules/lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -15627,12 +14277,6 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
-		"node_modules/lodash.once": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-			"dev": true
-		},
 		"node_modules/lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -15643,26 +14287,6 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
-			"dev": true
-		},
-		"node_modules/logform": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.5.1.tgz",
-			"integrity": "sha512-9FyqAm9o9NKKfiAKfZoYo9bGXXuwMkxQiQttkT4YjjVtQVIQtK6LmVtlxmCaFswo6N4AfEkHqZTV0taDtPotNg==",
-			"dev": true,
-			"dependencies": {
-				"@colors/colors": "1.5.0",
-				"@types/triple-beam": "^1.3.2",
-				"fecha": "^4.2.0",
-				"ms": "^2.1.1",
-				"safe-stable-stringify": "^2.3.1",
-				"triple-beam": "^1.3.0"
-			}
-		},
-		"node_modules/looper": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
-			"integrity": "sha512-6DzMHJcjbQX/UPHc1rRCBfKlLwDkvuGZ715cIR36wSdYqWXFT35uLXq5P/2orl3tz+t+VOVPxw4yPinQlUDGDQ==",
 			"dev": true
 		},
 		"node_modules/loose-envify": {
@@ -15696,12 +14320,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/ltgt": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
-			"integrity": "sha512-5VjHC5GsENtIi5rbJd+feEpDKhfr7j0odoUR2Uh978g+2p93nd5o34cTjQWohXsPsCZeqoDnIqEf88mPCe0Pfw==",
-			"dev": true
 		},
 		"node_modules/lz-string": {
 			"version": "1.4.4",
@@ -15863,18 +14481,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/mimic-response": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -15983,15 +14589,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/minimisted": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
-			"integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
-			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.5"
-			}
-		},
 		"node_modules/mitt": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -16015,58 +14612,6 @@
 			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
 			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
 			"dev": true
-		},
-		"node_modules/module-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
-			"integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/morgan": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-			"integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
-			"dev": true,
-			"dependencies": {
-				"basic-auth": "~2.0.1",
-				"debug": "2.6.9",
-				"depd": "~2.0.0",
-				"on-finished": "~2.3.0",
-				"on-headers": "~1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/morgan/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/morgan/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true
-		},
-		"node_modules/morgan/node_modules/on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-			"dev": true,
-			"dependencies": {
-				"ee-first": "1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/ms": {
 			"version": "2.1.2",
@@ -16115,12 +14660,6 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
-		"node_modules/napi-macros": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
-			"integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
-			"dev": true
-		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -16132,68 +14671,6 @@
 			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
 			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
 			"dev": true
-		},
-		"node_modules/nconf": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.0.tgz",
-			"integrity": "sha512-T3fZPw3c7Dfrz8JBQEbEcZJ2s8f7cUMpKuyBtsGQe0b71pcXx6gNh4oti2xh5dxB+gO9ufNfISBlGvvWtfyMcA==",
-			"dev": true,
-			"dependencies": {
-				"async": "^3.0.0",
-				"ini": "^2.0.0",
-				"secure-keys": "^1.0.0",
-				"yargs": "^16.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
-		"node_modules/nconf/node_modules/cliui": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-			"dev": true,
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0",
-				"wrap-ansi": "^7.0.0"
-			}
-		},
-		"node_modules/nconf/node_modules/ini": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-			"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/nconf/node_modules/yargs": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-			"dev": true,
-			"dependencies": {
-				"cliui": "^7.0.2",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.0",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^20.2.2"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/nconf/node_modules/yargs-parser": {
-			"version": "20.2.9",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"node_modules/negotiator": {
 			"version": "0.6.3",
@@ -16255,17 +14732,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 6.13.0"
-			}
-		},
-		"node_modules/node-gyp-build": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-			"integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
-			"dev": true,
-			"bin": {
-				"node-gyp-build": "bin.js",
-				"node-gyp-build-optional": "optional.js",
-				"node-gyp-build-test": "build-test.js"
 			}
 		},
 		"node_modules/node-int64": {
@@ -16342,12 +14808,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/notepack.io": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.3.0.tgz",
-			"integrity": "sha512-9RiFDxeydHsWOqdthRUck2Kd4UW2NzVd2xxOulZiQ9mvge6ElsHXLpwD3HEJyql6sFEnEn/eMO7HSdS0M5mWkA==",
-			"dev": true
 		},
 		"node_modules/npm-run-path": {
 			"version": "4.0.1",
@@ -16571,15 +15031,6 @@
 				"wrappy": "1"
 			}
 		},
-		"node_modules/one-time": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-			"dev": true,
-			"dependencies": {
-				"fn.name": "1.x.x"
-			}
-		},
 		"node_modules/onetime": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -16665,15 +15116,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/p-map": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/p-retry": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
@@ -16728,12 +15170,6 @@
 			"engines": {
 				"node": ">= 14"
 			}
-		},
-		"node_modules/pako": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-			"dev": true
 		},
 		"node_modules/param-case": {
 			"version": "3.0.4",
@@ -16899,15 +15335,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/pify": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/pirates": {
@@ -18514,12 +16941,6 @@
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"dev": true
 		},
-		"node_modules/prr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-			"dev": true
-		},
 		"node_modules/ps-tree": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
@@ -18540,64 +16961,6 @@
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
 			"integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
 			"dev": true
-		},
-		"node_modules/pull-cat": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
-			"integrity": "sha512-i3w+xZ3DCtTVz8S62hBOuNLRHqVDsHMNZmgrZsjPnsxXUgbWtXEee84lo1XswE7W2a3WHyqsNuDJTjVLAQR8xg==",
-			"dev": true
-		},
-		"node_modules/pull-defer": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
-			"integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA==",
-			"dev": true
-		},
-		"node_modules/pull-level": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
-			"integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
-			"dev": true,
-			"dependencies": {
-				"level-post": "^1.0.7",
-				"pull-cat": "^1.1.9",
-				"pull-live": "^1.0.1",
-				"pull-pushable": "^2.0.0",
-				"pull-stream": "^3.4.0",
-				"pull-window": "^2.1.4",
-				"stream-to-pull-stream": "^1.7.1"
-			}
-		},
-		"node_modules/pull-live": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
-			"integrity": "sha512-tkNz1QT5gId8aPhV5+dmwoIiA1nmfDOzJDlOOUpU5DNusj6neNd3EePybJ5+sITr2FwyCs/FVpx74YMCfc8YeA==",
-			"dev": true,
-			"dependencies": {
-				"pull-cat": "^1.1.9",
-				"pull-stream": "^3.4.0"
-			}
-		},
-		"node_modules/pull-pushable": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
-			"integrity": "sha512-M7dp95enQ2kaHvfCt2+DJfyzgCSpWVR2h2kWYnVsW6ZpxQBx5wOu0QWOvQPVoPnBLUZYitYP2y7HyHkLQNeGXg==",
-			"dev": true
-		},
-		"node_modules/pull-stream": {
-			"version": "3.6.14",
-			"resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
-			"integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew==",
-			"dev": true
-		},
-		"node_modules/pull-window": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
-			"integrity": "sha512-cbDzN76BMlcGG46OImrgpkMf/VkCnupj8JhsrpBw3aWBM9ye345aYnqitmZCgauBkc0HbbRRn9hCnsa3k2FNUg==",
-			"dev": true,
-			"dependencies": {
-				"looper": "^2.0.0"
-			}
 		},
 		"node_modules/pump": {
 			"version": "3.0.0",
@@ -18793,42 +17156,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/raw-body": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-			"integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-			"dev": true,
-			"dependencies": {
-				"bytes": "3.1.2",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/raw-body/node_modules/bytes": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/raw-body/node_modules/iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/react": {
@@ -20476,33 +18803,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/redis-commands": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
-			"dev": true
-		},
-		"node_modules/redis-errors": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-			"integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/redis-parser": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-			"integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-			"dev": true,
-			"dependencies": {
-				"redis-errors": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/reflect.getprototypeof": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
@@ -21010,29 +19310,6 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
-		"node_modules/run-parallel-limit": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
-			"integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"queue-microtask": "^1.2.2"
-			}
-		},
 		"node_modules/rxjs": {
 			"version": "7.8.1",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -21091,15 +19368,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/safe-stable-stringify": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/safer-buffer": {
@@ -21197,12 +19465,6 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
-		"node_modules/secure-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
-			"integrity": "sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg==",
-			"dev": true
-		},
 		"node_modules/select-hose": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -21274,33 +19536,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true
-		},
-		"node_modules/serialize-error": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
-			"integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
-			"dev": true,
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/serialize-error/node_modules/type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.1",
@@ -21498,66 +19733,6 @@
 			"resolved": "https://registry.npmjs.org/sillyname/-/sillyname-0.1.0.tgz",
 			"integrity": "sha512-GWA0Zont13ov+cMNw4T7nU4SCyW8jdhD3vjA5+qs8jr+09sCPxOf+FPS5zE0c9pYlCwD+NU/CiMimY462lgG9g=="
 		},
-		"node_modules/simple-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/simple-get": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"decompress-response": "^6.0.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
-			}
-		},
-		"node_modules/simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-			"dev": true,
-			"dependencies": {
-				"is-arrayish": "^0.3.1"
-			}
-		},
-		"node_modules/simple-swizzle/node_modules/is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-			"dev": true
-		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -21581,54 +19756,6 @@
 			"engines": {
 				"node": ">= 6.0.0",
 				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/socket.io": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.2.tgz",
-			"integrity": "sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==",
-			"dev": true,
-			"dependencies": {
-				"accepts": "~1.3.4",
-				"base64id": "~2.0.0",
-				"cors": "~2.8.5",
-				"debug": "~4.3.2",
-				"engine.io": "~6.5.2",
-				"socket.io-adapter": "~2.5.2",
-				"socket.io-parser": "~4.2.4"
-			},
-			"engines": {
-				"node": ">=10.2.0"
-			}
-		},
-		"node_modules/socket.io-adapter": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
-			"integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
-			"dev": true,
-			"dependencies": {
-				"ws": "~8.11.0"
-			}
-		},
-		"node_modules/socket.io-adapter/node_modules/ws": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/socket.io-client": {
@@ -21844,15 +19971,6 @@
 			"deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
 			"dev": true
 		},
-		"node_modules/stack-trace": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-			"integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/stack-utils": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -21878,12 +19996,6 @@
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
 			"integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
-			"dev": true
-		},
-		"node_modules/standard-as-callback": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-			"integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
 			"dev": true
 		},
 		"node_modules/start-server-and-test": {
@@ -21928,22 +20040,6 @@
 				"duplexer": "~0.1.1"
 			}
 		},
-		"node_modules/stream-to-pull-stream": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
-			"integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
-			"dev": true,
-			"dependencies": {
-				"looper": "^3.0.0",
-				"pull-stream": "^3.2.3"
-			}
-		},
-		"node_modules/stream-to-pull-stream/node_modules/looper": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-			"integrity": "sha512-LJ9wplN/uSn72oJRsXTx+snxPet5c8XiZmOKCm906NVYu+ag6SB6vUcnJcWxgnl2NfbIyeobAn7Bwv6xRj2XJg==",
-			"dev": true
-		},
 		"node_modules/streamx": {
 			"version": "2.15.1",
 			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.1.tgz",
@@ -21962,12 +20058,6 @@
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
 			}
-		},
-		"node_modules/string-hash": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-			"integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
-			"dev": true
 		},
 		"node_modules/string-length": {
 			"version": "4.0.2",
@@ -22614,12 +20704,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/text-hex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-			"dev": true
-		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -22737,15 +20821,6 @@
 			"dev": true,
 			"bin": {
 				"tree-kill": "cli.js"
-			}
-		},
-		"node_modules/triple-beam": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
-			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/tryer": {
@@ -22954,33 +21029,6 @@
 				"node": ">=4.2.0"
 			}
 		},
-		"node_modules/typewise": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-			"integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
-			"dev": true,
-			"dependencies": {
-				"typewise-core": "^1.2.0"
-			}
-		},
-		"node_modules/typewise-core": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-			"integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
-			"dev": true
-		},
-		"node_modules/typewiselite": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
-			"integrity": "sha512-J9alhjVHupW3Wfz6qFRGgQw0N3gr8hOkw6zm7FZ6UR1Cse/oD9/JVok7DNE9TT9IbciDHX2Ex9+ksE6cRmtymw==",
-			"dev": true
-		},
-		"node_modules/uid2": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-			"integrity": "sha512-5gSP1liv10Gjp8cMEnFd6shzkL/D6W1uhXSFNCxDC+YI8+L8wkCYCbJ7n77Ezb4wE/xzMogecE+DtamEe9PZjg==",
-			"dev": true
-		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -23166,19 +21214,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/util": {
-			"version": "0.12.5",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"is-arguments": "^1.0.4",
-				"is-generator-function": "^1.0.7",
-				"is-typed-array": "^1.1.3",
-				"which-typed-array": "^1.1.2"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -23818,42 +21853,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/winston": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.10.0.tgz",
-			"integrity": "sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==",
-			"dev": true,
-			"dependencies": {
-				"@colors/colors": "1.5.0",
-				"@dabh/diagnostics": "^2.0.2",
-				"async": "^3.2.3",
-				"is-stream": "^2.0.0",
-				"logform": "^2.4.0",
-				"one-time": "^1.0.0",
-				"readable-stream": "^3.4.0",
-				"safe-stable-stringify": "^2.3.1",
-				"stack-trace": "0.0.x",
-				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.5.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/winston-transport": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
-			"integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
-			"dev": true,
-			"dependencies": {
-				"logform": "^2.3.2",
-				"readable-stream": "^3.6.0",
-				"triple-beam": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 6.4.0"
-			}
-		},
 		"node_modules/workbox-background-sync": {
 			"version": "6.6.0",
 			"resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-6.6.0.tgz",
@@ -24269,15 +22268,6 @@
 			"integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.4"
 			}
 		},
 		"node_modules/y18n": {

--- a/react-demo/package.json
+++ b/react-demo/package.json
@@ -22,7 +22,7 @@
 		"prettier": "prettier --check . --ignore-path ./.prettierignore",
 		"prettier:fix": "prettier --write . --ignore-path ./.prettierignore",
 		"start": "react-scripts start",
-		"start:server": "npx tinylicious",
+		"start:server": "npx @fluidframework/azure-local-service",
 		"test": "start-server-and-test start:server 7070 test:jest",
 		"test:jest": "jest"
 	},
@@ -48,6 +48,7 @@
 		"react-dom": "^16.10.2"
 	},
 	"devDependencies": {
+		"@fluidframework/azure-local-service": "^1.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@testing-library/jest-dom": "^5.11.4",
 		"@testing-library/react": "^11.1.0",
@@ -58,8 +59,7 @@
 		"prettier": "^2.7.1",
 		"puppeteer": "^21.0.0",
 		"react-scripts": "^5.0.1",
-		"start-server-and-test": "^2.0.0",
-		"tinylicious": "^1.0.0"
+		"start-server-and-test": "^2.0.0"
 	},
 	"jest-junit": {
 		"outputDirectory": "nyc",

--- a/react-demo/package.json
+++ b/react-demo/package.json
@@ -48,7 +48,6 @@
 		"react-dom": "^16.10.2"
 	},
 	"devDependencies": {
-		"@fluidframework/azure-local-service": "^1.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@testing-library/jest-dom": "^5.11.4",
 		"@testing-library/react": "^11.1.0",

--- a/react-starter-template/README.md
+++ b/react-starter-template/README.md
@@ -40,10 +40,10 @@ In this readme we'll walk you through the following topics:
 
 ### Run the app locally
 
-To run our local server, Tinylicious, on the default values of `localhost:7070`, enter the following into a terminal window:
+To run our local server, `@fluidframework/azure-local-service`, on the default values of `localhost:7070`, enter the following into a terminal window:
 
 ```bash
-npx tinylicious
+npx @fluidframework/azure-local-service
 ```
 
 Now, with our local service running in the background, we need to connect the application to it.

--- a/react-starter-template/package-lock.json
+++ b/react-starter-template/package-lock.json
@@ -20,7 +20,6 @@
 				"uuid": "^8.3.2"
 			},
 			"devDependencies": {
-				"@fluidframework/azure-local-service": "^1.1.0",
 				"@fluidframework/build-common": "^2.0.0",
 				"@testing-library/jest-dom": "^5.13.0",
 				"@testing-library/react": "^11.2.7",
@@ -2182,15 +2181,6 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
 		},
-		"node_modules/@colors/colors": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.1.90"
-			}
-		},
 		"node_modules/@csstools/normalize.css": {
 			"version": "12.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
@@ -2475,17 +2465,6 @@
 			},
 			"peerDependencies": {
 				"postcss-selector-parser": "^6.0.10"
-			}
-		},
-		"node_modules/@dabh/diagnostics": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-			"integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
-			"dev": true,
-			"dependencies": {
-				"colorspace": "1.1.x",
-				"enabled": "2.0.x",
-				"kuler": "^2.0.0"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -2795,421 +2774,6 @@
 				"@fluidframework/synthesize": "^1.3.7",
 				"@fluidframework/view-interfaces": "^1.3.7",
 				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-1.1.1.tgz",
-			"integrity": "sha512-gvk+qy8RytXBQaZ554OREszHGN73W3FmgpfwV+aXeOOP5RWLMPSvkPoac5K9gcUYN+nAFbRs517c055yucP9ug==",
-			"dev": true,
-			"dependencies": {
-				"tinylicious": "^0.4.89251"
-			},
-			"bin": {
-				"azure-local-service": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/gitresources": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
-			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-base": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
-			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.4001.tgz",
-			"integrity": "sha512-rERfgXK5DXGJvxADjotkAZssKgp3ZxW6u7yUekrDnFDkXtbCW1Gcq+EwvjHTEyhsOp30YBnD0Z39xnZy4zEZRw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas-driver": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/semver": "^6.0.1",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"axios": "^0.26.0",
-				"buffer": "^6.0.3",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"semver": "^6.3.0",
-				"sha.js": "^2.4.11",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas-driver": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.4001.tgz",
-			"integrity": "sha512-qRs+vMbSS9aPx7vr3XemvER5DeY/nsJ5ZkcL3UDjUOxvLZxbOAD6C6JeH3Zgzc/jc8bqshcxai/u7qso2zCsFw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-local-server": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.4001.tgz",
-			"integrity": "sha512-FIlNUc9Ncul/5qzP+VyU53TJj8fxX7KZ1lweswZYalleRZwiqFA4Y+NbWRRWM0iJ1z8hvhyRZblG3iNrpGl04A==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.4001",
-				"@fluidframework/server-memory-orderer": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@fluidframework/server-test-utils": "^0.1038.4001",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"jsrsasign": "^10.5.25",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-memory-orderer": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.4001.tgz",
-			"integrity": "sha512-fdzTCLFRh8QfyY17MnB22/o8x2XEX1+wZrm+dn+1Av+ZVe/+ZhfdX5LsQCMKYv+X5mgAauNmC/12mQE4H6jvsQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^0.1038.4001",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/debug": "^4.1.5",
-				"@types/double-ended-queue": "^2.1.0",
-				"@types/lodash": "^4.14.118",
-				"@types/node": "^14.18.0",
-				"@types/ws": "^6.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1",
-				"ws": "^7.4.6"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-client": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
-			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-core": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.4001.tgz",
-			"integrity": "sha512-nuZ9ebvyeIoRdlpQQpBNGkawKtc2/tHKbc8CHbMZRMh7F7kwYUtoHd/J8powb9eUcg5IHDmXx1l+PQRbQX4vCg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@types/nconf": "^0.10.2",
-				"@types/node": "^14.18.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"nconf": "^0.12.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-shared": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.4001.tgz",
-			"integrity": "sha512-vDRB2G/Xnuhan+Ri0Eg5JMKfsm7hxstCXdEyQhzJzC7+bw66wts+ZIsEsn4Ha/3KkxblF/RSW3lBhrYpxii3cQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"@socket.io/redis-adapter": "^7.2.0",
-				"body-parser": "^1.17.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"ioredis": "^4.24.2",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"notepack.io": "^2.3.0",
-				"querystring": "^0.2.0",
-				"socket.io": "^4.5.3",
-				"socket.io-adapter": "^2.4.0",
-				"socket.io-parser": "^4.2.1",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-telemetry": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.4001.tgz",
-			"integrity": "sha512-2leJhB04+71RTmC5ShRXm/4FWng9tLn9dlrUAjApZH4RlUJAx1JGsvo/5JU1tIbpUutMHUle2IpWyfu/RV+S5g==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"path-browserify": "^1.0.1",
-				"serialize-error": "^8.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-utils": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.4001.tgz",
-			"integrity": "sha512-K7X/0mlonDAu0pPIgTz8U9nLwRSbJY2oBpFPwpkp1UtE6SU02jx2ZzraT9epDmOl3EXeS1rHzA+mbvBSe1aFMg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"debug": "^4.1.1",
-				"express": "^4.17.3",
-				"ioredis": "^4.24.2",
-				"json-stringify-safe": "^5.0.1",
-				"jsonwebtoken": "^9.0.0",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0",
-				"sillyname": "^0.1.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0",
-				"winston-transport": "^4.5.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-test-utils": {
-			"version": "0.1038.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.4001.tgz",
-			"integrity": "sha512-qrLp5H1UUPIJSEHlzZ1iYlPFJCQrd2WnmoafxnQIg0mfU1ZE8XUlG5MKUg8bT9pWsCoEGJDiOkkRHaq+WXupjQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^0.1038.4001",
-				"@fluidframework/protocol-base": "^0.1038.4001",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^0.1038.4001",
-				"@fluidframework/server-services-core": "^0.1038.4001",
-				"@fluidframework/server-services-telemetry": "^0.1038.4001",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"string-hash": "^1.1.3",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@types/node": {
-			"version": "14.18.63",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/@types/semver": {
-			"version": "6.2.5",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.5.tgz",
-			"integrity": "sha512-NAxro9/RqWXTqdSjccDZAjA4nXK+6zRun+HvibYJfGy8TQhpOC7Vv6v2rlHYKrT0Q8jGGoNRd/xVdHRIQRNlFQ==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/denque": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/ioredis": {
-			"version": "4.28.5",
-			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
-			"integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
-			"dev": true,
-			"dependencies": {
-				"cluster-key-slot": "^1.1.0",
-				"debug": "^4.3.1",
-				"denque": "^1.1.0",
-				"lodash.defaults": "^4.2.0",
-				"lodash.flatten": "^4.4.0",
-				"lodash.isarguments": "^3.1.0",
-				"p-map": "^2.1.0",
-				"redis-commands": "1.7.0",
-				"redis-errors": "^1.2.0",
-				"redis-parser": "^3.0.0",
-				"standard-as-callback": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ioredis"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/tinylicious": {
-			"version": "0.4.94771",
-			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
-			"integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/gitresources": "^0.1038.1000",
-				"@fluidframework/protocol-base": "^0.1038.1000",
-				"@fluidframework/protocol-definitions": "^1.0.0",
-				"@fluidframework/server-lambdas": "^0.1038.1000",
-				"@fluidframework/server-local-server": "^0.1038.1000",
-				"@fluidframework/server-memory-orderer": "^0.1038.1000",
-				"@fluidframework/server-services-client": "^0.1038.1000",
-				"@fluidframework/server-services-core": "^0.1038.1000",
-				"@fluidframework/server-services-shared": "^0.1038.1000",
-				"@fluidframework/server-services-telemetry": "^0.1038.1000",
-				"@fluidframework/server-services-utils": "^0.1038.1000",
-				"@fluidframework/server-test-utils": "^0.1038.1000",
-				"agentkeepalive": "^4.2.1",
-				"axios": "^0.26.0",
-				"body-parser": "^1.17.1",
-				"charwise": "^3.0.1",
-				"compression": "^1.7.2",
-				"cookie-parser": "^1.4.3",
-				"cors": "^2.8.4",
-				"detect-port": "^1.3.0",
-				"express": "^4.16.3",
-				"isomorphic-git": "^1.8.2",
-				"json-stringify-safe": "^5.0.1",
-				"level": "^8.0.0",
-				"level-sublevel": "6.6.4",
-				"lodash": "^4.17.21",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"socket.io": "^4.5.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.2",
-				"winston": "^3.6.0"
-			},
-			"bin": {
-				"tinylicious": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@fluidframework/azure-local-service/node_modules/ws": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@fluidframework/build-common": {
@@ -6111,27 +5675,6 @@
 			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
 			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
 		},
-		"node_modules/@socket.io/redis-adapter": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-7.2.0.tgz",
-			"integrity": "sha512-/r6oF6Myz0K9uatB/pfCi0BhKg/KRMh1OokrqcjlNz6aq40WiXdFLRbHJQuwGHq/KvB+D6141K+IynbVxZGvhw==",
-			"dev": true,
-			"dependencies": {
-				"debug": "~4.3.1",
-				"notepack.io": "~2.2.0",
-				"socket.io-adapter": "^2.4.0",
-				"uid2": "0.0.3"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/@socket.io/redis-adapter/node_modules/notepack.io": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.2.0.tgz",
-			"integrity": "sha512-9b5w3t5VSH6ZPosoYnyDONnUTF8o0UkBw7JLA6eBlYJWyGT1Q3vQa8Hmuj1/X6RYvHjjygBDgw6fJhe0JEojfw==",
-			"dev": true
-		},
 		"node_modules/@surma/rollup-plugin-off-main-thread": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -6577,36 +6120,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/cookie": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-			"integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-			"dev": true
-		},
-		"node_modules/@types/cors": {
-			"version": "2.8.14",
-			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.14.tgz",
-			"integrity": "sha512-RXHUvNWYICtbP6s18PnOCaqToK8y14DnLd75c6HfyKf228dxy7pHNOQkxPtvXKp/hINFMDjbYzsj63nnpPMSRQ==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@types/debug": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
-			"integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
-			"dev": true,
-			"dependencies": {
-				"@types/ms": "*"
-			}
-		},
-		"node_modules/@types/double-ended-queue": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@types/double-ended-queue/-/double-ended-queue-2.1.3.tgz",
-			"integrity": "sha512-PWBSlai2jeSM3xOlr4JPI0oDiGFLVkVvylJ1nK1+oK9V/RiBIqDy8vCtsk+gOQN/I1gU6O1cR1OHheBanFdbCQ==",
-			"dev": true
-		},
 		"node_modules/@types/eslint": {
 			"version": "8.44.2",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.2.tgz",
@@ -6744,28 +6257,10 @@
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
 		},
-		"node_modules/@types/lodash": {
-			"version": "4.14.198",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.198.tgz",
-			"integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg==",
-			"dev": true
-		},
 		"node_modules/@types/mime": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
 			"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-			"dev": true
-		},
-		"node_modules/@types/ms": {
-			"version": "0.7.31",
-			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
-			"dev": true
-		},
-		"node_modules/@types/nconf": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.3.tgz",
-			"integrity": "sha512-leyIuBk/rMIp9114FlPRkc/cQG+/JzCz1Afx3BD+CwK2ep3ZRxoC843V1rqnE2pC/jRRjANWhuVBEn4clCwlug==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -6928,12 +6423,6 @@
 				"@types/jest": "*"
 			}
 		},
-		"node_modules/@types/triple-beam": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.3.tgz",
-			"integrity": "sha512-6tOUG+nVHn0cJbVp25JFayS5UE6+xlbcNF9Lo9mU7U0zk3zeUShZied4YEQZjy1JBF043FSkdXw8YkUJuVtB5g==",
-			"dev": true
-		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.4.tgz",
@@ -6945,15 +6434,6 @@
 			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
 			"integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
 			"dev": true
-		},
-		"node_modules/@types/ws": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
-			"integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
 		},
 		"node_modules/@types/yargs": {
 			"version": "15.0.14",
@@ -7384,47 +6864,6 @@
 				"node": ">=6.5"
 			}
 		},
-		"node_modules/abstract-level": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
-			"integrity": "sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^6.0.3",
-				"catering": "^2.1.0",
-				"is-buffer": "^2.0.5",
-				"level-supports": "^4.0.0",
-				"level-transcoder": "^1.0.1",
-				"module-error": "^1.0.1",
-				"queue-microtask": "^1.2.3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/abstract-level/node_modules/is-buffer": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -7531,29 +6970,6 @@
 			},
 			"engines": {
 				"node": ">= 14"
-			}
-		},
-		"node_modules/agentkeepalive": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
-			"integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
-			"dev": true,
-			"dependencies": {
-				"debug": "^4.1.0",
-				"depd": "^1.1.2",
-				"humanize-ms": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 8.0.0"
-			}
-		},
-		"node_modules/agentkeepalive/node_modules/depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/ajv": {
@@ -7887,19 +7303,6 @@
 			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
 			"dev": true
 		},
-		"node_modules/assert": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
-			"integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"is-nan": "^1.3.2",
-				"object-is": "^1.1.5",
-				"object.assign": "^4.1.4",
-				"util": "^0.12.5"
-			}
-		},
 		"node_modules/ast-types": {
 			"version": "0.13.4",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -7922,12 +7325,6 @@
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
 			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-			"dev": true
-		},
-		"node_modules/async-lock": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz",
-			"integrity": "sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ==",
 			"dev": true
 		},
 		"node_modules/asynciterator.prototype": {
@@ -8332,33 +7729,6 @@
 				}
 			]
 		},
-		"node_modules/base64id": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-			"integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-			"dev": true,
-			"engines": {
-				"node": "^4.5.0 || >= 5.9"
-			}
-		},
-		"node_modules/basic-auth": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-			"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "5.1.2"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/basic-auth/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
 		"node_modules/basic-ftp": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
@@ -8413,66 +7783,6 @@
 			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
 			"dev": true
 		},
-		"node_modules/body-parser": {
-			"version": "1.20.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-			"integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
-			"dev": true,
-			"dependencies": {
-				"bytes": "3.1.2",
-				"content-type": "~1.0.5",
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"destroy": "1.2.0",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"on-finished": "2.4.1",
-				"qs": "6.11.0",
-				"raw-body": "2.5.2",
-				"type-is": "~1.6.18",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8",
-				"npm": "1.2.8000 || >= 1.4.16"
-			}
-		},
-		"node_modules/body-parser/node_modules/bytes": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/body-parser/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/body-parser/node_modules/iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/body-parser/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true
-		},
 		"node_modules/bonjour-service": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.1.tgz",
@@ -8517,18 +7827,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/browser-level": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
-			"integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
-			"dev": true,
-			"dependencies": {
-				"abstract-level": "^1.0.2",
-				"catering": "^2.1.1",
-				"module-error": "^1.0.2",
-				"run-parallel-limit": "^1.1.0"
 			}
 		},
 		"node_modules/browser-process-hrtime": {
@@ -8610,12 +7908,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/buffer-equal-constant-time": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-			"dev": true
-		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -8641,25 +7933,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/bytewise": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-			"integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
-			"dev": true,
-			"dependencies": {
-				"bytewise-core": "^1.2.2",
-				"typewise": "^1.0.3"
-			}
-		},
-		"node_modules/bytewise-core": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-			"integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
-			"dev": true,
-			"dependencies": {
-				"typewise-core": "^1.2"
 			}
 		},
 		"node_modules/call-bind": {
@@ -8755,15 +8028,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/catering": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
-			"integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/chalk": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -8785,12 +8049,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/charwise": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz",
-			"integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw==",
-			"dev": true
 		},
 		"node_modules/check-more-types": {
 			"version": "2.24.0",
@@ -8888,23 +8146,6 @@
 			"integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
 			"dev": true
 		},
-		"node_modules/classic-level": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.2.0.tgz",
-			"integrity": "sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"dependencies": {
-				"abstract-level": "^1.0.2",
-				"catering": "^2.1.0",
-				"module-error": "^1.0.1",
-				"napi-macros": "~2.0.0",
-				"node-gyp-build": "^4.3.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/clean-css": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
@@ -8916,12 +8157,6 @@
 			"engines": {
 				"node": ">= 10.0"
 			}
-		},
-		"node_modules/clean-git-ref": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
-			"integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
-			"dev": true
 		},
 		"node_modules/cliui": {
 			"version": "8.0.1",
@@ -8935,15 +8170,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/cluster-key-slot": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
-			"integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/co": {
@@ -9038,16 +8264,6 @@
 			"integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
 			"dev": true
 		},
-		"node_modules/color": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^1.9.3",
-				"color-string": "^1.6.0"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -9066,31 +8282,6 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
-		"node_modules/color-string": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
-		},
-		"node_modules/color/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/color/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
-		},
 		"node_modules/colord": {
 			"version": "2.9.3",
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
@@ -9102,16 +8293,6 @@
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
 			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
 			"dev": true
-		},
-		"node_modules/colorspace": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-			"integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-			"dev": true,
-			"dependencies": {
-				"color": "^3.1.3",
-				"text-hex": "1.0.x"
-			}
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
@@ -9263,28 +8444,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/cookie-parser": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-			"integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
-			"dev": true,
-			"dependencies": {
-				"cookie": "0.4.1",
-				"cookie-signature": "1.0.6"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/cookie-parser/node_modules/cookie": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-			"integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/cookie-signature": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -9331,19 +8490,6 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"dev": true
-		},
-		"node_modules/cors": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-			"dev": true,
-			"dependencies": {
-				"object-assign": "^4",
-				"vary": "^1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
 		},
 		"node_modules/cosmiconfig": {
 			"version": "7.0.1",
@@ -9899,21 +9045,6 @@
 			"integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
 			"dev": true
 		},
-		"node_modules/decompress-response": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-			"dev": true,
-			"dependencies": {
-				"mimic-response": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -10079,20 +9210,6 @@
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
 		},
-		"node_modules/detect-port": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
-			"integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
-			"dev": true,
-			"dependencies": {
-				"address": "^1.0.1",
-				"debug": "4"
-			},
-			"bin": {
-				"detect": "bin/detect-port.js",
-				"detect-port": "bin/detect-port.js"
-			}
-		},
 		"node_modules/detect-port-alt": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
@@ -10145,12 +9262,6 @@
 			"engines": {
 				"node": ">= 10.14.2"
 			}
-		},
-		"node_modules/diff3": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
-			"dev": true
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
@@ -10337,15 +9448,6 @@
 			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
 			"dev": true
 		},
-		"node_modules/ecdsa-sig-formatter": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"node_modules/ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -10400,12 +9502,6 @@
 				"node": ">= 4"
 			}
 		},
-		"node_modules/enabled": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
-			"dev": true
-		},
 		"node_modules/encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -10422,27 +9518,6 @@
 			"dev": true,
 			"dependencies": {
 				"once": "^1.4.0"
-			}
-		},
-		"node_modules/engine.io": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.2.tgz",
-			"integrity": "sha512-IXsMcGpw/xRfjra46sVZVHiSWo/nJ/3g1337q9KNXtS6YRzbW5yIzTCb9DjhrBe7r3GZQR0I4+nq+4ODk5g/cA==",
-			"dev": true,
-			"dependencies": {
-				"@types/cookie": "^0.4.1",
-				"@types/cors": "^2.8.12",
-				"@types/node": ">=10.0.0",
-				"accepts": "~1.3.4",
-				"base64id": "2.0.0",
-				"cookie": "~0.4.1",
-				"cors": "~2.8.5",
-				"debug": "~4.3.1",
-				"engine.io-parser": "~5.2.1",
-				"ws": "~8.11.0"
-			},
-			"engines": {
-				"node": ">=10.2.0"
 			}
 		},
 		"node_modules/engine.io-client": {
@@ -10485,36 +9560,6 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/engine.io/node_modules/cookie": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/engine.io/node_modules/ws": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.15.0",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
@@ -10535,18 +9580,6 @@
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/errno": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
-			"integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-			"dev": true,
-			"dependencies": {
-				"prr": "~1.0.1"
-			},
-			"bin": {
-				"errno": "cli.js"
 			}
 		},
 		"node_modules/error-ex": {
@@ -11928,12 +10961,6 @@
 				"pend": "~1.2.0"
 			}
 		},
-		"node_modules/fecha": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
-			"dev": true
-		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -12167,12 +11194,6 @@
 				"@fluidframework/map": "^1.3.7",
 				"@fluidframework/sequence": "^1.3.7"
 			}
-		},
-		"node_modules/fn.name": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-			"dev": true
 		},
 		"node_modules/follow-redirects": {
 			"version": "1.15.2",
@@ -13133,15 +12154,6 @@
 				"node": ">=10.17.0"
 			}
 		},
-		"node_modules/humanize-ms": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "^2.0.0"
-			}
-		},
 		"node_modules/iconv-lite": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -13550,22 +12562,6 @@
 			"integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
 			"dev": true
 		},
-		"node_modules/is-nan": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-negative-zero": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
@@ -13822,45 +12818,6 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
-		},
-		"node_modules/isomorphic-git": {
-			"version": "1.21.0",
-			"resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.21.0.tgz",
-			"integrity": "sha512-ZqCAUM63CYepA3fB8H7NVyPSiOkgzIbQ7T+QPrm9xtYgQypN9JUJ5uLMjB5iTfomdJf3mdm6aSxjZwnT6ubvEA==",
-			"dev": true,
-			"dependencies": {
-				"async-lock": "^1.1.0",
-				"clean-git-ref": "^2.0.1",
-				"crc-32": "^1.2.0",
-				"diff3": "0.0.3",
-				"ignore": "^5.1.4",
-				"minimisted": "^2.0.0",
-				"pako": "^1.0.10",
-				"pify": "^4.0.1",
-				"readable-stream": "^3.4.0",
-				"sha.js": "^2.4.9",
-				"simple-get": "^4.0.1"
-			},
-			"bin": {
-				"isogit": "cli.cjs"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/isomorphic-git/node_modules/readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.0",
@@ -18030,28 +16987,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/jsonwebtoken": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-			"integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-			"dev": true,
-			"dependencies": {
-				"jws": "^3.2.2",
-				"lodash.includes": "^4.3.0",
-				"lodash.isboolean": "^3.0.3",
-				"lodash.isinteger": "^4.0.4",
-				"lodash.isnumber": "^3.0.3",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.isstring": "^4.0.1",
-				"lodash.once": "^4.0.0",
-				"ms": "^2.1.1",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": ">=12",
-				"npm": ">=6"
-			}
-		},
 		"node_modules/jsrsasign": {
 			"version": "10.8.6",
 			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.8.6.tgz",
@@ -18073,27 +17008,6 @@
 			},
 			"engines": {
 				"node": ">=4.0"
-			}
-		},
-		"node_modules/jwa": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-			"dev": true,
-			"dependencies": {
-				"buffer-equal-constant-time": "1.0.1",
-				"ecdsa-sig-formatter": "1.0.11",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"node_modules/jws": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-			"dev": true,
-			"dependencies": {
-				"jwa": "^1.4.1",
-				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/jwt-decode": {
@@ -18137,12 +17051,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/kuler": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-			"dev": true
-		},
 		"node_modules/language-subtag-registry": {
 			"version": "0.3.22",
 			"resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
@@ -18175,134 +17083,6 @@
 			"dev": true,
 			"engines": {
 				"node": "> 0.8"
-			}
-		},
-		"node_modules/level": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/level/-/level-8.0.0.tgz",
-			"integrity": "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==",
-			"dev": true,
-			"dependencies": {
-				"browser-level": "^1.0.1",
-				"classic-level": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/level"
-			}
-		},
-		"node_modules/level-codec": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
-			"integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^5.6.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/level-codec/node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
-		},
-		"node_modules/level-errors": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-			"integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-			"dev": true,
-			"dependencies": {
-				"errno": "~0.1.1"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/level-iterator-stream": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
-			"integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.5",
-				"xtend": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/level-post": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
-			"integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
-			"dev": true,
-			"dependencies": {
-				"ltgt": "^2.1.2"
-			}
-		},
-		"node_modules/level-sublevel": {
-			"version": "6.6.4",
-			"resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.4.tgz",
-			"integrity": "sha512-pcCrTUOiO48+Kp6F1+UAzF/OtWqLcQVTVF39HLdZ3RO8XBoXt+XVPKZO1vVr1aUoxHZA9OtD2e1v7G+3S5KFDA==",
-			"dev": true,
-			"dependencies": {
-				"bytewise": "~1.1.0",
-				"level-codec": "^9.0.0",
-				"level-errors": "^2.0.0",
-				"level-iterator-stream": "^2.0.3",
-				"ltgt": "~2.1.1",
-				"pull-defer": "^0.2.2",
-				"pull-level": "^2.0.3",
-				"pull-stream": "^3.6.8",
-				"typewiselite": "~1.0.0",
-				"xtend": "~4.0.0"
-			}
-		},
-		"node_modules/level-supports": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
-			"integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/level-transcoder": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
-			"integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^6.0.3",
-				"module-error": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/leven": {
@@ -18388,60 +17168,6 @@
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
 			"dev": true
 		},
-		"node_modules/lodash.defaults": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-			"dev": true
-		},
-		"node_modules/lodash.flatten": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-			"dev": true
-		},
-		"node_modules/lodash.includes": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-			"dev": true
-		},
-		"node_modules/lodash.isarguments": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-			"dev": true
-		},
-		"node_modules/lodash.isboolean": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-			"dev": true
-		},
-		"node_modules/lodash.isinteger": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-			"dev": true
-		},
-		"node_modules/lodash.isnumber": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-			"dev": true
-		},
-		"node_modules/lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-			"dev": true
-		},
-		"node_modules/lodash.isstring": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-			"dev": true
-		},
 		"node_modules/lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -18454,12 +17180,6 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
-		"node_modules/lodash.once": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-			"dev": true
-		},
 		"node_modules/lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -18470,26 +17190,6 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
-			"dev": true
-		},
-		"node_modules/logform": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.5.1.tgz",
-			"integrity": "sha512-9FyqAm9o9NKKfiAKfZoYo9bGXXuwMkxQiQttkT4YjjVtQVIQtK6LmVtlxmCaFswo6N4AfEkHqZTV0taDtPotNg==",
-			"dev": true,
-			"dependencies": {
-				"@colors/colors": "1.5.0",
-				"@types/triple-beam": "^1.3.2",
-				"fecha": "^4.2.0",
-				"ms": "^2.1.1",
-				"safe-stable-stringify": "^2.3.1",
-				"triple-beam": "^1.3.0"
-			}
-		},
-		"node_modules/looper": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
-			"integrity": "sha512-6DzMHJcjbQX/UPHc1rRCBfKlLwDkvuGZ715cIR36wSdYqWXFT35uLXq5P/2orl3tz+t+VOVPxw4yPinQlUDGDQ==",
 			"dev": true
 		},
 		"node_modules/loose-envify": {
@@ -18523,12 +17223,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/ltgt": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
-			"integrity": "sha512-5VjHC5GsENtIi5rbJd+feEpDKhfr7j0odoUR2Uh978g+2p93nd5o34cTjQWohXsPsCZeqoDnIqEf88mPCe0Pfw==",
-			"dev": true
 		},
 		"node_modules/lz-string": {
 			"version": "1.4.4",
@@ -18699,18 +17393,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/mimic-response": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -18819,15 +17501,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/minimisted": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
-			"integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
-			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.5"
-			}
-		},
 		"node_modules/mitt": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -18851,58 +17524,6 @@
 			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
 			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
 			"dev": true
-		},
-		"node_modules/module-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
-			"integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/morgan": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-			"integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
-			"dev": true,
-			"dependencies": {
-				"basic-auth": "~2.0.1",
-				"debug": "2.6.9",
-				"depd": "~2.0.0",
-				"on-finished": "~2.3.0",
-				"on-headers": "~1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/morgan/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/morgan/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true
-		},
-		"node_modules/morgan/node_modules/on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-			"dev": true,
-			"dependencies": {
-				"ee-first": "1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/ms": {
 			"version": "2.1.2",
@@ -18951,12 +17572,6 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
-		"node_modules/napi-macros": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
-			"integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
-			"dev": true
-		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -18968,68 +17583,6 @@
 			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
 			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
 			"dev": true
-		},
-		"node_modules/nconf": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.0.tgz",
-			"integrity": "sha512-T3fZPw3c7Dfrz8JBQEbEcZJ2s8f7cUMpKuyBtsGQe0b71pcXx6gNh4oti2xh5dxB+gO9ufNfISBlGvvWtfyMcA==",
-			"dev": true,
-			"dependencies": {
-				"async": "^3.0.0",
-				"ini": "^2.0.0",
-				"secure-keys": "^1.0.0",
-				"yargs": "^16.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
-		"node_modules/nconf/node_modules/cliui": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-			"dev": true,
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0",
-				"wrap-ansi": "^7.0.0"
-			}
-		},
-		"node_modules/nconf/node_modules/ini": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-			"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/nconf/node_modules/yargs": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-			"dev": true,
-			"dependencies": {
-				"cliui": "^7.0.2",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.0",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^20.2.2"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/nconf/node_modules/yargs-parser": {
-			"version": "20.2.9",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"node_modules/negotiator": {
 			"version": "0.6.3",
@@ -19093,17 +17646,6 @@
 				"node": ">= 6.13.0"
 			}
 		},
-		"node_modules/node-gyp-build": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-			"integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
-			"dev": true,
-			"bin": {
-				"node-gyp-build": "bin.js",
-				"node-gyp-build-optional": "optional.js",
-				"node-gyp-build-test": "build-test.js"
-			}
-		},
 		"node_modules/node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -19161,12 +17703,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/notepack.io": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.3.0.tgz",
-			"integrity": "sha512-9RiFDxeydHsWOqdthRUck2Kd4UW2NzVd2xxOulZiQ9mvge6ElsHXLpwD3HEJyql6sFEnEn/eMO7HSdS0M5mWkA==",
-			"dev": true
 		},
 		"node_modules/npm-run-path": {
 			"version": "4.0.1",
@@ -19390,15 +17926,6 @@
 				"wrappy": "1"
 			}
 		},
-		"node_modules/one-time": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-			"dev": true,
-			"dependencies": {
-				"fn.name": "1.x.x"
-			}
-		},
 		"node_modules/onetime": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -19484,15 +18011,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/p-map": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/p-retry": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
@@ -19547,12 +18065,6 @@
 			"engines": {
 				"node": ">= 14"
 			}
-		},
-		"node_modules/pako": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-			"dev": true
 		},
 		"node_modules/param-case": {
 			"version": "3.0.4",
@@ -19725,15 +18237,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/pify": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/pirates": {
@@ -21313,12 +19816,6 @@
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"dev": true
 		},
-		"node_modules/prr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-			"dev": true
-		},
 		"node_modules/ps-tree": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
@@ -21339,64 +19836,6 @@
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
 			"integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
 			"dev": true
-		},
-		"node_modules/pull-cat": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
-			"integrity": "sha512-i3w+xZ3DCtTVz8S62hBOuNLRHqVDsHMNZmgrZsjPnsxXUgbWtXEee84lo1XswE7W2a3WHyqsNuDJTjVLAQR8xg==",
-			"dev": true
-		},
-		"node_modules/pull-defer": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
-			"integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA==",
-			"dev": true
-		},
-		"node_modules/pull-level": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
-			"integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
-			"dev": true,
-			"dependencies": {
-				"level-post": "^1.0.7",
-				"pull-cat": "^1.1.9",
-				"pull-live": "^1.0.1",
-				"pull-pushable": "^2.0.0",
-				"pull-stream": "^3.4.0",
-				"pull-window": "^2.1.4",
-				"stream-to-pull-stream": "^1.7.1"
-			}
-		},
-		"node_modules/pull-live": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
-			"integrity": "sha512-tkNz1QT5gId8aPhV5+dmwoIiA1nmfDOzJDlOOUpU5DNusj6neNd3EePybJ5+sITr2FwyCs/FVpx74YMCfc8YeA==",
-			"dev": true,
-			"dependencies": {
-				"pull-cat": "^1.1.9",
-				"pull-stream": "^3.4.0"
-			}
-		},
-		"node_modules/pull-pushable": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
-			"integrity": "sha512-M7dp95enQ2kaHvfCt2+DJfyzgCSpWVR2h2kWYnVsW6ZpxQBx5wOu0QWOvQPVoPnBLUZYitYP2y7HyHkLQNeGXg==",
-			"dev": true
-		},
-		"node_modules/pull-stream": {
-			"version": "3.6.14",
-			"resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
-			"integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew==",
-			"dev": true
-		},
-		"node_modules/pull-window": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
-			"integrity": "sha512-cbDzN76BMlcGG46OImrgpkMf/VkCnupj8JhsrpBw3aWBM9ye345aYnqitmZCgauBkc0HbbRRn9hCnsa3k2FNUg==",
-			"dev": true,
-			"dependencies": {
-				"looper": "^2.0.0"
-			}
 		},
 		"node_modules/pump": {
 			"version": "3.0.0",
@@ -21607,42 +20046,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/raw-body": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-			"integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-			"dev": true,
-			"dependencies": {
-				"bytes": "3.1.2",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/raw-body/node_modules/bytes": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/raw-body/node_modules/iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/react": {
@@ -22640,33 +21043,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/redis-commands": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
-			"dev": true
-		},
-		"node_modules/redis-errors": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-			"integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/redis-parser": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-			"integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-			"dev": true,
-			"dependencies": {
-				"redis-errors": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/reflect.getprototypeof": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
@@ -23188,29 +21564,6 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
-		"node_modules/run-parallel-limit": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
-			"integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"queue-microtask": "^1.2.2"
-			}
-		},
 		"node_modules/rxjs": {
 			"version": "7.8.1",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -23269,15 +21622,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/safe-stable-stringify": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/safer-buffer": {
@@ -23375,12 +21719,6 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
-		"node_modules/secure-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
-			"integrity": "sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg==",
-			"dev": true
-		},
 		"node_modules/select-hose": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -23458,21 +21796,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true
-		},
-		"node_modules/serialize-error": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
-			"integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
-			"dev": true,
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.1",
@@ -23670,66 +21993,6 @@
 			"resolved": "https://registry.npmjs.org/sillyname/-/sillyname-0.1.0.tgz",
 			"integrity": "sha512-GWA0Zont13ov+cMNw4T7nU4SCyW8jdhD3vjA5+qs8jr+09sCPxOf+FPS5zE0c9pYlCwD+NU/CiMimY462lgG9g=="
 		},
-		"node_modules/simple-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/simple-get": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"decompress-response": "^6.0.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
-			}
-		},
-		"node_modules/simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-			"dev": true,
-			"dependencies": {
-				"is-arrayish": "^0.3.1"
-			}
-		},
-		"node_modules/simple-swizzle/node_modules/is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-			"dev": true
-		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -23753,54 +22016,6 @@
 			"engines": {
 				"node": ">= 6.0.0",
 				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/socket.io": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.2.tgz",
-			"integrity": "sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==",
-			"dev": true,
-			"dependencies": {
-				"accepts": "~1.3.4",
-				"base64id": "~2.0.0",
-				"cors": "~2.8.5",
-				"debug": "~4.3.2",
-				"engine.io": "~6.5.2",
-				"socket.io-adapter": "~2.5.2",
-				"socket.io-parser": "~4.2.4"
-			},
-			"engines": {
-				"node": ">=10.2.0"
-			}
-		},
-		"node_modules/socket.io-adapter": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
-			"integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
-			"dev": true,
-			"dependencies": {
-				"ws": "~8.11.0"
-			}
-		},
-		"node_modules/socket.io-adapter/node_modules/ws": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/socket.io-client": {
@@ -24030,15 +22245,6 @@
 			"deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
 			"dev": true
 		},
-		"node_modules/stack-trace": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-			"integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/stack-utils": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -24064,12 +22270,6 @@
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
 			"integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
-			"dev": true
-		},
-		"node_modules/standard-as-callback": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-			"integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
 			"dev": true
 		},
 		"node_modules/start-server-and-test": {
@@ -24114,22 +22314,6 @@
 				"duplexer": "~0.1.1"
 			}
 		},
-		"node_modules/stream-to-pull-stream": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
-			"integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
-			"dev": true,
-			"dependencies": {
-				"looper": "^3.0.0",
-				"pull-stream": "^3.2.3"
-			}
-		},
-		"node_modules/stream-to-pull-stream/node_modules/looper": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-			"integrity": "sha512-LJ9wplN/uSn72oJRsXTx+snxPet5c8XiZmOKCm906NVYu+ag6SB6vUcnJcWxgnl2NfbIyeobAn7Bwv6xRj2XJg==",
-			"dev": true
-		},
 		"node_modules/streamx": {
 			"version": "2.15.1",
 			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.1.tgz",
@@ -24153,12 +22337,6 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"node_modules/string-hash": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-			"integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
 			"dev": true
 		},
 		"node_modules/string-length": {
@@ -24753,12 +22931,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/text-hex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-			"dev": true
-		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -24886,15 +23058,6 @@
 			"dev": true,
 			"bin": {
 				"tree-kill": "cli.js"
-			}
-		},
-		"node_modules/triple-beam": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
-			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/tryer": {
@@ -25091,33 +23254,6 @@
 			"engines": {
 				"node": ">=4.2.0"
 			}
-		},
-		"node_modules/typewise": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-			"integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
-			"dev": true,
-			"dependencies": {
-				"typewise-core": "^1.2.0"
-			}
-		},
-		"node_modules/typewise-core": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-			"integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
-			"dev": true
-		},
-		"node_modules/typewiselite": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
-			"integrity": "sha512-J9alhjVHupW3Wfz6qFRGgQw0N3gr8hOkw6zm7FZ6UR1Cse/oD9/JVok7DNE9TT9IbciDHX2Ex9+ksE6cRmtymw==",
-			"dev": true
-		},
-		"node_modules/uid2": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-			"integrity": "sha512-5gSP1liv10Gjp8cMEnFd6shzkL/D6W1uhXSFNCxDC+YI8+L8wkCYCbJ7n77Ezb4wE/xzMogecE+DtamEe9PZjg==",
-			"dev": true
 		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.2",
@@ -25337,19 +23473,6 @@
 			"peerDependencies": {
 				"immer": ">=2.0.0",
 				"react": "^16.8.0 || ^17.0.1"
-			}
-		},
-		"node_modules/util": {
-			"version": "0.12.5",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"is-arguments": "^1.0.4",
-				"is-generator-function": "^1.0.7",
-				"is-typed-array": "^1.1.3",
-				"which-typed-array": "^1.1.2"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -25994,70 +24117,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/winston": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.10.0.tgz",
-			"integrity": "sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==",
-			"dev": true,
-			"dependencies": {
-				"@colors/colors": "1.5.0",
-				"@dabh/diagnostics": "^2.0.2",
-				"async": "^3.2.3",
-				"is-stream": "^2.0.0",
-				"logform": "^2.4.0",
-				"one-time": "^1.0.0",
-				"readable-stream": "^3.4.0",
-				"safe-stable-stringify": "^2.3.1",
-				"stack-trace": "0.0.x",
-				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.5.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/winston-transport": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
-			"integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
-			"dev": true,
-			"dependencies": {
-				"logform": "^2.3.2",
-				"readable-stream": "^3.6.0",
-				"triple-beam": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 6.4.0"
-			}
-		},
-		"node_modules/winston-transport/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/winston/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/workbox-background-sync": {
 			"version": "6.6.0",
 			"resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-6.6.0.tgz",
@@ -26472,15 +24531,6 @@
 			"integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.4"
 			}
 		},
 		"node_modules/y18n": {

--- a/react-starter-template/package-lock.json
+++ b/react-starter-template/package-lock.json
@@ -20,6 +20,7 @@
 				"uuid": "^8.3.2"
 			},
 			"devDependencies": {
+				"@fluidframework/azure-local-service": "^1.1.0",
 				"@fluidframework/build-common": "^2.0.0",
 				"@testing-library/jest-dom": "^5.13.0",
 				"@testing-library/react": "^11.2.7",
@@ -37,7 +38,6 @@
 				"puppeteer": "^21.0.0",
 				"react-scripts": "^5.0.1",
 				"start-server-and-test": "^2.0.0",
-				"tinylicious": "^1.0.0",
 				"typescript": "^4.5.5"
 			},
 			"engines": {
@@ -2797,6 +2797,421 @@
 				"uuid": "^8.3.1"
 			}
 		},
+		"node_modules/@fluidframework/azure-local-service": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-1.1.1.tgz",
+			"integrity": "sha512-gvk+qy8RytXBQaZ554OREszHGN73W3FmgpfwV+aXeOOP5RWLMPSvkPoac5K9gcUYN+nAFbRs517c055yucP9ug==",
+			"dev": true,
+			"dependencies": {
+				"tinylicious": "^0.4.89251"
+			},
+			"bin": {
+				"azure-local-service": "dist/index.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/common-utils": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@types/events": "^3.0.0",
+				"base64-js": "^1.5.1",
+				"buffer": "^6.0.3",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sha.js": "^2.4.11"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/gitresources": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
+			"integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-base": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
+			"integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/protocol-definitions": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
+			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.4001.tgz",
+			"integrity": "sha512-rERfgXK5DXGJvxADjotkAZssKgp3ZxW6u7yUekrDnFDkXtbCW1Gcq+EwvjHTEyhsOp30YBnD0Z39xnZy4zEZRw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas-driver": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/semver": "^6.0.1",
+				"assert": "^2.0.0",
+				"async": "^3.2.2",
+				"axios": "^0.26.0",
+				"buffer": "^6.0.3",
+				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
+				"json-stringify-safe": "^5.0.1",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"semver": "^6.3.0",
+				"sha.js": "^2.4.11",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-lambdas-driver": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.4001.tgz",
+			"integrity": "sha512-qRs+vMbSS9aPx7vr3XemvER5DeY/nsJ5ZkcL3UDjUOxvLZxbOAD6C6JeH3Zgzc/jc8bqshcxai/u7qso2zCsFw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"assert": "^2.0.0",
+				"async": "^3.2.2",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-local-server": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.4001.tgz",
+			"integrity": "sha512-FIlNUc9Ncul/5qzP+VyU53TJj8fxX7KZ1lweswZYalleRZwiqFA4Y+NbWRRWM0iJ1z8hvhyRZblG3iNrpGl04A==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^0.1038.4001",
+				"@fluidframework/server-memory-orderer": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@fluidframework/server-test-utils": "^0.1038.4001",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"jsrsasign": "^10.5.25",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-memory-orderer": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.4001.tgz",
+			"integrity": "sha512-fdzTCLFRh8QfyY17MnB22/o8x2XEX1+wZrm+dn+1Av+ZVe/+ZhfdX5LsQCMKYv+X5mgAauNmC/12mQE4H6jvsQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-lambdas": "^0.1038.4001",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/debug": "^4.1.5",
+				"@types/double-ended-queue": "^2.1.0",
+				"@types/lodash": "^4.14.118",
+				"@types/node": "^14.18.0",
+				"@types/ws": "^6.0.1",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1",
+				"ws": "^7.4.6"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-client": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
+			"integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"axios": "^0.26.0",
+				"crc-32": "1.2.0",
+				"debug": "^4.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"jsrsasign": "^10.5.25",
+				"jwt-decode": "^3.0.0",
+				"querystring": "^0.2.0",
+				"sillyname": "^0.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-core": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.4001.tgz",
+			"integrity": "sha512-nuZ9ebvyeIoRdlpQQpBNGkawKtc2/tHKbc8CHbMZRMh7F7kwYUtoHd/J8powb9eUcg5IHDmXx1l+PQRbQX4vCg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@types/nconf": "^0.10.2",
+				"@types/node": "^14.18.0",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"nconf": "^0.12.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-shared": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.4001.tgz",
+			"integrity": "sha512-vDRB2G/Xnuhan+Ri0Eg5JMKfsm7hxstCXdEyQhzJzC7+bw66wts+ZIsEsn4Ha/3KkxblF/RSW3lBhrYpxii3cQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"@socket.io/redis-adapter": "^7.2.0",
+				"body-parser": "^1.17.1",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"ioredis": "^4.24.2",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"notepack.io": "^2.3.0",
+				"querystring": "^0.2.0",
+				"socket.io": "^4.5.3",
+				"socket.io-adapter": "^2.4.0",
+				"socket.io-parser": "^4.2.1",
+				"uuid": "^8.3.1",
+				"winston": "^3.6.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-telemetry": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.4001.tgz",
+			"integrity": "sha512-2leJhB04+71RTmC5ShRXm/4FWng9tLn9dlrUAjApZH4RlUJAx1JGsvo/5JU1tIbpUutMHUle2IpWyfu/RV+S5g==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"json-stringify-safe": "^5.0.1",
+				"path-browserify": "^1.0.1",
+				"serialize-error": "^8.1.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-services-utils": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.4001.tgz",
+			"integrity": "sha512-K7X/0mlonDAu0pPIgTz8U9nLwRSbJY2oBpFPwpkp1UtE6SU02jx2ZzraT9epDmOl3EXeS1rHzA+mbvBSe1aFMg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"debug": "^4.1.1",
+				"express": "^4.17.3",
+				"ioredis": "^4.24.2",
+				"json-stringify-safe": "^5.0.1",
+				"jsonwebtoken": "^9.0.0",
+				"morgan": "^1.8.1",
+				"nconf": "^0.12.0",
+				"serialize-error": "^8.1.0",
+				"sillyname": "^0.1.0",
+				"split": "^1.0.0",
+				"uuid": "^8.3.1",
+				"winston": "^3.6.0",
+				"winston-transport": "^4.5.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@fluidframework/server-test-utils": {
+			"version": "0.1038.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.4001.tgz",
+			"integrity": "sha512-qrLp5H1UUPIJSEHlzZ1iYlPFJCQrd2WnmoafxnQIg0mfU1ZE8XUlG5MKUg8bT9pWsCoEGJDiOkkRHaq+WXupjQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.1.1",
+				"@fluidframework/gitresources": "^0.1038.4001",
+				"@fluidframework/protocol-base": "^0.1038.4001",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1038.4001",
+				"@fluidframework/server-services-core": "^0.1038.4001",
+				"@fluidframework/server-services-telemetry": "^0.1038.4001",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"string-hash": "^1.1.3",
+				"uuid": "^8.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@types/node": {
+			"version": "14.18.63",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/@types/semver": {
+			"version": "6.2.5",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.5.tgz",
+			"integrity": "sha512-NAxro9/RqWXTqdSjccDZAjA4nXK+6zRun+HvibYJfGy8TQhpOC7Vv6v2rlHYKrT0Q8jGGoNRd/xVdHRIQRNlFQ==",
+			"dev": true
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/denque": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/ioredis": {
+			"version": "4.28.5",
+			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
+			"integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+			"dev": true,
+			"dependencies": {
+				"cluster-key-slot": "^1.1.0",
+				"debug": "^4.3.1",
+				"denque": "^1.1.0",
+				"lodash.defaults": "^4.2.0",
+				"lodash.flatten": "^4.4.0",
+				"lodash.isarguments": "^3.1.0",
+				"p-map": "^2.1.0",
+				"redis-commands": "1.7.0",
+				"redis-errors": "^1.2.0",
+				"redis-parser": "^3.0.0",
+				"standard-as-callback": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ioredis"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/split": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"dev": true,
+			"dependencies": {
+				"through": "2"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/tinylicious": {
+			"version": "0.4.94771",
+			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
+			"integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^1.0.0",
+				"@fluidframework/gitresources": "^0.1038.1000",
+				"@fluidframework/protocol-base": "^0.1038.1000",
+				"@fluidframework/protocol-definitions": "^1.0.0",
+				"@fluidframework/server-lambdas": "^0.1038.1000",
+				"@fluidframework/server-local-server": "^0.1038.1000",
+				"@fluidframework/server-memory-orderer": "^0.1038.1000",
+				"@fluidframework/server-services-client": "^0.1038.1000",
+				"@fluidframework/server-services-core": "^0.1038.1000",
+				"@fluidframework/server-services-shared": "^0.1038.1000",
+				"@fluidframework/server-services-telemetry": "^0.1038.1000",
+				"@fluidframework/server-services-utils": "^0.1038.1000",
+				"@fluidframework/server-test-utils": "^0.1038.1000",
+				"agentkeepalive": "^4.2.1",
+				"axios": "^0.26.0",
+				"body-parser": "^1.17.1",
+				"charwise": "^3.0.1",
+				"compression": "^1.7.2",
+				"cookie-parser": "^1.4.3",
+				"cors": "^2.8.4",
+				"detect-port": "^1.3.0",
+				"express": "^4.16.3",
+				"isomorphic-git": "^1.8.2",
+				"json-stringify-safe": "^5.0.1",
+				"level": "^8.0.0",
+				"level-sublevel": "6.6.4",
+				"lodash": "^4.17.21",
+				"morgan": "^1.8.1",
+				"nconf": "^0.12.0",
+				"socket.io": "^4.5.0",
+				"split": "^1.0.0",
+				"uuid": "^8.3.2",
+				"winston": "^3.6.0"
+			},
+			"bin": {
+				"tinylicious": "dist/index.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service/node_modules/ws": {
+			"version": "7.5.9",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.3.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@fluidframework/build-common": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-2.0.0.tgz",
@@ -3165,381 +3580,6 @@
 				"uuid": "^8.3.1"
 			}
 		},
-		"node_modules/@fluidframework/server-lambdas": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-1.0.1.tgz",
-			"integrity": "sha512-lwVKg4dVDvbNH4ckj328z5cNu1plHhArzIMP3kpl8T94L6OubqsJ8vf3g46Wab/SjwltHC41p/wWigJapXZjqA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas-driver": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/semver": "^7.5.0",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"axios": "^0.26.0",
-				"buffer": "^6.0.3",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"semver": "^7.5.3",
-				"sha.js": "^2.4.11",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-1.0.1.tgz",
-			"integrity": "sha512-TfQ7rz2/6pW6Rq5CbGBu9ShiSKyOHg2pXX0cUVHtnuuUPsWTxQDWlVilYukyG0uxHJfE3ZDU3R1QgnWUQQmGgg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"assert": "^2.0.0",
-				"async": "^3.2.2",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas-driver/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-lambdas/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-1.0.1.tgz",
-			"integrity": "sha512-494H0PYNa6aqngyq/M46K7wlY7NHdIx1B4qcfRCRQmjJZrD9GPza3FHt2/426teBQ93F6SOKkBrMw2vbmoUUGg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.1",
-				"@fluidframework/server-memory-orderer": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@fluidframework/server-test-utils": "^1.0.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"jsrsasign": "^10.5.25",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-local-server/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-1.0.1.tgz",
-			"integrity": "sha512-zUuNICwyKC7OTSl/W9MSiwplSccnRHVmRpdxImCe5qVs+VSK1jHuIGiIzCkt6dlVNMu3WHyUXmrKCLmhJZmFeQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.1",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/debug": "^4.1.5",
-				"@types/double-ended-queue": "^2.1.0",
-				"@types/lodash": "^4.14.118",
-				"@types/node": "^16.18.16",
-				"@types/ws": "^6.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1",
-				"ws": "^7.4.6"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/@types/node": {
-			"version": "16.18.51",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.51.tgz",
-			"integrity": "sha512-LKA7ZhY30I8PiUOzBzhtnIULQTACpiEpPXLiYMWyS+tPAORf+rmXUadHZXB/KFrFyMjeHeKc1GFvLd+3f7LE3w==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-memory-orderer/node_modules/ws": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@fluidframework/server-services-client": {
 			"version": "0.1036.5001",
 			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5001.tgz",
@@ -3554,398 +3594,6 @@
 				"debug": "^4.1.1",
 				"json-stringify-safe": "^5.0.1",
 				"jsrsasign": "^10.2.0",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-1.0.1.tgz",
-			"integrity": "sha512-/Lb5ZZxb4aHtzLH3p+lrboi6TW/WD0I53di8FI4rMmn5AM7+h69BolPW7nume52t3HUi1I2Mnqhx1W8FKV8BbA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@types/nconf": "^0.10.2",
-				"@types/node": "^16.18.16",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"nconf": "^0.12.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-core/node_modules/@types/node": {
-			"version": "16.18.51",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.51.tgz",
-			"integrity": "sha512-LKA7ZhY30I8PiUOzBzhtnIULQTACpiEpPXLiYMWyS+tPAORf+rmXUadHZXB/KFrFyMjeHeKc1GFvLd+3f7LE3w==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-shared": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-1.0.1.tgz",
-			"integrity": "sha512-Z+IyqWHUk/y0aZ5cUXUoehcOiIr4qw1VkDR5i+1rnLntCRkPKk7h6FFXcWo+OBmI7D3AJOKZagMr6npezIPEmQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"@socket.io/redis-adapter": "^7.2.0",
-				"body-parser": "^1.17.1",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"ioredis": "^5.2.3",
-				"lodash": "^4.17.21",
-				"nconf": "^0.12.0",
-				"notepack.io": "^2.3.0",
-				"querystring": "^0.2.0",
-				"serialize-error": "^8.1.0",
-				"socket.io": "^4.5.3",
-				"socket.io-adapter": "^2.4.0",
-				"socket.io-parser": "^4.2.1",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-shared/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-telemetry": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-1.0.1.tgz",
-			"integrity": "sha512-qeNtIr5mnkDS5hwD9t+2kcmsRK4zxdAtR+F0j0/rZ/pBWuaVmJI6YiKC5HzWTuszW5F1VDpGnul0M8HEWyhrgQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"path-browserify": "^1.0.1",
-				"serialize-error": "^8.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-telemetry/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-1.0.1.tgz",
-			"integrity": "sha512-MzoonbJ/EQMbPi+m7/TZxWqyYzs1wxOdtN/Fe4FkaKOcHJjXR1e33iBw3YTkMQR9W8Z8E3WfSe6UVmzNDNH1TQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"debug": "^4.1.1",
-				"express": "^4.17.3",
-				"ioredis": "^5.2.3",
-				"json-stringify-safe": "^5.0.1",
-				"jsonwebtoken": "^9.0.0",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"serialize-error": "^8.1.0",
-				"sillyname": "^0.1.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.1",
-				"winston": "^3.6.0",
-				"winston-transport": "^4.5.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-services-utils/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-1.0.1.tgz",
-			"integrity": "sha512-+2ZP2pU4eq3KY5EySJhcwyAZqy9WojPhirA+fNUPKblT0fmeAn2ks6mF3d98fcxwqjMPb+5UPLRWDf7/+i1/Aw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-services-client": "^1.0.1",
-				"@fluidframework/server-services-core": "^1.0.1",
-				"@fluidframework/server-services-telemetry": "^1.0.1",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"string-hash": "^1.1.3",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/@fluidframework/server-test-utils/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
 				"jwt-decode": "^3.0.0",
 				"querystring": "^0.2.0",
 				"sillyname": "^0.1.0",
@@ -4081,12 +3729,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-			"dev": true
-		},
-		"node_modules/@ioredis/commands": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-			"integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
 			"dev": true
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
@@ -10394,15 +10036,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/denque": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-			"integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
 		"node_modules/depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -10445,6 +10078,20 @@
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
+		},
+		"node_modules/detect-port": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
+			"integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
+			"dev": true,
+			"dependencies": {
+				"address": "^1.0.1",
+				"debug": "4"
+			},
+			"bin": {
+				"detect": "bin/detect-port.js",
+				"detect-port": "bin/detect-port.js"
+			}
 		},
 		"node_modules/detect-port-alt": {
 			"version": "1.1.6",
@@ -13660,30 +13307,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/ioredis": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
-			"integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
-			"dev": true,
-			"dependencies": {
-				"@ioredis/commands": "^1.1.1",
-				"cluster-key-slot": "^1.1.0",
-				"debug": "^4.3.4",
-				"denque": "^2.1.0",
-				"lodash.defaults": "^4.2.0",
-				"lodash.isarguments": "^3.1.0",
-				"redis-errors": "^1.2.0",
-				"redis-parser": "^3.0.0",
-				"standard-as-callback": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=12.22.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ioredis"
 			}
 		},
 		"node_modules/ip": {
@@ -18771,6 +18394,12 @@
 			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
 			"dev": true
 		},
+		"node_modules/lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+			"dev": true
+		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -19853,6 +19482,15 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/p-map": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/p-retry": {
@@ -23002,6 +22640,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/redis-commands": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
+			"dev": true
+		},
 		"node_modules/redis-errors": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
@@ -25169,142 +24813,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
 			"integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-		},
-		"node_modules/tinylicious": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-1.0.0.tgz",
-			"integrity": "sha512-ACL8mEKT5LPbFyAXCDjYWqi3vcNef7y2ABMnU3O4jK1cRuEn0MywH7ppMM5ZrMgtSMMsJAINcWxZjpq3ndH8hg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.0",
-				"@fluidframework/protocol-base": "^1.0.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/server-lambdas": "^1.0.0",
-				"@fluidframework/server-local-server": "^1.0.0",
-				"@fluidframework/server-memory-orderer": "^1.0.0",
-				"@fluidframework/server-services-client": "^1.0.0",
-				"@fluidframework/server-services-core": "^1.0.0",
-				"@fluidframework/server-services-shared": "^1.0.0",
-				"@fluidframework/server-services-telemetry": "^1.0.0",
-				"@fluidframework/server-services-utils": "^1.0.0",
-				"@fluidframework/server-test-utils": "^1.0.0",
-				"agentkeepalive": "^4.2.1",
-				"axios": "^0.26.0",
-				"body-parser": "^1.17.1",
-				"charwise": "^3.0.1",
-				"compression": "^1.7.2",
-				"cookie-parser": "^1.4.3",
-				"cors": "^2.8.4",
-				"detect-port": "^1.3.0",
-				"express": "^4.17.3",
-				"isomorphic-git": "^1.8.2",
-				"json-stringify-safe": "^5.0.1",
-				"level": "^8.0.0",
-				"level-sublevel": "6.6.4",
-				"lodash": "^4.17.21",
-				"morgan": "^1.8.1",
-				"nconf": "^0.12.0",
-				"socket.io": "^4.5.0",
-				"split": "^1.0.0",
-				"uuid": "^8.3.2",
-				"winston": "^3.6.0"
-			},
-			"bin": {
-				"tinylicious": "dist/index.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/common-utils": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
-			"integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@types/events": "^3.0.0",
-				"base64-js": "^1.5.1",
-				"buffer": "^6.0.3",
-				"events": "^3.1.0",
-				"lodash": "^4.17.21",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/gitresources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-1.0.1.tgz",
-			"integrity": "sha512-zs4RKtlgGaEgd6YvFeLtk5FeG9UslGV05TTDWHJm1T8ZCu1b3nopoivsvpID0boHmMFlJ5cpdI2RYHZ1kLgu9A==",
-			"dev": true
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/protocol-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-1.0.1.tgz",
-			"integrity": "sha512-IBGhTCbgbosD0c6KWwWX24YbyEPE7oKR3jkKwdfOHBwnD0NvUOmlADE3MwWqUDLAoGBaEFAG6WNZFA7voKWbJA==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"events": "^3.1.0"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.2.0.tgz",
-			"integrity": "sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
-		},
-		"node_modules/tinylicious/node_modules/@fluidframework/server-services-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-1.0.1.tgz",
-			"integrity": "sha512-JQAHY+LEMoy+tZI0L9+Yx5McmWezQ6Xso2XERW1jt4F9BE3IaXDmX5WJLwhWUY+SzfCZDIt0Tm2HROqasnR/Qg==",
-			"dev": true,
-			"dependencies": {
-				"@fluidframework/common-utils": "^1.1.1",
-				"@fluidframework/gitresources": "^1.0.1",
-				"@fluidframework/protocol-base": "^1.0.1",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"axios": "^0.26.0",
-				"crc-32": "1.2.0",
-				"debug": "^4.1.1",
-				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
-				"jwt-decode": "^3.0.0",
-				"querystring": "^0.2.0",
-				"sillyname": "^0.1.0",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/tinylicious/node_modules/detect-port": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
-			"integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
-			"dev": true,
-			"dependencies": {
-				"address": "^1.0.1",
-				"debug": "4"
-			},
-			"bin": {
-				"detect": "bin/detect-port.js",
-				"detect-port": "bin/detect-port.js"
-			}
-		},
-		"node_modules/tinylicious/node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
 		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",

--- a/react-starter-template/package.json
+++ b/react-starter-template/package.json
@@ -37,7 +37,6 @@
 		"uuid": "^8.3.2"
 	},
 	"devDependencies": {
-		"@fluidframework/azure-local-service": "^1.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@testing-library/jest-dom": "^5.13.0",
 		"@testing-library/react": "^11.2.7",

--- a/react-starter-template/package.json
+++ b/react-starter-template/package.json
@@ -10,7 +10,7 @@
 		"ci:test": "start-server-and-test start:server 7070 ci:test:jest",
 		"ci:test:jest": "jest --ci --reporters=default --reporters=jest-junit",
 		"start": "react-scripts start",
-		"start:server": "npx tinylicious@latest",
+		"start:server": "npx tinylicious",
 		"build": "react-scripts build",
 		"test": "start-server-and-test start:server 7070 test:jest",
 		"test:jest": "jest",

--- a/react-starter-template/package.json
+++ b/react-starter-template/package.json
@@ -10,7 +10,7 @@
 		"ci:test": "start-server-and-test start:server 7070 ci:test:jest",
 		"ci:test:jest": "jest --ci --reporters=default --reporters=jest-junit",
 		"start": "react-scripts start",
-		"start:server": "npx tinylicious",
+		"start:server": "npx @fluidframework/azure-local-service",
 		"build": "react-scripts build",
 		"test": "start-server-and-test start:server 7070 test:jest",
 		"test:jest": "jest",
@@ -37,6 +37,7 @@
 		"uuid": "^8.3.2"
 	},
 	"devDependencies": {
+		"@fluidframework/azure-local-service": "^1.1.0",
 		"@fluidframework/build-common": "^2.0.0",
 		"@testing-library/jest-dom": "^5.13.0",
 		"@testing-library/react": "^11.2.7",
@@ -54,7 +55,6 @@
 		"puppeteer": "^21.0.0",
 		"react-scripts": "^5.0.1",
 		"start-server-and-test": "^2.0.0",
-		"tinylicious": "^1.0.0",
 		"typescript": "^4.5.5"
 	},
 	"eslintConfig": {


### PR DESCRIPTION
Standardizes all examples to use `@fluidframework/azure-local-service` instead of tinylicious

