### PR TITLE
Fix users count in brainstorm app on startup

### DIFF
--- a/brainstorm/src/react/canvasux.tsx
+++ b/brainstorm/src/react/canvasux.tsx
@@ -91,6 +91,7 @@ export function Canvas(props: {
 
 	useEffect(() => {
 		props.audience.on("membersChanged", updateMembers);
+		updateMembers();
 		return () => {
 			props.audience.off("membersChanged", updateMembers);
 		};


### PR DESCRIPTION
This PR fixes a bug in the brainstorm app where the users count does not properly update on startup. This is because we setup the event listener, but it does not fire until another `"membersChanged"` event. To fix this, we can call `updateMembers()` to ensure it gets the latest audience data on startup.