### PR TITLE
Update examples

### DIFF
--- a/brainstorm/package-lock.json
+++ b/brainstorm/package-lock.json
@@ -10,14 +10,14 @@
 			"license": "MIT",
 			"dependencies": {
 				"@fluentui/react-icons": "^2.0.221",
-				"@fluidframework/azure-client": "2.0.0-rc.1.0.1",
-				"@fluidframework/telemetry-utils": "2.0.0-rc.1.0.1",
-				"@fluidframework/test-runtime-utils": "2.0.0-rc.1.0.1",
+				"@fluidframework/azure-client": "2.0.0-rc.2.0.0",
+				"@fluidframework/telemetry-utils": "2.0.0-rc.2.0.0",
+				"@fluidframework/test-runtime-utils": "2.0.0-rc.2.0.0",
 				"@types/react": "^18.2.0",
 				"@types/react-dom": "^18.2.0",
 				"axios": "^1.6.2",
 				"dotenv": "^16.0.2",
-				"fluid-framework": "2.0.0-rc.1.0.1",
+				"fluid-framework": "2.0.0-rc.2.0.0",
 				"guid-typescript": "^1.0.9",
 				"hashids": "^2.2.10",
 				"react": "^18.2.0",
@@ -29,7 +29,7 @@
 			"devDependencies": {
 				"@babel/preset-env": "^7.15.0",
 				"@fluidframework/build-common": "^2.0.0",
-				"@fluidframework/devtools": "2.0.0-rc.1.0.1",
+				"@fluidframework/devtools": "2.0.0-rc.2.0.0",
 				"@types/debug": "^4.1.7",
 				"@typescript-eslint/eslint-plugin": "^5.38.0",
 				"@typescript-eslint/parser": "^5.38.0",
@@ -2112,60 +2112,58 @@
 			}
 		},
 		"node_modules/@fluid-internal/client-utils": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-O4nqXfHQKEOiz2qzt/ipyGzQ7AVx8S58fnIN7ah1l+ziz3VJL10uFECAqw9y8zJx3QNIr2NIsBByW0L8DxKl+A==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-8+J9NS62coRUUxzcab0pLdOHS0OvfmM1iBJ8thi+JtYX4Asvcf/+He/vpJcxLRAL+aipQbHkkFAsi79JCAUF2w==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@types/events": "^3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@types/events_pkg": "npm:@types/events@^3.0.0",
 				"base64-js": "^1.5.1",
 				"buffer": "^6.0.3",
-				"events": "^3.1.0",
+				"events_pkg": "npm:events@^3.1.0",
 				"lodash": "^4.17.21",
 				"sha.js": "^2.4.11"
 			}
 		},
 		"node_modules/@fluidframework/aqueduct": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-OSG+g71OPW7PMcHeIS/fUjY63+U2OpWW3/TxTJug3hWQPw1nTaguXC9N2iBP6+IfdIdlGueC9S06DI2RSumZhw==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-0Xgn1rYMBIanP8JzQjjXUpF9FNytRhs00qArSAqaVJcnWxYI1Ovt0qfl7RpiflUOLwkwWsua828qJyqLGB+96g==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/map": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/synthesize": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"uuid": "^9.0.0"
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-runtime": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/map": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/request-handler": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/synthesize": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/azure-client": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-RGlpDBtZvyl3ngZMtaXIuMk1uNabXwa1cxrYkS4mdBDf9K2Y1iNN5aoTuOarUO4y6tS+Yn1K/7uDaKHIShPeqw==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-uDwHon+lPeCvqyeB0OYK8ntH1apHro4MLb7xMiUq0bUUZ4DFAJMAKjdKeK51DNZsn1SZ/gGn/XLyniT+RvLZCQ==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/map": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/server-services-client": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-loader": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/fluid-static": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/map": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/server-services-client": "^4.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"axios": "^1.6.2"
 			}
 		},
@@ -2179,18 +2177,18 @@
 			}
 		},
 		"node_modules/@fluidframework/cell": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-cn4ZsR7kmzEu7JO5iUBcXw36M1eGCjvLe2zNwjrAmzs9Zf6WH2JEIxhFWWn5sa+3cY+5USNPN2FIoA2dP0qnsg==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-4zLe3nGlHi79qsAo++kgzOPMk4CP193HigkSO0DpziLCpEUqHOGGUOMAofISeUyJfCwFtbBZwxHIBZiQSyEc7A==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/common-definitions": {
@@ -2213,282 +2211,280 @@
 			}
 		},
 		"node_modules/@fluidframework/container-definitions": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-0IU+gArPIEI5Xfakt2ROgmJ7AbzSfXNX0mQicyzW/5Wgml8y/sIWOvK/7jwB1l+M8XW3+tdDECOHgTw2+Mix/A==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-jsdYc2FW1/Fim5bp1BkLOP7LZlMggWRnUx7zG5iN5UrtyZUl+OTAJvTbiakjTQzx5obVuf1w3VxJpXXthVepzQ==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"events": "^3.1.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@types/events_pkg": "npm:@types/events@^3.0.0"
 			}
 		},
 		"node_modules/@fluidframework/container-loader": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-5XU3/dORkmhkpu1LTb7rtKRsVscHET17DNy7yhpDypK3oS00wl8OmrBOzDvjWpWebqTy2eYHzdA47GpVW3hOKg==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-x8Kf+r0qlq7QiLmWjINifXk55584zEAy5JFSH/1PS+XUMPQJNn12rXXLJ+gemkvSZMctr+2qytkS09MhieuEzA==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-base": "^3.0.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-base": "^4.0.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@ungap/structured-clone": "^1.2.0",
 				"debug": "^4.3.4",
 				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"url": "^0.11.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/container-runtime": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-v9zmxvZaX30yeKh9pUB4Hh5qOw7CbIn+vo+y8SIRmGlTzvxpse5bkEbNYVORnRvy0ItwOqd4bFFEMP5uKsIn5w==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-pG5P4+ZFk/zT17mBnWF3ushY16R82myw1XdPlAAnzM0YfZiJz/OqVuJ0u5y/tYUCCKTYWG6YgYB+6R8KlOgsgw==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/id-compressor": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/id-compressor": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"@tylerbu/sorted-btree-es6": "^1.8.0",
 				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
 				"lz4js": "^0.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/container-runtime-definitions": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-1RfFTxUrKy0EjVlKYZPw5jbX6dpATpkFvZtRnndSBfyAuTJaJfxZgcCZAE5FMlX3YH0Jb7jAEGifGkm8qN4xoQ==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-gs/17ogpoXqj5w/RYOmFd0Ccd2R5R+tXJMDnsvRrEuTOqxKRkdS4i2LpK0m2bJN8ffNhyJMfFcPKDC7JJQ8MLg==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/core-interfaces": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-Xazv2hOxnQ/TBBlEC4zYUq4DGG+i8zdzhfoPr3xkj+fiOle1R6r2qG5SO6tzEVqXDNzefO/76YUNSYwgNJHWww=="
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-aFfzQ17IWF1aC9Df6P/tPsEtf1ZO66q4Jy40zlDVm1R2l374sdLUiUTzCH2VQw8JxZN4I9UBS9fl9BGCYMt8WQ=="
 		},
 		"node_modules/@fluidframework/core-utils": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-FCNN2cH5IYzODuSyk6F3creB2ssZAhpII4KSOxcPsUElZu7BAAMME04uvHleOkMOh/LfQW8NNnP1XvHt7+Z3GA=="
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-zr1mFtVMu6G4okuY0rpGv2rOwstZOaZeGCIy7qE/FN1rmHRK/eI3lZRJyynPbE5ldk0hfCLu0JmE9QMBJ6DLxw=="
 		},
 		"node_modules/@fluidframework/counter": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-7UXfPO/Eo4FtuC3YKPrEzQ7lr8p+Q8vCZiifFly+qVG1CpX0Pcg15J9u49VWOmS1VHyz8b9ym1qmA3sTfo1tDg==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-b57+GqDNTj3GLeMkpvfrQDk0AHgKi2Lmp/UJ3/umDoq5TJPau4pJ/Z90ccLztnm5K+NwiMMY637SW6S2ApoUVQ==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/datastore": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-Odbi46ET26auOehT89nPvgF091afIaXNhbxsrfgE65KcPRVQUnNfhYZo760fZDdRUKJpQwPLZZ3DFFAtFVLQTA==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-yHQcQbYT5dU80TeNwIBss3Xz+lFk7SEHtUF1ZdCMaIEytOEVbVMzchMGhccKGOr6w6TMHDMTCYB93sxcr6mTuw==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/id-compressor": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"lodash": "^4.17.21",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/datastore-definitions": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-IR6WBHxhfs+4P+vsZuAuY6zMUouCvqEvolDIgD13t2tx1FFq3yMzPfuwRAv7gHkkm65lkOJQ8XDgjfLBugTX9g==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-AS1x1Ek0+taEoe9djwJ26Yh26po+bKbjWz1cxhob1T+nCzP+LlFGAyE9uLElXOhX7O3twSO6vSbOWVIM5PK5VA==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/id-compressor": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/id-compressor": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/devtools": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/devtools/-/devtools-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-JXZJuqoVk0Pk/I/uhVX4YtKHpNC4POId6zXUYnhISvDxCOA2N6nLVTkvzu8yCPktzGvDwrzTVZikjLghE0WwrQ==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/devtools/-/devtools-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-KP/r7sCMQ72C4Op/ASRZiBCQzjRZVa0joj1QvZ5xcj22r4c3SfeetLQ2UtM0X4aqFKCYK7baClD7fdKamz9SuQ==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/devtools-core": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/devtools-core": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/fluid-static": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/devtools-core": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/devtools-core/-/devtools-core-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-RmEEbCqk0v27dI7ePMYvK19viXCzUW04Spw11aBkGwoJIgwUVuMPX2UqsBkL3nkMghkzxd6auldZhXKixKzS8g==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/devtools-core/-/devtools-core-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-rl/Nx7uFTH6AyegwoJ9XYeleAxCSmruJMeZdVNJWZxXDYSjt/PxIHtHLaLGOXWTlNemaDFd6xtWuWMPlZZZNrg==",
 			"dev": true,
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/cell": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/counter": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/map": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/matrix": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/sequence": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/tree": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/cell": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-loader": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/counter": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/map": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/matrix": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/sequence": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/tree": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-base": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-awS0Y80bvXc+iD5Npzx/7uPXcPAAuFmDdb0At8SKukl36Es/m06WKTc1eGxuAW9tXKeCmezqxp0hnxSbESFadQ==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-DcGq/c9WTFY85qcxub7wokkBg8kUPlMAX3V6DsXQtXaerbjizF8VXeOSNjDcm4K0CahZCXLP8db2dQlAt2iFNA==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-definitions": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-nqfhZUvSJGzNbHMLpPTFkrM/rjtslU5igqVuqm7PQSp8sNaDkzGmttCPI8xFVJlmYxHQ7Onclo+c5BX+Eg5X3Q==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-2xIvYEb8q7XjxEL7F6I0vyelCxnLxI34kjfd9fT+NG0nTAbJtLtLpIVKz1EXJSYSXm2mp+nm4HDPwoB3OvSUgA==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-utils": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-Y+MkC7Ks4Akh5mhS/Oa3SLrYzELnPLFp5o1ZRhkxlAo3bZF4HCJmHNiDD6KvFa7zaH+VmVBxFmMUkcSZ/ktJrQ==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-kl5t2zjeSTRcGzY56fcqfWoai+AtuK0KGfoIEVuKkmhLvdbDMWhfzfG4RyT7snvFvxQevGNBigZtVXY3UsIlkg==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/gitresources": "^3.0.0",
-				"@fluidframework/protocol-base": "^3.0.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/gitresources": "^4.0.0",
+				"@fluidframework/protocol-base": "^4.0.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"axios": "^1.6.2",
 				"lz4js": "^0.2.0",
-				"url": "^0.11.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/fluid-static": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-BLnDzUqgAip0WRkJCS8UXk4NEVbZ7UEwsd7nwRKxgDTzbDvfrqbYZBdcfmF0QL88h8MXkP867l8qhOX2FmsGBw==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-972AntH1tNZ/MFcqXrlWonG010CftL8RKJLq460Mbc/eoHWH4kTtxXaKoGPkozxABsJP0yd0ut6QILctAqHHAw==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/aqueduct": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/aqueduct": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-loader": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-runtime": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/request-handler": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/gitresources": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-3.0.0.tgz",
-			"integrity": "sha512-kpbONpwCIE7q2G+Q+KTfBHUz+VneL/7tPWlYFZ96uP0dpeBVdSJdf9dgd0ILIzs6rpO6XRpceI2D503LRU6j9g=="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-4.0.0.tgz",
+			"integrity": "sha512-3E4bjOp0/el0EFIzut8fb5XDM5xF/zWKyKn8n1RLEsstMM9nktjFOhCHoP57tRsfc16p3g9GoXhtpWCwe0vqnQ=="
 		},
 		"node_modules/@fluidframework/id-compressor": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/id-compressor/-/id-compressor-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-Ny07wjM6s0SRYI7JhiUvAFPExBjCLkQSAnUcfJmnLCIuoiP58RhqiSfyovoi6WDk9I+dkMNZrgWnWlJw5z8Dzg==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/id-compressor/-/id-compressor-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-oW4oWIVRNlgnWNLHjhj+JcX2nHtzHASG5GIq4E2YsAgrBsqc6879+SRoqG+QeirKdbe4h7ycMvlu1v3xTOkfdA==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"@tylerbu/sorted-btree-es6": "^1.8.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/map": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-ILLMVPXCnLFZ58WkgTho1fCcEwId01/HeB0PaFcfnB2XHrKnR7YYPbcUku788KDf2on0SWYKl/MdWrZhsNfyrg==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-FGLFjWk2BRJ8/i05XeduZUzVZzVZ1It978i0jLI/8yEAPJornMsQAvwCH3qaZut3Htxd/vig6WErfAS0IDgktQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/merge-tree": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/merge-tree": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"node_modules/@fluidframework/matrix": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-FldhwHGzbwVYYd2wQTrNKGXaONSVh27tNcYV4WwZbWNMvUdvme/psTGcm2XXallJMo9Svnni1VAKgIfizMzPvw==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-iISwfK4F2sWLWuD9Ayy+VWxFx6x4cxHWrNw16+VLjV7geU2M2h05/f/KlWOKjkbhS2bfjJerpDcbNgKwpJLz2Q==",
 			"dev": true,
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/merge-tree": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/merge-tree": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
-				"events": "^3.1.0",
+				"double-ended-queue": "^2.1.0-0",
 				"tslib": "^1.10.0"
 			}
 		},
@@ -2499,231 +2495,221 @@
 			"dev": true
 		},
 		"node_modules/@fluidframework/merge-tree": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-clLDnz21PbJNa2agipR5KrcQdXr84Fyl65YH8YWIhaMCwqzZ9bXPR6t2FrRv7Ye/WkDL+qvAu33ohSDic9T8ZA==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-C2q46zDuZi+EiBtzVyzVgkf4xRJRjzpNKojzV7B7Sj9/cK4HSyBKAgZbzuRNzgB2ANVICqS8bzdcg+ArKaJJqw==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/protocol-base": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-3.0.0.tgz",
-			"integrity": "sha512-csvei49LHDZhD+gQ3brUZEeekQmvk/ndsBNhYnqxJeoAOlBi5MtIqyb5vA96pKd0o23cwGE5PWEfrxJcsqEmTQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-4.0.0.tgz",
+			"integrity": "sha512-mpuYXOOfCXKKEdzauxQ3KTY+ZWNj+NTEQTEJW8PD/xqN95g3AYoYXiikEkuzPbKghkAWcr6gYNxmK//MLbIVFw==",
 			"dependencies": {
 				"@fluidframework/common-utils": "^3.1.0",
-				"@fluidframework/gitresources": "~3.0.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
+				"@fluidframework/gitresources": "~4.0.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
 				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/protocol-definitions": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-3.1.0.tgz",
-			"integrity": "sha512-BgGF82z4sk5M4torMR38NGjHjFG9t6Y653UcGOlXiIaGQMDZpRfrxiIuq53Gb12OTfUgbNtvBJL1W46JfLvzQw=="
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-3.2.0.tgz",
+			"integrity": "sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA=="
 		},
 		"node_modules/@fluidframework/request-handler": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-OoCt6rGUTFl2WucMTNY2SG32w+MCTvFb1Bdqp4MM6BhdZIw6nyS/++0RSTbSXbOHa8SW1I35ExoMu9NP6x58SA==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-sAcspxSU3R70gBJIc58OrRny66rGJk0B5qRTeJUd0dD42y+YHf9wriwNWb9DuckkwUkF9nSMdEvPX6n1ury6IQ==",
 			"dependencies": {
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/routerlicious-driver": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-VaKa0ZDikUAwib7VHJyUNilethdCNab1rxQ8nD3BiRGN28WvDPSAjKH0rLEXsuC60BN1k711G0/meH+y6ZD7rw==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-SchvLvYYA40fdVOSriL26Rfts3b2NBpDVaIf1o98UEaE9eg6Q2dSrE691EYweI7N9LLCm0tWMX5U+O62oNv5KQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-base": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/gitresources": "^3.0.0",
-				"@fluidframework/protocol-base": "^3.0.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/server-services-client": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-base": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/gitresources": "^4.0.0",
+				"@fluidframework/protocol-base": "^4.0.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/server-services-client": "^4.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
-				"socket.io-client": "^4.6.1",
-				"url-parse": "^1.5.8",
+				"socket.io-client": "^4.7.3",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/runtime-definitions": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-vEVkHwAP5ew3dczz3d3KjyF161BUU5RVNF56monmLxDbSxful1uCq6Lz7ytC4vyGo2d1SSbTpkvE9OKbupsKnw==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-Ciq+bJjS0fZBWnRMhMITWh4tAC97l//qfoxN/1wTnHTDYwJjmkflqYVdpYMDxtKFdN1eU7wEHDDiCvsl/NILPQ==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/id-compressor": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0"
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/id-compressor": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0"
 			}
 		},
 		"node_modules/@fluidframework/runtime-utils": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-9maXqcCtcDt+BDLCssqBhsdDUZtIzNY9cm7+2i3IoKXnRCbezgBI8V1E88AnNOv9EDWj9Hq9cOe/sXH4N5U1Gw==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-s2gd2AF04TzU9aPbvw7MAy3JXuI4FBVvoJ69dP7J1K0zi2wQ7ROlsNNEp4OMn/IGhWur2IATtnvUuOFfl8dc4w==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/sequence": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-7YatZ+1nNwbgIyZi6vWrxlc4GVkNxDRrEzB7hMuHqMk3fa2Pyno8IzCjeV19uL5wUj9i/F7WgoIVm1kegP4U6Q==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-H5cwW0qrXSzufE2yQjls6fg2uFvKKvtNVjso+YEfYx731l0+swN7E5WKAH2TDLI7DJygoc6TpJkcSUA3+25RGQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/merge-tree": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/merge-tree": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/server-services-client": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-3.0.0.tgz",
-			"integrity": "sha512-obsH2oYOkmvQoOSuluwEwiViOuZe3wNBNBWxuUHkGKmfeg1xU5Ko2Sj5/0Ku45f5EY8puRenlApCTS/2mKhSaw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-4.0.0.tgz",
+			"integrity": "sha512-ExvztSQrliaYMSeLLxlACdWkuDk6auDle4eIQ2euvkgl0RWnupatPYgUVdfnNMIE6vBIeOwDzJaWy2giFx7Z6Q==",
 			"dependencies": {
 				"@fluidframework/common-utils": "^3.1.0",
-				"@fluidframework/gitresources": "~3.0.0",
-				"@fluidframework/protocol-base": "~3.0.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
+				"@fluidframework/gitresources": "~4.0.0",
+				"@fluidframework/protocol-base": "~4.0.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
 				"axios": "^1.6.2",
 				"crc-32": "1.2.0",
 				"debug": "^4.3.4",
 				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
+				"jsrsasign": "^11.0.0",
 				"jwt-decode": "^4.0.0",
-				"querystring": "^0.2.0",
 				"sillyname": "^0.1.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/shared-object-base": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-sR9lueWM6MGI1BS9pTv4XJ251WyiK5Q4s7qUH2M3N9ruMOLchSBwaJw/PzLuZ6494daH2dX4bD0VrNponFO8tQ==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-Ld3IUskCkdL2KBTOAPQvGn6vNVXMM5SWaDYdKbchKoPvuY3dWMCgakXjQ5STGHp7q5CUrPgQ+96PxbdfFYo+GA==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-runtime": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/synthesize": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-ZbFIoScFmGsIFDpPcozMb7VW5wrPdOi6/WAp3/oYVobTYneDhQu8oAHMMdZQhuFxV0PmQqk2oa7E6FXhS/nDNw==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-eqkzLgS08RX+/PUZwqrqKt5o5Lak48GpFsJmMylNXDq5KiuHJoMJ51W6+hi3aI4UYfwt8fRr+3KvbE3/QFmRNA==",
 			"dependencies": {
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/telemetry-utils": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-AHGK8pPUUGfE9L3lDpQN6JRS2s3oKEQGktH2lNu85f5zjMPUhLV6ZIIwt5G2ILbNpZuLuyEjQkaSEXlpxGFt6g==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-OILipzJ1XBCjLeY+tOdt+bnOrX5zM+SKM8q4OsG8Qq9miwpbai1Ah830nMTYXEvlmdcbgrmBmRPtW8bs5MHVUA==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
 				"debug": "^4.3.4",
-				"events": "^3.1.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/test-runtime-utils": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-BpHdmliCp3824s1C9HEz+Tuq+rqJ7Tx8Fqjv3FtbIAk5ikLbqfgFedt1+j3lyAjsQGut6DhAV3bGRiPZY9UYQA==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-8LgccYD3x2jzIYbZioQbZ4ImQgiKRicJ9YH/wdx5ZjWVAF4Xu7RVS0m77sP9gNUo+h2fmh3DzdRaZp/5KXKzaQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/id-compressor": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"events": "^3.1.0",
-				"jsrsasign": "^10.5.25",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/id-compressor": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"jsrsasign": "^11.0.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/tree": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tree/-/tree-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-fTJB8lg1tx3jaytQKy4tcTd2zpFri5UNlRVnlnr7TSEWWjPV0dzXditbw4qTdj3YdG6l/yLMyJ/jwr1TRwCEfw==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tree/-/tree-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-mRkj+Qs5mpNGJyl+7xFj4VgsgYgv2C2NyglIb1T5fvFaZ6AoI1n7miDQzYri6PPJpNswbIKYT+JI8DTw7as8Sw==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/id-compressor": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-runtime": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/id-compressor": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"@sinclair/typebox": "^0.29.4",
 				"@tylerbu/sorted-btree-es6": "^1.8.0",
 				"@ungap/structured-clone": "^1.2.0",
 				"uuid": "^9.0.0"
-			}
-		},
-		"node_modules/@fluidframework/view-interfaces": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-6lGwNkN6Gx/y9KnlXdcg/ypQVkqyU1SjtzLUK5+3p5tUrPSD9p+xRA6z63GdluNDNV+z30Kk4NHs/k2XuAiSbg==",
-			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
 			}
 		},
 		"node_modules/@griffel/core": {
@@ -3530,6 +3516,12 @@
 			"dev": true
 		},
 		"node_modules/@types/events": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
+			"integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g=="
+		},
+		"node_modules/@types/events_pkg": {
+			"name": "@types/events",
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
 			"integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g=="
@@ -5052,6 +5044,7 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
 			"integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.2",
 				"get-intrinsic": "^1.2.1",
@@ -5832,6 +5825,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
 			"integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+			"dev": true,
 			"dependencies": {
 				"get-intrinsic": "^1.2.1",
 				"gopd": "^1.0.1",
@@ -6201,9 +6195,9 @@
 			}
 		},
 		"node_modules/engine.io-parser": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
-			"integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
+			"integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==",
 			"engines": {
 				"node": ">=10.0.0"
 			}
@@ -6705,6 +6699,15 @@
 				"node": ">=0.8.x"
 			}
 		},
+		"node_modules/events_pkg": {
+			"name": "events",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"engines": {
+				"node": ">=0.8.x"
+			}
+		},
 		"node_modules/execa": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -7180,23 +7183,23 @@
 			"dev": true
 		},
 		"node_modules/fluid-framework": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-4M0dXUxT1G86yWToJ7vNHt04NhJLOzZAJAtEXCld/lcQy31O+qyRFsKKXTLl/pcJPjrXIl9g+Quh/HWQFIDf6g==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-4GEdwpOQCR5DWv6SiQKolMp+s2rn2ekTf501IVsateIHLRPGD7kXjk5mMB1ooheegrq+xIpAHfGviYMtscTe1A==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/map": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/sequence": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/tree": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-loader": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/fluid-static": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/map": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/sequence": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/tree": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.4",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-			"integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+			"version": "1.15.6",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+			"integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
 			"funding": [
 				{
 					"type": "individual",
@@ -7311,6 +7314,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -7364,6 +7368,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
 			"integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.2",
 				"has-proto": "^1.0.1",
@@ -7558,6 +7563,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
 			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+			"dev": true,
 			"dependencies": {
 				"get-intrinsic": "^1.1.3"
 			},
@@ -7610,6 +7616,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
 			"integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+			"dev": true,
 			"dependencies": {
 				"get-intrinsic": "^1.2.2"
 			},
@@ -7621,6 +7628,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
 			"integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -7632,6 +7640,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
 			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -7663,6 +7672,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
 			"integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.2"
 			},
@@ -8099,9 +8109,9 @@
 			}
 		},
 		"node_modules/ip": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-			"integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
+			"integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
 			"dev": true
 		},
 		"node_modules/ipaddr.js": {
@@ -9485,9 +9495,9 @@
 			}
 		},
 		"node_modules/jsrsasign": {
-			"version": "10.9.0",
-			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.9.0.tgz",
-			"integrity": "sha512-QWLUikj1SBJGuyGK8tjKSx3K7Y69KYJnrs/pQ1KZ6wvZIkHkWjZ1PJDpuvc1/28c1uP0KW9qn1eI1LzHQqDOwQ==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.1.0.tgz",
+			"integrity": "sha512-Ov74K9GihaK9/9WncTe1mPmvrO7Py665TUfUKvraXBpu+xcTWitrtuOwcjf4KMU9maPaYn0OuaWy0HOzy/GBXg==",
 			"funding": {
 				"url": "https://github.com/kjur/jsrsasign#donations"
 			}
@@ -10138,6 +10148,7 @@
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
 			"integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -11105,34 +11116,6 @@
 				}
 			]
 		},
-		"node_modules/qs": {
-			"version": "6.11.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
-			"integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
-			"dependencies": {
-				"side-channel": "^1.0.4"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/querystring": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-			"integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
-			"deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-			"engines": {
-				"node": ">=0.4.x"
-			}
-		},
-		"node_modules/querystringify": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -11528,7 +11511,8 @@
 		"node_modules/requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+			"dev": true
 		},
 		"node_modules/resolve": {
 			"version": "2.0.0-next.5",
@@ -11971,6 +11955,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
 			"integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+			"dev": true,
 			"dependencies": {
 				"define-data-property": "^1.1.1",
 				"get-intrinsic": "^1.2.1",
@@ -12059,6 +12044,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
 			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.0",
 				"get-intrinsic": "^1.0.2",
@@ -12105,9 +12091,9 @@
 			}
 		},
 		"node_modules/socket.io-client": {
-			"version": "4.7.3",
-			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.3.tgz",
-			"integrity": "sha512-nU+ywttCyBitXIl9Xe0RSEfek4LneYkJxCeNnKCuhwoH4jGXO1ipIUw/VA/+Vvv2G1MTym11fzFC0SxkrcfXDw==",
+			"version": "4.7.5",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.5.tgz",
+			"integrity": "sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==",
 			"dependencies": {
 				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.3.2",
@@ -12179,9 +12165,9 @@
 			}
 		},
 		"node_modules/socks/node_modules/ip": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-			"integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+			"integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
 			"dev": true
 		},
 		"node_modules/source-list-map": {
@@ -13290,29 +13276,6 @@
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
-		},
-		"node_modules/url": {
-			"version": "0.11.3",
-			"resolved": "https://registry.npmjs.org/url/-/url-0.11.3.tgz",
-			"integrity": "sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==",
-			"dependencies": {
-				"punycode": "^1.4.1",
-				"qs": "^6.11.2"
-			}
-		},
-		"node_modules/url-parse": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-			"dependencies": {
-				"querystringify": "^2.1.1",
-				"requires-port": "^1.0.0"
-			}
-		},
-		"node_modules/url/node_modules/punycode": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
 		},
 		"node_modules/urlpattern-polyfill": {
 			"version": "9.0.0",

--- a/brainstorm/package.json
+++ b/brainstorm/package.json
@@ -15,21 +15,21 @@
 		"lint": "eslint src",
 		"webpack": "cross-env FLUID_CLIENT='azure' webpack",
 		"start": "npm run dev",
-		"start:server": "npx @fluidframework/azure-local-service@2.0.0-rc.1.0.1"
+		"start:server": "npx @fluidframework/azure-local-service@2.0.0-rc.2.0.0"
 	},
 	"engines": {
 		"node": ">=18.0.0"
 	},
 	"dependencies": {
 		"@fluentui/react-icons": "^2.0.221",
-		"@fluidframework/azure-client": "2.0.0-rc.1.0.1",
-		"@fluidframework/telemetry-utils": "2.0.0-rc.1.0.1",
-		"@fluidframework/test-runtime-utils": "2.0.0-rc.1.0.1",
+		"@fluidframework/azure-client": "2.0.0-rc.2.0.0",
+		"@fluidframework/telemetry-utils": "2.0.0-rc.2.0.0",
+		"@fluidframework/test-runtime-utils": "2.0.0-rc.2.0.0",
 		"@types/react": "^18.2.0",
 		"@types/react-dom": "^18.2.0",
 		"axios": "^1.6.2",
 		"dotenv": "^16.0.2",
-		"fluid-framework": "2.0.0-rc.1.0.1",
+		"fluid-framework": "2.0.0-rc.2.0.0",
 		"guid-typescript": "^1.0.9",
 		"hashids": "^2.2.10",
 		"react": "^18.2.0",
@@ -41,7 +41,7 @@
 	"devDependencies": {
 		"@babel/preset-env": "^7.15.0",
 		"@fluidframework/build-common": "^2.0.0",
-		"@fluidframework/devtools": "2.0.0-rc.1.0.1",
+		"@fluidframework/devtools": "2.0.0-rc.2.0.0",
 		"@types/debug": "^4.1.7",
 		"@typescript-eslint/eslint-plugin": "^5.38.0",
 		"@typescript-eslint/parser": "^5.38.0",

--- a/brainstorm/src/index.tsx
+++ b/brainstorm/src/index.tsx
@@ -13,7 +13,6 @@ import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { initializeDevtools } from "@fluidframework/devtools";
 import { devtoolsLogger } from "./infra/clientProps";
-import { ITree } from "fluid-framework";
 import { appTreeConfiguration } from "./schema/app_schema";
 import { sessionTreeConfiguration } from "./schema/session_schema";
 
@@ -33,10 +32,8 @@ async function start() {
 	const { services, container } = await loadFluidData(containerId, notesContainerSchema);
 
 	// Initialize the SharedTree DDSes
-	const sessionTree = (container.initialObjects.sessionData as ITree).schematize(
-		sessionTreeConfiguration,
-	);
-	const appTree = (container.initialObjects.appData as ITree).schematize(appTreeConfiguration);
+	const sessionTree = container.initialObjects.sessionData.schematize(sessionTreeConfiguration);
+	const appTree = container.initialObjects.appData.schematize(appTreeConfiguration);
 
 	// Initialize debugging tools
 	initializeDevtools({

--- a/brainstorm/src/infra/containerSchema.ts
+++ b/brainstorm/src/infra/containerSchema.ts
@@ -8,9 +8,9 @@ import { ContainerSchema, SharedTree } from "fluid-framework";
 // Define the schema of our Container. This includes the DDSes/DataObjects
 // that we want to create dynamically and any
 // initial DataObjects we want created when the container is first created.
-export const notesContainerSchema: ContainerSchema = {
+export const notesContainerSchema = {
 	initialObjects: {
 		appData: SharedTree,
 		sessionData: SharedTree,
 	},
-};
+} satisfies ContainerSchema;

--- a/brainstorm/src/infra/fluid.ts
+++ b/brainstorm/src/infra/fluid.ts
@@ -15,14 +15,14 @@ const client = new AzureClient(clientProps);
  *
  * @returns The loaded container and container services.
  */
-export const loadFluidData = async (
+export async function loadFluidData<T extends ContainerSchema>(
 	containerId: string,
-	containerSchema: ContainerSchema,
+	containerSchema: T,
 ): Promise<{
 	services: AzureContainerServices;
-	container: IFluidContainer;
-}> => {
-	let container: IFluidContainer;
+	container: IFluidContainer<T>;
+}> {
+	let container: IFluidContainer<T>;
 	let services: AzureContainerServices;
 
 	// Get or create the document depending if we are running through the create new flow
@@ -36,4 +36,4 @@ export const loadFluidData = async (
 		({ container, services } = await client.getContainer(containerId, containerSchema));
 	}
 	return { services, container };
-};
+}

--- a/item-counter/.prettierrc.js
+++ b/item-counter/.prettierrc.js
@@ -4,5 +4,5 @@
  */
 
 module.exports = {
-    ...require("@fluidframework/build-common/prettier.config.cjs"),
+	...require("@fluidframework/build-common/prettier.config.cjs"),
 };

--- a/item-counter/jest-puppeteer.config.js
+++ b/item-counter/jest-puppeteer.config.js
@@ -4,16 +4,16 @@
  */
 
 module.exports = {
-    launch: {
-        slowMo: 300,
-        headless: "new",
-        devtools: false,
-        args: ["--disable-setuid-sandbox", "--no-sandbox"],
-    },
-    server: {
-        command: "npm run start",
-        port: 8080,
-        launchTimeout: 30000,
-        debug: true,
-    },
+	launch: {
+		slowMo: 300,
+		headless: "new",
+		devtools: false,
+		args: ["--disable-setuid-sandbox", "--no-sandbox"],
+	},
+	server: {
+		command: "npm run start",
+		port: 8080,
+		launchTimeout: 30000,
+		debug: true,
+	},
 };

--- a/item-counter/jest.config.js
+++ b/item-counter/jest.config.js
@@ -4,14 +4,14 @@
  */
 
 module.exports = {
-    preset: "jest-puppeteer",
-    globals: {
-        URL: "http://localhost:8080",
-    },
-    verbose: true,
-    testTimeout: 20000,
-    transform: {
-        "^.+\\.jsx?$": "babel-jest",
-    },
-    reporters: ["jest-junit"],
+	preset: "jest-puppeteer",
+	globals: {
+		URL: "http://localhost:8080",
+	},
+	verbose: true,
+	testTimeout: 20000,
+	transform: {
+		"^.+\\.jsx?$": "babel-jest",
+	},
+	reporters: ["jest-junit"],
 };

--- a/item-counter/package-lock.json
+++ b/item-counter/package-lock.json
@@ -10,14 +10,14 @@
 			"license": "MIT",
 			"dependencies": {
 				"@fluentui/react-icons": "^2.0.221",
-				"@fluidframework/azure-client": "2.0.0-rc.1.0.1",
-				"@fluidframework/telemetry-utils": "2.0.0-rc.1.0.1",
-				"@fluidframework/test-runtime-utils": "2.0.0-rc.1.0.1",
+				"@fluidframework/azure-client": "2.0.0-rc.2.0.0",
+				"@fluidframework/telemetry-utils": "2.0.0-rc.2.0.0",
+				"@fluidframework/test-runtime-utils": "2.0.0-rc.2.0.0",
 				"@types/react": "^18.2.0",
 				"@types/react-dom": "^18.2.0",
 				"axios": "^1.6.2",
 				"dotenv": "^16.0.2",
-				"fluid-framework": "2.0.0-rc.1.0.1",
+				"fluid-framework": "2.0.0-rc.2.0.0",
 				"guid-typescript": "^1.0.9",
 				"hashids": "^2.2.10",
 				"react": "^18.2.0",
@@ -26,7 +26,7 @@
 			"devDependencies": {
 				"@babel/preset-env": "^7.15.0",
 				"@fluidframework/build-common": "^2.0.0",
-				"@fluidframework/devtools": "2.0.0-rc.1.0.1",
+				"@fluidframework/devtools": "2.0.0-rc.2.0.0",
 				"@types/debug": "^4.1.7",
 				"@typescript-eslint/eslint-plugin": "^5.38.0",
 				"@typescript-eslint/parser": "^5.38.0",
@@ -2124,60 +2124,58 @@
 			}
 		},
 		"node_modules/@fluid-internal/client-utils": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-O4nqXfHQKEOiz2qzt/ipyGzQ7AVx8S58fnIN7ah1l+ziz3VJL10uFECAqw9y8zJx3QNIr2NIsBByW0L8DxKl+A==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-8+J9NS62coRUUxzcab0pLdOHS0OvfmM1iBJ8thi+JtYX4Asvcf/+He/vpJcxLRAL+aipQbHkkFAsi79JCAUF2w==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@types/events": "^3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@types/events_pkg": "npm:@types/events@^3.0.0",
 				"base64-js": "^1.5.1",
 				"buffer": "^6.0.3",
-				"events": "^3.1.0",
+				"events_pkg": "npm:events@^3.1.0",
 				"lodash": "^4.17.21",
 				"sha.js": "^2.4.11"
 			}
 		},
 		"node_modules/@fluidframework/aqueduct": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-OSG+g71OPW7PMcHeIS/fUjY63+U2OpWW3/TxTJug3hWQPw1nTaguXC9N2iBP6+IfdIdlGueC9S06DI2RSumZhw==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-0Xgn1rYMBIanP8JzQjjXUpF9FNytRhs00qArSAqaVJcnWxYI1Ovt0qfl7RpiflUOLwkwWsua828qJyqLGB+96g==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/map": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/synthesize": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"uuid": "^9.0.0"
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-runtime": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/map": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/request-handler": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/synthesize": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/azure-client": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-RGlpDBtZvyl3ngZMtaXIuMk1uNabXwa1cxrYkS4mdBDf9K2Y1iNN5aoTuOarUO4y6tS+Yn1K/7uDaKHIShPeqw==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-uDwHon+lPeCvqyeB0OYK8ntH1apHro4MLb7xMiUq0bUUZ4DFAJMAKjdKeK51DNZsn1SZ/gGn/XLyniT+RvLZCQ==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/map": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/server-services-client": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-loader": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/fluid-static": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/map": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/server-services-client": "^4.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"axios": "^1.6.2"
 			}
 		},
@@ -2191,18 +2189,18 @@
 			}
 		},
 		"node_modules/@fluidframework/cell": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-cn4ZsR7kmzEu7JO5iUBcXw36M1eGCjvLe2zNwjrAmzs9Zf6WH2JEIxhFWWn5sa+3cY+5USNPN2FIoA2dP0qnsg==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-4zLe3nGlHi79qsAo++kgzOPMk4CP193HigkSO0DpziLCpEUqHOGGUOMAofISeUyJfCwFtbBZwxHIBZiQSyEc7A==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/common-definitions": {
@@ -2225,282 +2223,280 @@
 			}
 		},
 		"node_modules/@fluidframework/container-definitions": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-0IU+gArPIEI5Xfakt2ROgmJ7AbzSfXNX0mQicyzW/5Wgml8y/sIWOvK/7jwB1l+M8XW3+tdDECOHgTw2+Mix/A==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-jsdYc2FW1/Fim5bp1BkLOP7LZlMggWRnUx7zG5iN5UrtyZUl+OTAJvTbiakjTQzx5obVuf1w3VxJpXXthVepzQ==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"events": "^3.1.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@types/events_pkg": "npm:@types/events@^3.0.0"
 			}
 		},
 		"node_modules/@fluidframework/container-loader": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-5XU3/dORkmhkpu1LTb7rtKRsVscHET17DNy7yhpDypK3oS00wl8OmrBOzDvjWpWebqTy2eYHzdA47GpVW3hOKg==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-x8Kf+r0qlq7QiLmWjINifXk55584zEAy5JFSH/1PS+XUMPQJNn12rXXLJ+gemkvSZMctr+2qytkS09MhieuEzA==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-base": "^3.0.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-base": "^4.0.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@ungap/structured-clone": "^1.2.0",
 				"debug": "^4.3.4",
 				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
-				"url": "^0.11.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/container-runtime": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-v9zmxvZaX30yeKh9pUB4Hh5qOw7CbIn+vo+y8SIRmGlTzvxpse5bkEbNYVORnRvy0ItwOqd4bFFEMP5uKsIn5w==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-pG5P4+ZFk/zT17mBnWF3ushY16R82myw1XdPlAAnzM0YfZiJz/OqVuJ0u5y/tYUCCKTYWG6YgYB+6R8KlOgsgw==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/id-compressor": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/id-compressor": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"@tylerbu/sorted-btree-es6": "^1.8.0",
 				"double-ended-queue": "^2.1.0-0",
-				"events": "^3.1.0",
 				"lz4js": "^0.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/container-runtime-definitions": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-1RfFTxUrKy0EjVlKYZPw5jbX6dpATpkFvZtRnndSBfyAuTJaJfxZgcCZAE5FMlX3YH0Jb7jAEGifGkm8qN4xoQ==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-gs/17ogpoXqj5w/RYOmFd0Ccd2R5R+tXJMDnsvRrEuTOqxKRkdS4i2LpK0m2bJN8ffNhyJMfFcPKDC7JJQ8MLg==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/core-interfaces": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-Xazv2hOxnQ/TBBlEC4zYUq4DGG+i8zdzhfoPr3xkj+fiOle1R6r2qG5SO6tzEVqXDNzefO/76YUNSYwgNJHWww=="
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-aFfzQ17IWF1aC9Df6P/tPsEtf1ZO66q4Jy40zlDVm1R2l374sdLUiUTzCH2VQw8JxZN4I9UBS9fl9BGCYMt8WQ=="
 		},
 		"node_modules/@fluidframework/core-utils": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-FCNN2cH5IYzODuSyk6F3creB2ssZAhpII4KSOxcPsUElZu7BAAMME04uvHleOkMOh/LfQW8NNnP1XvHt7+Z3GA=="
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-zr1mFtVMu6G4okuY0rpGv2rOwstZOaZeGCIy7qE/FN1rmHRK/eI3lZRJyynPbE5ldk0hfCLu0JmE9QMBJ6DLxw=="
 		},
 		"node_modules/@fluidframework/counter": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-7UXfPO/Eo4FtuC3YKPrEzQ7lr8p+Q8vCZiifFly+qVG1CpX0Pcg15J9u49VWOmS1VHyz8b9ym1qmA3sTfo1tDg==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-b57+GqDNTj3GLeMkpvfrQDk0AHgKi2Lmp/UJ3/umDoq5TJPau4pJ/Z90ccLztnm5K+NwiMMY637SW6S2ApoUVQ==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/datastore": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-Odbi46ET26auOehT89nPvgF091afIaXNhbxsrfgE65KcPRVQUnNfhYZo760fZDdRUKJpQwPLZZ3DFFAtFVLQTA==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-yHQcQbYT5dU80TeNwIBss3Xz+lFk7SEHtUF1ZdCMaIEytOEVbVMzchMGhccKGOr6w6TMHDMTCYB93sxcr6mTuw==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/id-compressor": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"lodash": "^4.17.21",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/datastore-definitions": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-IR6WBHxhfs+4P+vsZuAuY6zMUouCvqEvolDIgD13t2tx1FFq3yMzPfuwRAv7gHkkm65lkOJQ8XDgjfLBugTX9g==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-AS1x1Ek0+taEoe9djwJ26Yh26po+bKbjWz1cxhob1T+nCzP+LlFGAyE9uLElXOhX7O3twSO6vSbOWVIM5PK5VA==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/id-compressor": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/id-compressor": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/devtools": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/devtools/-/devtools-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-JXZJuqoVk0Pk/I/uhVX4YtKHpNC4POId6zXUYnhISvDxCOA2N6nLVTkvzu8yCPktzGvDwrzTVZikjLghE0WwrQ==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/devtools/-/devtools-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-KP/r7sCMQ72C4Op/ASRZiBCQzjRZVa0joj1QvZ5xcj22r4c3SfeetLQ2UtM0X4aqFKCYK7baClD7fdKamz9SuQ==",
 			"dev": true,
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/devtools-core": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/devtools-core": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/fluid-static": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/devtools-core": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/devtools-core/-/devtools-core-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-RmEEbCqk0v27dI7ePMYvK19viXCzUW04Spw11aBkGwoJIgwUVuMPX2UqsBkL3nkMghkzxd6auldZhXKixKzS8g==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/devtools-core/-/devtools-core-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-rl/Nx7uFTH6AyegwoJ9XYeleAxCSmruJMeZdVNJWZxXDYSjt/PxIHtHLaLGOXWTlNemaDFd6xtWuWMPlZZZNrg==",
 			"dev": true,
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/cell": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/counter": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/map": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/matrix": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/sequence": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/tree": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/cell": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-loader": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/counter": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/map": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/matrix": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/sequence": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/tree": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-base": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-awS0Y80bvXc+iD5Npzx/7uPXcPAAuFmDdb0At8SKukl36Es/m06WKTc1eGxuAW9tXKeCmezqxp0hnxSbESFadQ==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-DcGq/c9WTFY85qcxub7wokkBg8kUPlMAX3V6DsXQtXaerbjizF8VXeOSNjDcm4K0CahZCXLP8db2dQlAt2iFNA==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-definitions": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-nqfhZUvSJGzNbHMLpPTFkrM/rjtslU5igqVuqm7PQSp8sNaDkzGmttCPI8xFVJlmYxHQ7Onclo+c5BX+Eg5X3Q==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-2xIvYEb8q7XjxEL7F6I0vyelCxnLxI34kjfd9fT+NG0nTAbJtLtLpIVKz1EXJSYSXm2mp+nm4HDPwoB3OvSUgA==",
 			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-utils": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-Y+MkC7Ks4Akh5mhS/Oa3SLrYzELnPLFp5o1ZRhkxlAo3bZF4HCJmHNiDD6KvFa7zaH+VmVBxFmMUkcSZ/ktJrQ==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-kl5t2zjeSTRcGzY56fcqfWoai+AtuK0KGfoIEVuKkmhLvdbDMWhfzfG4RyT7snvFvxQevGNBigZtVXY3UsIlkg==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/gitresources": "^3.0.0",
-				"@fluidframework/protocol-base": "^3.0.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/gitresources": "^4.0.0",
+				"@fluidframework/protocol-base": "^4.0.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"axios": "^1.6.2",
 				"lz4js": "^0.2.0",
-				"url": "^0.11.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/fluid-static": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-BLnDzUqgAip0WRkJCS8UXk4NEVbZ7UEwsd7nwRKxgDTzbDvfrqbYZBdcfmF0QL88h8MXkP867l8qhOX2FmsGBw==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-972AntH1tNZ/MFcqXrlWonG010CftL8RKJLq460Mbc/eoHWH4kTtxXaKoGPkozxABsJP0yd0ut6QILctAqHHAw==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/aqueduct": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/aqueduct": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-loader": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-runtime": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/request-handler": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/gitresources": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-3.0.0.tgz",
-			"integrity": "sha512-kpbONpwCIE7q2G+Q+KTfBHUz+VneL/7tPWlYFZ96uP0dpeBVdSJdf9dgd0ILIzs6rpO6XRpceI2D503LRU6j9g=="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-4.0.0.tgz",
+			"integrity": "sha512-3E4bjOp0/el0EFIzut8fb5XDM5xF/zWKyKn8n1RLEsstMM9nktjFOhCHoP57tRsfc16p3g9GoXhtpWCwe0vqnQ=="
 		},
 		"node_modules/@fluidframework/id-compressor": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/id-compressor/-/id-compressor-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-Ny07wjM6s0SRYI7JhiUvAFPExBjCLkQSAnUcfJmnLCIuoiP58RhqiSfyovoi6WDk9I+dkMNZrgWnWlJw5z8Dzg==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/id-compressor/-/id-compressor-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-oW4oWIVRNlgnWNLHjhj+JcX2nHtzHASG5GIq4E2YsAgrBsqc6879+SRoqG+QeirKdbe4h7ycMvlu1v3xTOkfdA==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"@tylerbu/sorted-btree-es6": "^1.8.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/map": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-ILLMVPXCnLFZ58WkgTho1fCcEwId01/HeB0PaFcfnB2XHrKnR7YYPbcUku788KDf2on0SWYKl/MdWrZhsNfyrg==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-FGLFjWk2BRJ8/i05XeduZUzVZzVZ1It978i0jLI/8yEAPJornMsQAvwCH3qaZut3Htxd/vig6WErfAS0IDgktQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/merge-tree": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/merge-tree": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"node_modules/@fluidframework/matrix": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-FldhwHGzbwVYYd2wQTrNKGXaONSVh27tNcYV4WwZbWNMvUdvme/psTGcm2XXallJMo9Svnni1VAKgIfizMzPvw==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-iISwfK4F2sWLWuD9Ayy+VWxFx6x4cxHWrNw16+VLjV7geU2M2h05/f/KlWOKjkbhS2bfjJerpDcbNgKwpJLz2Q==",
 			"dev": true,
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/merge-tree": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/merge-tree": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
-				"events": "^3.1.0",
+				"double-ended-queue": "^2.1.0-0",
 				"tslib": "^1.10.0"
 			}
 		},
@@ -2511,231 +2507,221 @@
 			"dev": true
 		},
 		"node_modules/@fluidframework/merge-tree": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-clLDnz21PbJNa2agipR5KrcQdXr84Fyl65YH8YWIhaMCwqzZ9bXPR6t2FrRv7Ye/WkDL+qvAu33ohSDic9T8ZA==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-C2q46zDuZi+EiBtzVyzVgkf4xRJRjzpNKojzV7B7Sj9/cK4HSyBKAgZbzuRNzgB2ANVICqS8bzdcg+ArKaJJqw==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/protocol-base": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-3.0.0.tgz",
-			"integrity": "sha512-csvei49LHDZhD+gQ3brUZEeekQmvk/ndsBNhYnqxJeoAOlBi5MtIqyb5vA96pKd0o23cwGE5PWEfrxJcsqEmTQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-4.0.0.tgz",
+			"integrity": "sha512-mpuYXOOfCXKKEdzauxQ3KTY+ZWNj+NTEQTEJW8PD/xqN95g3AYoYXiikEkuzPbKghkAWcr6gYNxmK//MLbIVFw==",
 			"dependencies": {
 				"@fluidframework/common-utils": "^3.1.0",
-				"@fluidframework/gitresources": "~3.0.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
+				"@fluidframework/gitresources": "~4.0.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
 				"events": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/protocol-definitions": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-3.1.0.tgz",
-			"integrity": "sha512-BgGF82z4sk5M4torMR38NGjHjFG9t6Y653UcGOlXiIaGQMDZpRfrxiIuq53Gb12OTfUgbNtvBJL1W46JfLvzQw=="
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-3.2.0.tgz",
+			"integrity": "sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA=="
 		},
 		"node_modules/@fluidframework/request-handler": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-OoCt6rGUTFl2WucMTNY2SG32w+MCTvFb1Bdqp4MM6BhdZIw6nyS/++0RSTbSXbOHa8SW1I35ExoMu9NP6x58SA==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-sAcspxSU3R70gBJIc58OrRny66rGJk0B5qRTeJUd0dD42y+YHf9wriwNWb9DuckkwUkF9nSMdEvPX6n1ury6IQ==",
 			"dependencies": {
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/routerlicious-driver": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-VaKa0ZDikUAwib7VHJyUNilethdCNab1rxQ8nD3BiRGN28WvDPSAjKH0rLEXsuC60BN1k711G0/meH+y6ZD7rw==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-SchvLvYYA40fdVOSriL26Rfts3b2NBpDVaIf1o98UEaE9eg6Q2dSrE691EYweI7N9LLCm0tWMX5U+O62oNv5KQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-base": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/gitresources": "^3.0.0",
-				"@fluidframework/protocol-base": "^3.0.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/server-services-client": "^3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-base": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/gitresources": "^4.0.0",
+				"@fluidframework/protocol-base": "^4.0.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/server-services-client": "^4.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
-				"socket.io-client": "^4.6.1",
-				"url-parse": "^1.5.8",
+				"socket.io-client": "^4.7.3",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/runtime-definitions": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-vEVkHwAP5ew3dczz3d3KjyF161BUU5RVNF56monmLxDbSxful1uCq6Lz7ytC4vyGo2d1SSbTpkvE9OKbupsKnw==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-Ciq+bJjS0fZBWnRMhMITWh4tAC97l//qfoxN/1wTnHTDYwJjmkflqYVdpYMDxtKFdN1eU7wEHDDiCvsl/NILPQ==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/id-compressor": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0"
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/id-compressor": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0"
 			}
 		},
 		"node_modules/@fluidframework/runtime-utils": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-9maXqcCtcDt+BDLCssqBhsdDUZtIzNY9cm7+2i3IoKXnRCbezgBI8V1E88AnNOv9EDWj9Hq9cOe/sXH4N5U1Gw==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-s2gd2AF04TzU9aPbvw7MAy3JXuI4FBVvoJ69dP7J1K0zi2wQ7ROlsNNEp4OMn/IGhWur2IATtnvUuOFfl8dc4w==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/sequence": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-7YatZ+1nNwbgIyZi6vWrxlc4GVkNxDRrEzB7hMuHqMk3fa2Pyno8IzCjeV19uL5wUj9i/F7WgoIVm1kegP4U6Q==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-H5cwW0qrXSzufE2yQjls6fg2uFvKKvtNVjso+YEfYx731l0+swN7E5WKAH2TDLI7DJygoc6TpJkcSUA3+25RGQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/merge-tree": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/merge-tree": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/server-services-client": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-3.0.0.tgz",
-			"integrity": "sha512-obsH2oYOkmvQoOSuluwEwiViOuZe3wNBNBWxuUHkGKmfeg1xU5Ko2Sj5/0Ku45f5EY8puRenlApCTS/2mKhSaw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-4.0.0.tgz",
+			"integrity": "sha512-ExvztSQrliaYMSeLLxlACdWkuDk6auDle4eIQ2euvkgl0RWnupatPYgUVdfnNMIE6vBIeOwDzJaWy2giFx7Z6Q==",
 			"dependencies": {
 				"@fluidframework/common-utils": "^3.1.0",
-				"@fluidframework/gitresources": "~3.0.0",
-				"@fluidframework/protocol-base": "~3.0.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
+				"@fluidframework/gitresources": "~4.0.0",
+				"@fluidframework/protocol-base": "~4.0.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
 				"axios": "^1.6.2",
 				"crc-32": "1.2.0",
 				"debug": "^4.3.4",
 				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
+				"jsrsasign": "^11.0.0",
 				"jwt-decode": "^4.0.0",
-				"querystring": "^0.2.0",
 				"sillyname": "^0.1.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/shared-object-base": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-sR9lueWM6MGI1BS9pTv4XJ251WyiK5Q4s7qUH2M3N9ruMOLchSBwaJw/PzLuZ6494daH2dX4bD0VrNponFO8tQ==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-Ld3IUskCkdL2KBTOAPQvGn6vNVXMM5SWaDYdKbchKoPvuY3dWMCgakXjQ5STGHp7q5CUrPgQ+96PxbdfFYo+GA==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-runtime": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/synthesize": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-ZbFIoScFmGsIFDpPcozMb7VW5wrPdOi6/WAp3/oYVobTYneDhQu8oAHMMdZQhuFxV0PmQqk2oa7E6FXhS/nDNw==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-eqkzLgS08RX+/PUZwqrqKt5o5Lak48GpFsJmMylNXDq5KiuHJoMJ51W6+hi3aI4UYfwt8fRr+3KvbE3/QFmRNA==",
 			"dependencies": {
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/@fluidframework/telemetry-utils": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-AHGK8pPUUGfE9L3lDpQN6JRS2s3oKEQGktH2lNu85f5zjMPUhLV6ZIIwt5G2ILbNpZuLuyEjQkaSEXlpxGFt6g==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-OILipzJ1XBCjLeY+tOdt+bnOrX5zM+SKM8q4OsG8Qq9miwpbai1Ah830nMTYXEvlmdcbgrmBmRPtW8bs5MHVUA==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
 				"debug": "^4.3.4",
-				"events": "^3.1.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/test-runtime-utils": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-BpHdmliCp3824s1C9HEz+Tuq+rqJ7Tx8Fqjv3FtbIAk5ikLbqfgFedt1+j3lyAjsQGut6DhAV3bGRiPZY9UYQA==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-8LgccYD3x2jzIYbZioQbZ4ImQgiKRicJ9YH/wdx5ZjWVAF4Xu7RVS0m77sP9gNUo+h2fmh3DzdRaZp/5KXKzaQ==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/id-compressor": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"events": "^3.1.0",
-				"jsrsasign": "^10.5.25",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/id-compressor": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"jsrsasign": "^11.0.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/tree": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tree/-/tree-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-fTJB8lg1tx3jaytQKy4tcTd2zpFri5UNlRVnlnr7TSEWWjPV0dzXditbw4qTdj3YdG6l/yLMyJ/jwr1TRwCEfw==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tree/-/tree-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-mRkj+Qs5mpNGJyl+7xFj4VgsgYgv2C2NyglIb1T5fvFaZ6AoI1n7miDQzYri6PPJpNswbIKYT+JI8DTw7as8Sw==",
 			"dependencies": {
-				"@fluid-internal/client-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-runtime": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/core-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/id-compressor": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/protocol-definitions": "^3.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
+				"@fluid-internal/client-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-runtime": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/core-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/id-compressor": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
 				"@sinclair/typebox": "^0.29.4",
 				"@tylerbu/sorted-btree-es6": "^1.8.0",
 				"@ungap/structured-clone": "^1.2.0",
 				"uuid": "^9.0.0"
-			}
-		},
-		"node_modules/@fluidframework/view-interfaces": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-6lGwNkN6Gx/y9KnlXdcg/ypQVkqyU1SjtzLUK5+3p5tUrPSD9p+xRA6z63GdluNDNV+z30Kk4NHs/k2XuAiSbg==",
-			"dependencies": {
-				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
 			}
 		},
 		"node_modules/@griffel/core": {
@@ -3490,6 +3476,12 @@
 			"dev": true
 		},
 		"node_modules/@types/events": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
+			"integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g=="
+		},
+		"node_modules/@types/events_pkg": {
+			"name": "@types/events",
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
 			"integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g=="
@@ -5012,6 +5004,7 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
 			"integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.2",
 				"get-intrinsic": "^1.2.1",
@@ -5778,6 +5771,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
 			"integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+			"dev": true,
 			"dependencies": {
 				"get-intrinsic": "^1.2.1",
 				"gopd": "^1.0.1",
@@ -6137,9 +6131,9 @@
 			}
 		},
 		"node_modules/engine.io-parser": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
-			"integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
+			"integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==",
 			"engines": {
 				"node": ">=10.0.0"
 			}
@@ -6744,6 +6738,15 @@
 				"node": ">=0.8.x"
 			}
 		},
+		"node_modules/events_pkg": {
+			"name": "events",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"engines": {
+				"node": ">=0.8.x"
+			}
+		},
 		"node_modules/execa": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -7185,23 +7188,23 @@
 			"dev": true
 		},
 		"node_modules/fluid-framework": {
-			"version": "2.0.0-rc.1.0.1",
-			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-rc.1.0.1.tgz",
-			"integrity": "sha512-4M0dXUxT1G86yWToJ7vNHt04NhJLOzZAJAtEXCld/lcQy31O+qyRFsKKXTLl/pcJPjrXIl9g+Quh/HWQFIDf6g==",
+			"version": "2.0.0-rc.2.0.0",
+			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-rc.2.0.0.tgz",
+			"integrity": "sha512-4GEdwpOQCR5DWv6SiQKolMp+s2rn2ekTf501IVsateIHLRPGD7kXjk5mMB1ooheegrq+xIpAHfGviYMtscTe1A==",
 			"dependencies": {
-				"@fluidframework/container-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/container-loader": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/fluid-static": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/map": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/sequence": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0",
-				"@fluidframework/tree": ">=2.0.0-rc.1.0.1 <2.0.0-rc.1.1.0"
+				"@fluidframework/container-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/container-loader": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/fluid-static": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/map": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/sequence": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0",
+				"@fluidframework/tree": ">=2.0.0-rc.2.0.0 <2.0.0-rc.2.1.0"
 			}
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.4",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-			"integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+			"version": "1.15.6",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+			"integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
 			"funding": [
 				{
 					"type": "individual",
@@ -7316,6 +7319,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -7369,6 +7373,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
 			"integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.2",
 				"has-proto": "^1.0.1",
@@ -7563,6 +7568,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
 			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+			"dev": true,
 			"dependencies": {
 				"get-intrinsic": "^1.1.3"
 			},
@@ -7615,6 +7621,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
 			"integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+			"dev": true,
 			"dependencies": {
 				"get-intrinsic": "^1.2.2"
 			},
@@ -7626,6 +7633,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
 			"integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -7637,6 +7645,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
 			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -7668,6 +7677,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
 			"integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.2"
 			},
@@ -8059,9 +8069,9 @@
 			}
 		},
 		"node_modules/ip": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-			"integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
+			"integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
 			"dev": true
 		},
 		"node_modules/ipaddr.js": {
@@ -9391,9 +9401,9 @@
 			}
 		},
 		"node_modules/jsrsasign": {
-			"version": "10.9.0",
-			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.9.0.tgz",
-			"integrity": "sha512-QWLUikj1SBJGuyGK8tjKSx3K7Y69KYJnrs/pQ1KZ6wvZIkHkWjZ1PJDpuvc1/28c1uP0KW9qn1eI1LzHQqDOwQ==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.1.0.tgz",
+			"integrity": "sha512-Ov74K9GihaK9/9WncTe1mPmvrO7Py665TUfUKvraXBpu+xcTWitrtuOwcjf4KMU9maPaYn0OuaWy0HOzy/GBXg==",
 			"funding": {
 				"url": "https://github.com/kjur/jsrsasign#donations"
 			}
@@ -10044,6 +10054,7 @@
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
 			"integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -10918,11 +10929,6 @@
 				"once": "^1.3.1"
 			}
 		},
-		"node_modules/punycode": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
-		},
 		"node_modules/puppeteer": {
 			"version": "21.7.0",
 			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.7.0.tgz",
@@ -11003,34 +11009,6 @@
 					"url": "https://opencollective.com/fast-check"
 				}
 			]
-		},
-		"node_modules/qs": {
-			"version": "6.11.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
-			"integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
-			"dependencies": {
-				"side-channel": "^1.0.4"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/querystring": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-			"integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
-			"deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-			"engines": {
-				"node": ">=0.4.x"
-			}
-		},
-		"node_modules/querystringify": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
@@ -11380,7 +11358,8 @@
 		"node_modules/requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+			"dev": true
 		},
 		"node_modules/resolve": {
 			"version": "2.0.0-next.5",
@@ -11819,6 +11798,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
 			"integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+			"dev": true,
 			"dependencies": {
 				"define-data-property": "^1.1.1",
 				"get-intrinsic": "^1.2.1",
@@ -11907,6 +11887,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
 			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.0",
 				"get-intrinsic": "^1.0.2",
@@ -11953,9 +11934,9 @@
 			}
 		},
 		"node_modules/socket.io-client": {
-			"version": "4.7.3",
-			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.3.tgz",
-			"integrity": "sha512-nU+ywttCyBitXIl9Xe0RSEfek4LneYkJxCeNnKCuhwoH4jGXO1ipIUw/VA/+Vvv2G1MTym11fzFC0SxkrcfXDw==",
+			"version": "4.7.5",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.5.tgz",
+			"integrity": "sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==",
 			"dependencies": {
 				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.3.2",
@@ -12027,9 +12008,9 @@
 			}
 		},
 		"node_modules/socks/node_modules/ip": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-			"integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+			"integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
 			"dev": true
 		},
 		"node_modules/source-list-map": {
@@ -13164,24 +13145,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/url": {
-			"version": "0.11.3",
-			"resolved": "https://registry.npmjs.org/url/-/url-0.11.3.tgz",
-			"integrity": "sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==",
-			"dependencies": {
-				"punycode": "^1.4.1",
-				"qs": "^6.11.2"
-			}
-		},
-		"node_modules/url-parse": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-			"dependencies": {
-				"querystringify": "^2.1.1",
-				"requires-port": "^1.0.0"
 			}
 		},
 		"node_modules/urlpattern-polyfill": {

--- a/item-counter/package.json
+++ b/item-counter/package.json
@@ -15,21 +15,21 @@
 		"lint": "eslint src",
 		"webpack": "cross-env FLUID_CLIENT='azure' webpack",
 		"start": "npm run dev",
-		"start:server": "npx @fluidframework/azure-local-service@2.0.0-rc.1.0.1"
+		"start:server": "npx @fluidframework/azure-local-service@2.0.0-rc.2.0.0"
 	},
 	"engines": {
 		"node": ">=18.0.0"
 	},
 	"dependencies": {
 		"@fluentui/react-icons": "^2.0.221",
-		"@fluidframework/azure-client": "2.0.0-rc.1.0.1",
-		"@fluidframework/telemetry-utils": "2.0.0-rc.1.0.1",
-		"@fluidframework/test-runtime-utils": "2.0.0-rc.1.0.1",
+		"@fluidframework/azure-client": "2.0.0-rc.2.0.0",
+		"@fluidframework/telemetry-utils": "2.0.0-rc.2.0.0",
+		"@fluidframework/test-runtime-utils": "2.0.0-rc.2.0.0",
 		"@types/react": "^18.2.0",
 		"@types/react-dom": "^18.2.0",
 		"axios": "^1.6.2",
 		"dotenv": "^16.0.2",
-		"fluid-framework": "2.0.0-rc.1.0.1",
+		"fluid-framework": "2.0.0-rc.2.0.0",
 		"guid-typescript": "^1.0.9",
 		"hashids": "^2.2.10",
 		"react": "^18.2.0",
@@ -38,7 +38,7 @@
 	"devDependencies": {
 		"@babel/preset-env": "^7.15.0",
 		"@fluidframework/build-common": "^2.0.0",
-		"@fluidframework/devtools": "2.0.0-rc.1.0.1",
+		"@fluidframework/devtools": "2.0.0-rc.2.0.0",
 		"@types/debug": "^4.1.7",
 		"@typescript-eslint/eslint-plugin": "^5.38.0",
 		"@typescript-eslint/parser": "^5.38.0",

--- a/item-counter/src/index.tsx
+++ b/item-counter/src/index.tsx
@@ -9,7 +9,6 @@ import { createRoot } from "react-dom/client";
 import { loadFluidData, containerSchema } from "./infra/fluid";
 import { initializeDevtools } from "@fluidframework/devtools";
 import { devtoolsLogger } from "./infra/clientProps";
-import { ITree } from "fluid-framework";
 import { treeConfiguration } from "./schema";
 import "./output.css";
 import { ReactApp } from "./react_app";
@@ -30,7 +29,7 @@ async function start() {
 	const { container } = await loadFluidData(containerId, containerSchema);
 
 	// Initialize the SharedTree Data Structure
-	const appData = (container.initialObjects.appData as ITree).schematize(
+	const appData = container.initialObjects.appData.schematize(
 		treeConfiguration, // This is defined in schema.ts
 	);
 

--- a/item-counter/src/infra/fluid.ts
+++ b/item-counter/src/infra/fluid.ts
@@ -15,14 +15,14 @@ const client = new AzureClient(clientProps);
  *
  * @returns The loaded container and container services.
  */
-export const loadFluidData = async (
+export async function loadFluidData<T extends ContainerSchema>(
 	containerId: string,
-	containerSchema: ContainerSchema,
+	containerSchema: T,
 ): Promise<{
 	services: AzureContainerServices;
-	container: IFluidContainer;
-}> => {
-	let container: IFluidContainer;
+	container: IFluidContainer<T>;
+}> {
+	let container: IFluidContainer<T>;
 	let services: AzureContainerServices;
 
 	// Get or create the document depending if we are running through the create new flow
@@ -36,10 +36,10 @@ export const loadFluidData = async (
 		({ container, services } = await client.getContainer(containerId, containerSchema));
 	}
 	return { services, container };
-};
+}
 
-export const containerSchema: ContainerSchema = {
+export const containerSchema = {
 	initialObjects: {
 		appData: SharedTree,
 	},
-};
+} satisfies ContainerSchema;

--- a/item-counter/src/react_app.tsx
+++ b/item-counter/src/react_app.tsx
@@ -5,17 +5,17 @@
 
 import React, { ReactNode, useEffect, useState } from "react";
 import { TreeView, Tree } from "fluid-framework";
-import { App, StringArray } from "./schema";
+import { StringArray } from "./schema";
 
-export function ReactApp(props: { data: TreeView<App> }): JSX.Element {
+export function ReactApp(props: { data: TreeView<StringArray> }): JSX.Element {
 	const [invalidations, setInvalidations] = useState(0);
 
-	const app = props.data.root;
+	const strings = props.data.root;
 
 	// Register for tree deltas when the component mounts.
 	// Any time the tree changes, the app will update
 	useEffect(() => {
-		const unsubscribe = Tree.on(app, "afterChange", () => {
+		const unsubscribe = Tree.on(strings, "afterChange", () => {
 			setInvalidations(invalidations + Math.random());
 		});
 		return unsubscribe;
@@ -24,7 +24,7 @@ export function ReactApp(props: { data: TreeView<App> }): JSX.Element {
 	return (
 		<div className="flex flex-col gap-3 items-center justify-center content-center m-6">
 			<div className="flex flex-row gap-3 justify-center flex-wrap w-full h-full">
-				<ListGroup list={app.stringArray} />
+				<ListGroup list={strings} />
 			</div>
 			<Explanation />
 		</div>

--- a/item-counter/src/schema.ts
+++ b/item-counter/src/schema.ts
@@ -11,30 +11,25 @@ const sf = new SchemaFactory("d302b84c-75f6-4ecd-9663-524f467013e3");
 // Define a class that is an array of strings
 // This class is used to create an array in the SharedTree
 export class StringArray extends sf.array("StringArray", sf.string) {
-	// Remove the first item in the list if the list is not empty
+	/**
+	 * Remove the first item in the list if the list is not empty
+	 */
 	public removeFirst() {
 		if (this.length > 0) this.removeAt(0);
 	}
 
-	// Add an item to the beginning of the list
+	/**
+	 * Add an item to the beginning of the list
+	 */
 	public insertNew() {
 		this.insertAtStart("");
 	}
 }
 
-// Define a class to be the root of the app
-export class App extends sf.object("App", {
-	stringArray: StringArray,
-}) {}
-
-// Specify the root type - App.
-// Specify the initial state of the tree which is used if this is a new tree.
-// This object is passed into the SharedTree via the schematize
-// method.
+// This object is passed into the SharedTree via the schematize method.
 export const treeConfiguration = new TreeConfiguration(
-	App,
-	() =>
-		new App({
-			stringArray: [],
-		}),
+	// Specify the root type - StringArray.
+	StringArray,
+	// Initial state of the tree which is used for new trees.
+	() => new StringArray([]),
 );

--- a/item-counter/tsconfig.json
+++ b/item-counter/tsconfig.json
@@ -1,15 +1,15 @@
 {
-    "compilerOptions": {
-        // DO NOT EDIT
-        "outDir": "./dist",
-        "target": "es6",
-        "module": "es6",
-        "sourceMap": true,
-        // Set your preferences here for TypeScript
-        "strict": true,
-        "jsx": "react",
-        "moduleResolution": "node",
-        "allowSyntheticDefaultImports": true,
-        "esModuleInterop": true        
-    }
+	"compilerOptions": {
+		// DO NOT EDIT
+		"outDir": "./dist",
+		"target": "es6",
+		"module": "es6",
+		"sourceMap": true,
+		// Set your preferences here for TypeScript
+		"strict": true,
+		"jsx": "react",
+		"moduleResolution": "node",
+		"allowSyntheticDefaultImports": true,
+		"esModuleInterop": true,
+	},
 }

--- a/item-counter/webpack.config.js
+++ b/item-counter/webpack.config.js
@@ -4,74 +4,74 @@
  */
 
 /* eslint-disable @typescript-eslint/no-var-requires */
-const path = require('path');
-const Dotenv = require('dotenv-webpack');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const path = require("path");
+const Dotenv = require("dotenv-webpack");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 module.exports = {
-    // Basic configuration
-    entry: './src/index.tsx',
-    // Necessary in order to use source maps and debug directly TypeScript files
-    devtool: 'source-map',
-    mode: 'development',
-    performance: {
-        maxAssetSize: 4000000,
-        maxEntrypointSize: 4000000,
-    },
-    module: {        
-        rules: [
-            // Necessary in order to use TypeScript
-            {
-                test: /\.ts$|tsx/,
-                use: 'ts-loader',
-                exclude: /node_modules/,
-            },            
-            {
-                test: /\.css$/,
-                use: [
-                    {
-                        loader: 'style-loader',
-                    },
-                    {
-                        loader: 'css-loader',
-                    },
-                ],
-            },
-        ],
-    },
-    resolve: {
-        // Alway keep '.js' even though you don't use it.
-        // https://github.com/webpack/webpack-dev-server/issues/720#issuecomment-268470989
-        extensions: ['.tsx', '.ts', '.js'],
-    },
-    output: {
-        filename: 'bundle.js',
-        path: path.resolve(__dirname, 'dist'),
-        // This line is VERY important for VS Code debugging to attach properly
-        // Tamper with it at your own risks
-        devtoolModuleFilenameTemplate: '[absolute-resource-path]',
-        clean: true,
-    },
-    plugins: [
-        // No need to write a index.html
-        new HtmlWebpackPlugin({
-            title: 'Fluid Demo',
-            favicon: '',
-        }),
-        // Load environment variables during webpack bundle
-        new Dotenv({
-            systemvars: true,
-        }),
-        // Extract CSS to separate file
-        new MiniCssExtractPlugin({
-            filename: 'css/mystyles.css',
-        }),        
-    ],
-    devServer: {
-        // keep port in sync with VS Code launch.json
-        port: 8080,
-        // Hot-reloading, the sole reason to use webpack here <3
-        hot: true,
-    },
+	// Basic configuration
+	entry: "./src/index.tsx",
+	// Necessary in order to use source maps and debug directly TypeScript files
+	devtool: "source-map",
+	mode: "development",
+	performance: {
+		maxAssetSize: 4000000,
+		maxEntrypointSize: 4000000,
+	},
+	module: {
+		rules: [
+			// Necessary in order to use TypeScript
+			{
+				test: /\.ts$|tsx/,
+				use: "ts-loader",
+				exclude: /node_modules/,
+			},
+			{
+				test: /\.css$/,
+				use: [
+					{
+						loader: "style-loader",
+					},
+					{
+						loader: "css-loader",
+					},
+				],
+			},
+		],
+	},
+	resolve: {
+		// Alway keep '.js' even though you don't use it.
+		// https://github.com/webpack/webpack-dev-server/issues/720#issuecomment-268470989
+		extensions: [".tsx", ".ts", ".js"],
+	},
+	output: {
+		filename: "bundle.js",
+		path: path.resolve(__dirname, "dist"),
+		// This line is VERY important for VS Code debugging to attach properly
+		// Tamper with it at your own risks
+		devtoolModuleFilenameTemplate: "[absolute-resource-path]",
+		clean: true,
+	},
+	plugins: [
+		// No need to write a index.html
+		new HtmlWebpackPlugin({
+			title: "Fluid Demo",
+			favicon: "",
+		}),
+		// Load environment variables during webpack bundle
+		new Dotenv({
+			systemvars: true,
+		}),
+		// Extract CSS to separate file
+		new MiniCssExtractPlugin({
+			filename: "css/mystyles.css",
+		}),
+	],
+	devServer: {
+		// keep port in sync with VS Code launch.json
+		port: 8080,
+		// Hot-reloading, the sole reason to use webpack here <3
+		hot: true,
+	},
 };


### PR DESCRIPTION
- Update to Fluid 2.0.0-rc.2.0.0
- `npm audit fix`
- Make loadFluidData a function (for consistent style with other functions)
- make loadFluidData use the new more type safe generic container schema
- Make container schema declaration not lose detailed type info
- Avoid no longer needed casts when accessing DDS from container
- Normalize whitespace in a few files (remove trailing, use tabs)
- Tweak docs in item-counter/src/schema.ts
- Remove unneeded root node from item-counter.