### PR TITLE
Allow recursion in brainstorm example

### DIFF
--- a/brainstorm/src/index.tsx
+++ b/brainstorm/src/index.tsx
@@ -52,7 +52,7 @@ async function start() {
 	root.render(
 		<DndProvider backend={HTML5Backend}>
 			<ReactApp
-				appTree={appTree}
+				items={appTree}
 				sessionTree={sessionTree}
 				audience={services.audience}
 				container={container}

--- a/brainstorm/src/react/buttonux.tsx
+++ b/brainstorm/src/react/buttonux.tsx
@@ -4,8 +4,8 @@
  */
 
 import React from "react";
-import { App, Note } from "../schema/app_schema";
-import { deleteNote, moveItem, findNote } from "../utils/app_helpers";
+import { Items, Note } from "../schema/app_schema";
+import { moveItem, findNote } from "../utils/app_helpers";
 import {
 	ThumbLikeFilled,
 	DismissFilled,
@@ -19,20 +19,20 @@ import { Session } from "../schema/session_schema";
 import { getSelectedNotes } from "../utils/session_helpers";
 
 export function NewGroupButton(props: {
-	root: App;
+	items: Items;
 	session: Session;
 	clientId: string;
 }): JSX.Element {
 	const handleClick = (e: React.MouseEvent) => {
 		e.stopPropagation();
-		const group = props.root.items.newGroup("[new group]");
+		const group = props.items.addGroup("[new group]");
 
 		const ids = getSelectedNotes(props.session, props.clientId);
 
 		for (const id of ids) {
-			const n = findNote(props.root.items, id);
+			const n = findNote(props.items, id);
 			if (n instanceof Note) {
-				moveItem(n, Infinity, group.notes);
+				moveItem(n, Infinity, group.items);
 			}
 		}
 	};
@@ -48,10 +48,10 @@ export function NewGroupButton(props: {
 	);
 }
 
-export function NewNoteButton(props: { root: App; clientId: string }): JSX.Element {
+export function NewNoteButton(props: { items: Items; clientId: string }): JSX.Element {
 	const handleClick = (e: React.MouseEvent) => {
 		e.stopPropagation();
-		props.root.items.newNote(props.clientId);
+		props.items.addNode(props.clientId);
 	};
 
 	return (
@@ -68,16 +68,14 @@ export function NewNoteButton(props: { root: App; clientId: string }): JSX.Eleme
 
 export function DeleteNotesButton(props: {
 	session: Session;
-	app: App;
+	items: Items;
 	clientId: string;
 }): JSX.Element {
 	const handleClick = () => {
 		const ids = getSelectedNotes(props.session, props.clientId);
 		for (const i of ids) {
-			const n = findNote(props.app.items, i);
-			if (n instanceof Note) {
-				deleteNote(n);
-			}
+			const n = findNote(props.items, i);
+			n?.delete();
 		}
 	};
 	return (

--- a/brainstorm/src/react/groupux.tsx
+++ b/brainstorm/src/react/groupux.tsx
@@ -4,18 +4,18 @@
  */
 
 import React from "react";
-import { App, Group, Note } from "../schema/app_schema";
-import { deleteGroup, moveItem } from "../utils/app_helpers";
+import { Group, Items, Note } from "../schema/app_schema";
+import { moveItem } from "../utils/app_helpers";
 import { ConnectableElement, useDrag, useDrop } from "react-dnd";
-import { NoteContainer } from "./noteux";
 import { DeleteButton } from "./buttonux";
 import { dragType } from "../utils/utils";
 import { Session } from "../schema/session_schema";
+import { ItemsView } from "./canvasux";
 
 export function GroupView(props: {
 	group: Group;
 	clientId: string;
-	app: App;
+	parent: Items;
 	session: Session;
 	fluidMembers: string[];
 }): JSX.Element {
@@ -46,7 +46,7 @@ export function GroupView(props: {
 
 			const droppedItem = item;
 			if (droppedItem instanceof Group || droppedItem instanceof Note) {
-				moveItem(droppedItem, props.app.items.indexOf(props.group), props.app.items);
+				moveItem(droppedItem, props.parent.indexOf(props.group), props.parent);
 			}
 
 			return;
@@ -77,12 +77,13 @@ export function GroupView(props: {
 					(isOver && canDrop ? "translate-x-3" : "")
 				}
 			>
-				<GroupToolbar pile={props.group} app={props.app} />
-				<NoteContainer
-					group={props.group}
+				<GroupToolbar pile={props.group} parent={props.parent} />
+				<ItemsView
+					items={props.group.items}
 					clientId={props.clientId}
 					session={props.session}
 					fluidMembers={props.fluidMembers}
+					isRoot={false}
 				/>
 			</div>
 		</div>
@@ -100,15 +101,15 @@ function GroupName(props: { pile: Group }): JSX.Element {
 	);
 }
 
-function GroupToolbar(props: { pile: Group; app: App }): JSX.Element {
+function GroupToolbar(props: { pile: Group; parent: Items }): JSX.Element {
 	return (
 		<div className="flex flex-row justify-between">
 			<GroupName pile={props.pile} />
-			<DeletePileButton pile={props.pile} app={props.app} />
+			<DeletePileButton pile={props.pile} items={props.parent} />
 		</div>
 	);
 }
 
-export function DeletePileButton(props: { pile: Group; app: App }): JSX.Element {
-	return <DeleteButton handleClick={() => deleteGroup(props.pile, props.app)}></DeleteButton>;
+export function DeletePileButton(props: { pile: Group; items: Items }): JSX.Element {
+	return <DeleteButton handleClick={() => props.pile.delete()}></DeleteButton>;
 }

--- a/brainstorm/src/react/ux.tsx
+++ b/brainstorm/src/react/ux.tsx
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState } from "react";
-import { App } from "../schema/app_schema";
+import { Items } from "../schema/app_schema";
 import { Session } from "../schema/session_schema";
 import "../output.css";
 import { IFluidContainer, IMember, IServiceAudience, TreeView } from "fluid-framework";
@@ -13,7 +13,7 @@ import { undefinedUserId } from "../utils/utils";
 import { Canvas } from "./canvasux";
 
 export function ReactApp(props: {
-	appTree: TreeView<App>;
+	items: TreeView<Items>;
 	sessionTree: TreeView<Session>;
 	audience: IServiceAudience<IMember>;
 	container: IFluidContainer;
@@ -36,7 +36,7 @@ export function ReactApp(props: {
 			/>
 			<div className="flex h-[calc(100vh-48px)] flex-row ">
 				<Canvas
-					appTree={props.appTree}
+					items={props.items.root}
 					sessionTree={props.sessionTree}
 					audience={props.audience}
 					container={props.container}

--- a/brainstorm/src/schema/app_schema.ts
+++ b/brainstorm/src/schema/app_schema.ts
@@ -3,29 +3,38 @@
  * Licensed under the MIT License.
  */
 
-import { TreeConfiguration, SchemaFactory } from "fluid-framework";
-import { addNote } from "../utils/app_helpers";
+import { TreeConfiguration, SchemaFactoryRecursive, Tree } from "fluid-framework";
 import { Guid } from "guid-typescript";
 
 // Schema is defined using a factory object that generates classes for objects as well
 // as list and map nodes.
 
-// Include a UUID to guarantee that this schema will be uniquely identifiable
-const sf = new SchemaFactory("fc1db2e8-0a00-11ee-be56-0242ac120002");
+// Include a UUID to guarantee that this schema will be uniquely identifiable.
+// As this schema uses a recursive type, the beta SchemaFactoryRecursive is used instead of just SchemaFactory.
+const sf = new SchemaFactoryRecursive("fc1db2e8-0a00-11ee-be56-0242ac120002");
 
-// Define the schema for the note object. This schema includes an id to make
-// building the React app simpler, several fields that use primitive types, and a sequence
-// of user ids to track which users have voted on this note.
-// Some of the helper functions for working with the data contained in this object
-// are included in this class definition.
-export class Note extends sf.object("Note", {
-	id: sf.string,
-	text: sf.string,
-	author: sf.string,
-	votes: sf.array(sf.string),
-	created: sf.number,
-	lastChanged: sf.number,
-}) {
+// Define the schema for the note object.
+// Helper functions for working with the data contained in this object
+// are included in this class definition as methods.
+export class Note extends sf.object(
+	"Note",
+	// Fields for Notes which SharedTree will store and synchronize across clients.
+	// These fields are exposed as members of instances of the Note class.
+	{
+		/**
+		 * Id to make building the React app simpler.
+		 */
+		id: sf.string,
+		text: sf.string,
+		author: sf.string,
+		/**
+		 * Sequence of user ids to track which users have voted on this note.
+		 */
+		votes: sf.array(sf.string),
+		created: sf.number,
+		lastChanged: sf.number,
+	},
+) {
 	// Update the note text and also update the timestamp in the note
 	public updateText(text: string) {
 		this.lastChanged = new Date().getTime();
@@ -36,40 +45,55 @@ export class Note extends sf.object("Note", {
 		const index = this.votes.indexOf(user);
 		if (index > -1) {
 			this.votes.removeAt(index);
-			this.lastChanged = new Date().getTime();
 		} else {
 			this.votes.insertAtEnd(user);
-			this.lastChanged = new Date().getTime();
+		}
+
+		this.lastChanged = new Date().getTime();
+	}
+
+	/**
+	 * Removes a node from its parent {@link Items}.
+	 * If the note is not in an {@link Items}, it is left unchanged.
+	 */
+	public delete() {
+		const parent = Tree.parent(this);
+		// Use type narrowing to ensure that parent is Items as expected for a note.
+		if (Tree.is(parent, Items)) {
+			const index = parent.indexOf(this);
+			parent.removeAt(index);
 		}
 	}
 }
 
-// Schema for a list of Notes.
-export class Notes extends sf.array("Notes", Note) {
-	public newNote(author: string) {
-		addNote(this, "", author);
-	}
-}
-
-// Define the schema for the container of notes.
-export class Group extends sf.object("Group", {
-	id: sf.string,
-	name: sf.string,
-	notes: Notes,
-}) {}
-
 // Schema for a list of Notes and Groups.
-export class Items extends sf.array("Items", [Group, Note]) {
-	public newNote(author: string) {
-		addNote(this, "", author);
+export class Items extends sf.arrayRecursive("Items", [() => Group, Note]) {
+	public addNode(author: string) {
+		const timeStamp = new Date().getTime();
+
+		// Define the note to add to the SharedTree - this must conform to
+		// the schema definition of a note
+		const newNote = new Note({
+			id: Guid.create().toString(),
+			text: "",
+			author,
+			votes: [],
+			created: timeStamp,
+			lastChanged: timeStamp,
+		});
+
+		// Insert the note into the SharedTree.
+		this.insertAtEnd(newNote);
 	}
 
-	// Add a new group (container for notes) to the SharedTree.
-	public newGroup(name: string): Group {
+	/**
+	 * Add a new group (container for notes) to the SharedTree.
+	 */
+	public addGroup(name: string): Group {
 		const group = new Group({
 			id: Guid.create().toString(),
 			name,
-			notes: [],
+			items: new Items([]),
 		});
 
 		this.insertAtEnd(group);
@@ -77,17 +101,41 @@ export class Items extends sf.array("Items", [Group, Note]) {
 	}
 }
 
-// Define a root type.
-export class App extends sf.object("App", {
+// Define the schema for the container of notes.
+export class Group extends sf.object("Group", {
+	id: sf.string,
+	name: sf.string,
 	items: Items,
-}) {}
+}) {
+	/**
+	 * Removes a group from its parent {@link Items}.
+	 * If the note is not in an {@link Items}, it is left unchanged.
+	 *
+	 * Before removing the group, its children are move to the parent.
+	 */
+	public delete() {
+		const parent = Tree.parent(this);
+		if (Tree.is(parent, Items)) {
+			// Test for the presence of notes and move them to the root
+			// in the same position as the group
+			// TODO: This check for `length !== 0` should be able to be removed once a bug in SharedTree is fixed.
+			if (this.items.length !== 0) {
+				const index = parent.indexOf(this);
+				parent.moveRangeToIndex(index, 0, this.items.length, this.items);
+			}
 
-// Export the tree config appropriate for this schema
-// This is passed into the SharedTree when it is initialized
+			// Delete the now empty group
+			const i = parent.indexOf(this);
+			parent.removeAt(i);
+		}
+	}
+}
+
+// Export the tree config appropriate for this schema.
+// This is passed into the SharedTree when it is initialized.
 export const appTreeConfiguration = new TreeConfiguration(
-	App, // root node
-	() => ({
-		// initial tree
-		items: [],
-	}),
+	// Schema for the root
+	Items,
+	// initial tree
+	() => new Items([]),
 );

--- a/brainstorm/src/schema/app_schema.ts
+++ b/brainstorm/src/schema/app_schema.ts
@@ -3,7 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { TreeConfiguration, SchemaFactoryRecursive, Tree } from "fluid-framework";
+import {
+	TreeConfiguration,
+	SchemaFactoryRecursive,
+	Tree,
+	ValidateRecursiveSchema,
+} from "fluid-framework";
 import { Guid } from "guid-typescript";
 
 // Schema is defined using a factory object that generates classes for objects as well
@@ -99,6 +104,14 @@ export class Items extends sf.arrayRecursive("Items", [() => Group, Note]) {
 		this.insertAtEnd(group);
 		return group;
 	}
+}
+
+{
+	// Due to limitations of TypeScript, recursive schema may not produce type errors when declared incorrectly.
+	// Using ValidateRecursiveSchema helps ensure that mistakes made in the definition of a recursive schema (like `Items`)
+	// will introduce a compile error.
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	type _check = ValidateRecursiveSchema<typeof Items>;
 }
 
 // Define the schema for the container of notes.

--- a/brainstorm/src/utils/app_helpers.ts
+++ b/brainstorm/src/utils/app_helpers.ts
@@ -4,36 +4,11 @@
  */
 
 import { Tree, TreeStatus } from "fluid-framework";
-import { App, Note, Group, Notes, Items } from "../schema/app_schema";
-import { Guid } from "guid-typescript";
-
-// Takes a destination list, content string, and author data and adds a new
-// note to the SharedTree with that data.
-// This function is called from methods in the Items and Notes classes
-// defined in the app_schema.ts file.
-export function addNote(notes: Notes | Items, text: string, author: string) {
-	const timeStamp = new Date().getTime();
-
-	// Define the note to add to the SharedTree - this must conform to
-	// the schema definition of a note
-	const newNote = new Note({
-		id: Guid.create().toString(),
-		text,
-		author,
-		votes: [],
-		created: timeStamp,
-		lastChanged: timeStamp,
-	});
-
-	// Insert the note into the SharedTree. This code always inserts the note at the end of the
-	// notes sequence in the provided pile object. As this function can insert multiple items,
-	// the note is passed in an array.
-	notes.insertAtEnd(newNote);
-}
+import { Note, Group, Items } from "../schema/app_schema";
 
 // Move a note from one position in a sequence to another position in the same sequence or
 // in a different sequence. The index being passed here is the desired index after the move.
-export function moveItem(item: Note | Group, destinationIndex: number, destination: Notes | Items) {
+export function moveItem(item: Note | Group, destinationIndex: number, destination: Items) {
 	// need to test that the destination or the item being dragged hasn't been deleted
 	// because the move may have been initiated through a drag and drop which
 	// is asynchronous - the state may have changed during the drag but this function
@@ -46,22 +21,10 @@ export function moveItem(item: Note | Group, destinationIndex: number, destinati
 
 	const source = Tree.parent(item);
 
-	// Use instanceof to narrow the type of source to the items schema
+	// Use Tree.is to narrow the type of source to the items schema
 	// If source uses the items schema, it can receive both a note
 	// and a group
-	if (source instanceof Items) {
-		const index = source.indexOf(item);
-		if (destinationIndex == Infinity) {
-			destination.moveToEnd(index, source);
-		} else {
-			destination.moveToIndex(destinationIndex, index, source);
-		}
-	}
-
-	// Use instanceof to narrow the type of source to the notes schema
-	// If source uses the notes schema, it can only receive a note
-	// so we also narrow the type of item to the note schema
-	if (source instanceof Notes && item instanceof Note) {
+	if (Tree.is(source, Items)) {
 		const index = source.indexOf(item);
 		if (destinationIndex == Infinity) {
 			destination.moveToEnd(index, source);
@@ -71,46 +34,16 @@ export function moveItem(item: Note | Group, destinationIndex: number, destinati
 	}
 }
 
-// Function that deletes a group and moves the notes in that group
-// to the root instead of deleting them as well
-export function deleteGroup(group: Group, app: App) {
-	// Test for the presence of notes and move them to the root
-	// in the same position as the group
-	if (group.notes.length !== 0) {
-		const index = app.items.indexOf(group);
-		app.items.moveRangeToIndex(index, 0, group.notes.length, group.notes);
-	}
-
-	// Delete the now empty group
-	const parent = Tree.parent(group);
-	if (parent instanceof Items) {
-		const i = parent.indexOf(group);
-		parent.removeAt(i);
-	}
-}
-
-// Function to delete a note.
-export function deleteNote(note: Note) {
-	const parent = Tree.parent(note);
-	// Use type narrowing to ensure that parent is one of the two
-	// types of allowed lists for a note and not undefined
-	if (Tree.is(parent, Notes) || Tree.is(parent, Items)) {
-		const index = parent.indexOf(note);
-		parent.removeAt(index);
-	}
-}
-
-export const findNote = (items: Items | Notes, id: string): Note | undefined => {
+export function findNote(items: Items, id: string): Note | undefined {
 	for (const i of items) {
-		if (i instanceof Note) {
+		if (Tree.is(i, Note)) {
 			if (i.id === id) return i;
-		}
-		if (i instanceof Group) {
-			const n = findNote(i.notes, id);
-			if (n instanceof Note) {
+		} else {
+			const n = findNote(i.items, id);
+			if (n !== undefined) {
 				return n;
 			}
 		}
 	}
 	return undefined;
-};
+}


### PR DESCRIPTION
Demo recursive schema support in Brainstorm. As far as I know this is the first non-trivial use of the new recursive schema APIs, so this was a valuable test of those, as well as a demo for them.

Additionally, more functions were moved onto the schema as methods, root and group handling were unified (via Items), some comments were converted to doc comments to help with IntelliSense and show off that doc comments on fields in schema actually work.

A few places stopped taking in parents explicitly and instead look them up in the tree.

Tree.is has been used instead of instancof since it works in more cases (for example with leaf nodes and POJO mode schema): this is more of just encouraging a more general pattern than a fix since instancof works fine where it was used.