### PR TITLE
build: Update `html-webpack-plugin` and `webpack-dev-server`

### DIFF
--- a/brainstorm/package-lock.json
+++ b/brainstorm/package-lock.json
@@ -50,7 +50,7 @@
 				"dotenv-webpack": "^7.1.1",
 				"eslint": "^8.23.1",
 				"eslint-plugin-react": "^7.31.8",
-				"html-webpack-plugin": "^4.5.2",
+				"html-webpack-plugin": "^5.6.0",
 				"jest": "^29.2.2",
 				"jest-junit": "^16.0.0",
 				"jest-puppeteer": "^9.0.0",
@@ -4738,9 +4738,9 @@
 			}
 		},
 		"node_modules/@types/html-minifier-terser": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz",
-			"integrity": "sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
+			"integrity": "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==",
 			"dev": true
 		},
 		"node_modules/@types/http-errors": {
@@ -4931,22 +4931,10 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/source-list-map": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.6.tgz",
-			"integrity": "sha512-5JcVt1u5HDmlXkwOD2nslZVllBBc7HDuOICfiZah2Z0is8M8g+ddAEawbmd3VjedfDHBzxCaXLs07QEmb7y54g==",
-			"dev": true
-		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
 			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-			"dev": true
-		},
-		"node_modules/@types/tapable": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.12.tgz",
-			"integrity": "sha512-bTHG8fcxEqv1M9+TD14P8ok8hjxoOCkfKc8XXLaaD05kI7ohpeI956jtDOD3XHKBQrlyPughUtzm1jtVhHpA5Q==",
 			"dev": true
 		},
 		"node_modules/@types/triple-beam": {
@@ -4955,54 +4943,11 @@
 			"integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
 			"dev": true
 		},
-		"node_modules/@types/uglify-js": {
-			"version": "3.17.5",
-			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.17.5.tgz",
-			"integrity": "sha512-TU+fZFBTBcXj/GpDpDaBmgWk/gn96kMZ+uocaFUlV2f8a6WdMzzI44QBCmGcCiYR0Y6ZlNRiyUyKKt5nl/lbzQ==",
-			"dev": true,
-			"dependencies": {
-				"source-map": "^0.6.1"
-			}
-		},
 		"node_modules/@types/uuid": {
 			"version": "9.0.8",
 			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
 			"integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
 			"dev": true
-		},
-		"node_modules/@types/webpack": {
-			"version": "4.41.38",
-			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.38.tgz",
-			"integrity": "sha512-oOW7E931XJU1mVfCnxCVgv8GLFL768pDO5u2Gzk82i8yTIgX6i7cntyZOkZYb/JtYM8252SN9bQp9tgkVDSsRw==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*",
-				"@types/tapable": "^1",
-				"@types/uglify-js": "*",
-				"@types/webpack-sources": "*",
-				"anymatch": "^3.0.0",
-				"source-map": "^0.6.0"
-			}
-		},
-		"node_modules/@types/webpack-sources": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-3.2.3.tgz",
-			"integrity": "sha512-4nZOdMwSPHZ4pTEZzSp0AsTM4K7Qmu40UKW4tJDiOVs20UzYF9l+qUe4s0ftfN0pin06n+5cWWDJXH+sbhAiDw==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*",
-				"@types/source-list-map": "*",
-				"source-map": "^0.7.3"
-			}
-		},
-		"node_modules/@types/webpack-sources/node_modules/source-map": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-			"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 8"
-			}
 		},
 		"node_modules/@types/ws": {
 			"version": "6.0.4",
@@ -5875,27 +5820,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/array.prototype.reduce": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.7.tgz",
-			"integrity": "sha512-mzmiUCVwtiD4lgxYP8g7IYy8El8p2CSMePvIbTS7gchKir/L1fgJrk0yDKmAX6mnRQFKNADYIk8nNlTris5H1Q==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.7",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.2",
-				"es-array-method-boxes-properly": "^1.0.0",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.0.0",
-				"is-string": "^1.0.7"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/array.prototype.toreversed": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/array.prototype.toreversed/-/array.prototype.toreversed-1.1.2.tgz",
@@ -6755,15 +6679,15 @@
 			}
 		},
 		"node_modules/clean-css": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
-			"integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+			"integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
 			"dev": true,
 			"dependencies": {
 				"source-map": "~0.6.0"
 			},
 			"engines": {
-				"node": ">= 4.0"
+				"node": ">= 10.0"
 			}
 		},
 		"node_modules/clean-git-ref": {
@@ -8129,12 +8053,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/es-array-method-boxes-properly": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-			"dev": true
 		},
 		"node_modules/es-define-property": {
 			"version": "1.0.0",
@@ -9844,73 +9762,74 @@
 			"dev": true
 		},
 		"node_modules/html-minifier-terser": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
-			"integrity": "sha512-ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
+			"integrity": "sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==",
 			"dev": true,
 			"dependencies": {
-				"camel-case": "^4.1.1",
-				"clean-css": "^4.2.3",
-				"commander": "^4.1.1",
+				"camel-case": "^4.1.2",
+				"clean-css": "^5.2.2",
+				"commander": "^8.3.0",
 				"he": "^1.2.0",
-				"param-case": "^3.0.3",
+				"param-case": "^3.0.4",
 				"relateurl": "^0.2.7",
-				"terser": "^4.6.3"
+				"terser": "^5.10.0"
 			},
 			"bin": {
 				"html-minifier-terser": "cli.js"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=12"
+			}
+		},
+		"node_modules/html-minifier-terser/node_modules/commander": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+			"dev": true,
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/html-webpack-plugin": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.5.2.tgz",
-			"integrity": "sha512-q5oYdzjKUIPQVjOosjgvCHQOv9Ett9CYYHlgvJeXG0qQvdSojnBq4vAdQBwn1+yGveAwHCoe/rMR86ozX3+c2A==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.0.tgz",
+			"integrity": "sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==",
 			"dev": true,
 			"dependencies": {
-				"@types/html-minifier-terser": "^5.0.0",
-				"@types/tapable": "^1.0.5",
-				"@types/webpack": "^4.41.8",
-				"html-minifier-terser": "^5.0.1",
-				"loader-utils": "^1.2.3",
-				"lodash": "^4.17.20",
-				"pretty-error": "^2.1.1",
-				"tapable": "^1.1.3",
-				"util.promisify": "1.0.0"
+				"@types/html-minifier-terser": "^6.0.0",
+				"html-minifier-terser": "^6.0.2",
+				"lodash": "^4.17.21",
+				"pretty-error": "^4.0.0",
+				"tapable": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=6.9"
+				"node": ">=10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/html-webpack-plugin"
 			},
 			"peerDependencies": {
-				"webpack": "^4.0.0 || ^5.0.0"
+				"@rspack/core": "0.x || 1.x",
+				"webpack": "^5.20.0"
+			},
+			"peerDependenciesMeta": {
+				"@rspack/core": {
+					"optional": true
+				},
+				"webpack": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/html-webpack-plugin/node_modules/json5": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+		"node_modules/html-webpack-plugin/node_modules/tapable": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
 			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.0"
-			},
-			"bin": {
-				"json5": "lib/cli.js"
-			}
-		},
-		"node_modules/html-webpack-plugin/node_modules/loader-utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-			"integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-			"dev": true,
-			"dependencies": {
-				"big.js": "^5.2.2",
-				"emojis-list": "^3.0.0",
-				"json5": "^1.0.1"
-			},
 			"engines": {
-				"node": ">=4.0.0"
+				"node": ">=6"
 			}
 		},
 		"node_modules/htmlparser2": {
@@ -14134,27 +14053,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/object.getownpropertydescriptors": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.8.tgz",
-			"integrity": "sha512-qkHIGe4q0lSYMv0XI4SsBTJz3WaURhLvd0lKSgtVuOsJ2krg4SgMw3PIRQFMp07yi++UR3se2mkcLqsBNpBb/A==",
-			"dev": true,
-			"dependencies": {
-				"array.prototype.reduce": "^1.0.6",
-				"call-bind": "^1.0.7",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.2",
-				"es-object-atoms": "^1.0.0",
-				"gopd": "^1.0.1",
-				"safe-array-concat": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/object.hasown": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.4.tgz",
@@ -14893,13 +14791,13 @@
 			}
 		},
 		"node_modules/pretty-error": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.2.tgz",
-			"integrity": "sha512-EY5oDzmsX5wvuynAByrmY0P0hcp+QpnAKbJng2A2MPjVKXCxrDSUkzghVJ4ZGPIv+JC4gX8fPUWscC0RtjsWGw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
+			"integrity": "sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==",
 			"dev": true,
 			"dependencies": {
 				"lodash": "^4.17.20",
-				"renderkid": "^2.0.4"
+				"renderkid": "^3.0.0"
 			}
 		},
 		"node_modules/pretty-format": {
@@ -15523,37 +15421,16 @@
 			}
 		},
 		"node_modules/renderkid": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.7.tgz",
-			"integrity": "sha512-oCcFyxaMrKsKcTY59qnCAtmDVSLfPbrv6A3tVbPdFMMrv5jaK10V6m40cKsoPNhAqN6rmHW9sswW4o3ruSrwUQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
+			"integrity": "sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==",
 			"dev": true,
 			"dependencies": {
 				"css-select": "^4.1.3",
 				"dom-converter": "^0.2.0",
 				"htmlparser2": "^6.1.0",
 				"lodash": "^4.17.21",
-				"strip-ansi": "^3.0.1"
-			}
-		},
-		"node_modules/renderkid/node_modules/ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/renderkid/node_modules/strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
+				"strip-ansi": "^6.0.1"
 			}
 		},
 		"node_modules/require-directory": {
@@ -17019,20 +16896,21 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "4.8.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
-			"integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+			"version": "5.31.5",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.31.5.tgz",
+			"integrity": "sha512-YPmas0L0rE1UyLL/llTWA0SiDOqIcAQYLeUj7cJYzXHlRTAnMSg9pPe4VJ5PlKvTrPQsdVFuiRiwyeNlYgwh2Q==",
 			"dev": true,
 			"dependencies": {
+				"@jridgewell/source-map": "^0.3.3",
+				"acorn": "^8.8.2",
 				"commander": "^2.20.0",
-				"source-map": "~0.6.1",
-				"source-map-support": "~0.5.12"
+				"source-map-support": "~0.5.20"
 			},
 			"bin": {
 				"terser": "bin/terser"
 			},
 			"engines": {
-				"node": ">=6.0.0"
+				"node": ">=10"
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
@@ -17068,12 +16946,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/terser-webpack-plugin/node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
 		},
 		"node_modules/terser-webpack-plugin/node_modules/has-flag": {
 			"version": "4.0.0",
@@ -17116,16 +16988,6 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
-		"node_modules/terser-webpack-plugin/node_modules/source-map-support": {
-			"version": "0.5.21",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-			"dev": true,
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			}
-		},
 		"node_modules/terser-webpack-plugin/node_modules/supports-color": {
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -17141,29 +17003,21 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
-		"node_modules/terser-webpack-plugin/node_modules/terser": {
-			"version": "5.30.3",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.30.3.tgz",
-			"integrity": "sha512-STdUgOUx8rLbMGO9IOwHLpCqolkDITFFQSMYYwKE1N2lY6MVSaeoi10z/EhWxRc6ybqoVmKSkhKYH/XUpl7vSA==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/source-map": "^0.3.3",
-				"acorn": "^8.8.2",
-				"commander": "^2.20.0",
-				"source-map-support": "~0.5.20"
-			},
-			"bin": {
-				"terser": "bin/terser"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/terser/node_modules/commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
+		},
+		"node_modules/terser/node_modules/source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
 		},
 		"node_modules/test-exclude": {
 			"version": "6.0.0",
@@ -17861,16 +17715,6 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true
-		},
-		"node_modules/util.promisify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-			"dev": true,
-			"dependencies": {
-				"define-properties": "^1.1.2",
-				"object.getownpropertydescriptors": "^2.0.3"
-			}
 		},
 		"node_modules/utila": {
 			"version": "0.4.0",

--- a/brainstorm/package-lock.json
+++ b/brainstorm/package-lock.json
@@ -64,7 +64,7 @@
 				"typescript": "~5.4",
 				"webpack": "^5.88.2",
 				"webpack-cli": "^5.1.4",
-				"webpack-dev-server": "^4.15.1"
+				"webpack-dev-server": "^5.0.4"
 			},
 			"engines": {
 				"node": ">=20.0.0"
@@ -4277,6 +4277,60 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@jsonjoy.com/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/json-pack": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.1.0.tgz",
+			"integrity": "sha512-zlQONA+msXPPwHWZMKFVS78ewFczIll5lXiVPwFPCZUsrOKdxc2AvxU1HoNBmMRhqDZUR9HkC3UOm+6pME6Xsg==",
+			"dev": true,
+			"dependencies": {
+				"@jsonjoy.com/base64": "^1.1.1",
+				"@jsonjoy.com/util": "^1.1.2",
+				"hyperdyperid": "^1.2.0",
+				"thingies": "^1.20.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/util": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.3.0.tgz",
+			"integrity": "sha512-Cebt4Vk7k1xHy87kHY7KSPLT77A7Ev7IfOblyLZhtYEhrdQ6fX4EoLq3xOQ3O/DRMEh2ok5nyC180E+ABS8Wmw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
 		"node_modules/@leichtgewicht/ip-codec": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -4881,9 +4935,9 @@
 			}
 		},
 		"node_modules/@types/retry": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+			"integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
 			"dev": true
 		},
 		"node_modules/@types/semver": {
@@ -6430,6 +6484,21 @@
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true
 		},
+		"node_modules/bundle-name": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+			"integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+			"dev": true,
+			"dependencies": {
+				"run-applescript": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/bytes": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -7456,6 +7525,34 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/default-browser": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+			"integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+			"dev": true,
+			"dependencies": {
+				"bundle-name": "^4.1.0",
+				"default-browser-id": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser-id": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+			"integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/default-gateway": {
@@ -9267,12 +9364,6 @@
 				"node": ">=14.14"
 			}
 		},
-		"node_modules/fs-monkey": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.5.tgz",
-			"integrity": "sha512-8uMbBjrhzW76TYgEV27Y5E//W2f/lTFmx78P2w19FZSxarhI/798APGQyuGCwmkNxgwGRhrLfvWyLBvNtuOmew==",
-			"dev": true
-		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -9959,6 +10050,15 @@
 				"ms": "^2.0.0"
 			}
 		},
+		"node_modules/hyperdyperid": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+			"integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.18"
+			}
+		},
 		"node_modules/iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -10427,6 +10527,39 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-inside-container": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"dev": true,
+			"dependencies": {
+				"is-docker": "^3.0.0"
+			},
+			"bin": {
+				"is-inside-container": "cli.js"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-inside-container/node_modules/is-docker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"dev": true,
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-map": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -10465,6 +10598,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-network-error": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.1.0.tgz",
+			"integrity": "sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-number": {
@@ -13392,15 +13537,22 @@
 			}
 		},
 		"node_modules/memfs": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
-			"integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.11.1.tgz",
+			"integrity": "sha512-LZcMTBAgqUUKNXZagcZxvXXfgF1bHX7Y7nQ0QyEiNbRJgE29GhgPd8Yna1VQcLlPiHt/5RFJMWYN9Uv/VPNvjQ==",
 			"dev": true,
 			"dependencies": {
-				"fs-monkey": "^1.0.4"
+				"@jsonjoy.com/json-pack": "^1.0.3",
+				"@jsonjoy.com/util": "^1.3.0",
+				"tree-dump": "^1.0.1",
+				"tslib": "^2.0.0"
 			},
 			"engines": {
 				"node": ">= 4.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
 			}
 		},
 		"node_modules/memory-fs": {
@@ -13623,9 +13775,9 @@
 			}
 		},
 		"node_modules/minipass": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-			"integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
 			"dev": true,
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -14229,16 +14381,20 @@
 			}
 		},
 		"node_modules/p-retry": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.0.tgz",
+			"integrity": "sha512-JA6nkq6hKyWLLasXQXUrO4z8BUZGUt/LjlJxx8Gb2+2ntodU/SS63YZ8b0LUTbQ8ZB9iwOfhEPhg4ykKnn2KsA==",
 			"dev": true,
 			"dependencies": {
-				"@types/retry": "0.12.0",
+				"@types/retry": "0.12.2",
+				"is-network-error": "^1.0.0",
 				"retry": "^0.13.1"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-try": {
@@ -14281,6 +14437,12 @@
 			"engines": {
 				"node": ">= 14"
 			}
+		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+			"integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+			"dev": true
 		},
 		"node_modules/pako": {
 			"version": "1.0.11",
@@ -14395,16 +14557,16 @@
 			"dev": true
 		},
 		"node_modules/path-scurry": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.2.tgz",
-			"integrity": "sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^10.2.0",
 				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": ">=16 || 14 >=14.18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -15566,6 +15728,18 @@
 			"integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
 			"dependencies": {
 				"@babel/runtime": "^7.1.2"
+			}
+		},
+		"node_modules/run-applescript": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+			"integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/run-parallel": {
@@ -17075,6 +17249,18 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/thingies": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
+			"integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.18"
+			},
+			"peerDependencies": {
+				"tslib": "^2"
+			}
+		},
 		"node_modules/through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -17216,6 +17402,22 @@
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+		},
+		"node_modules/tree-dump": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.2.tgz",
+			"integrity": "sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
 		},
 		"node_modules/tree-kill": {
 			"version": "1.2.2",
@@ -17923,77 +18125,83 @@
 			}
 		},
 		"node_modules/webpack-dev-middleware": {
-			"version": "5.3.4",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
-			"integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.3.0.tgz",
+			"integrity": "sha512-xD2qnNew+F6KwOGZR7kWdbIou/ud7cVqLEXeK1q0nHcNsX/u7ul/fSdlOTX4ntSL5FNFy7ZJJXbf0piF591JYw==",
 			"dev": true,
 			"dependencies": {
 				"colorette": "^2.0.10",
-				"memfs": "^3.4.3",
+				"memfs": "^4.6.0",
 				"mime-types": "^2.1.31",
+				"on-finished": "^2.4.1",
 				"range-parser": "^1.2.1",
 				"schema-utils": "^4.0.0"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.0.0 || ^5.0.0"
+				"webpack": "^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"webpack": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/webpack-dev-server": {
-			"version": "4.15.2",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
-			"integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.0.4.tgz",
+			"integrity": "sha512-dljXhUgx3HqKP2d8J/fUMvhxGhzjeNVarDLcbO/EWMSgRizDkxHQDZQaLFL5VJY9tRBj2Gz+rvCEYYvhbqPHNA==",
 			"dev": true,
 			"dependencies": {
-				"@types/bonjour": "^3.5.9",
-				"@types/connect-history-api-fallback": "^1.3.5",
-				"@types/express": "^4.17.13",
-				"@types/serve-index": "^1.9.1",
-				"@types/serve-static": "^1.13.10",
-				"@types/sockjs": "^0.3.33",
-				"@types/ws": "^8.5.5",
+				"@types/bonjour": "^3.5.13",
+				"@types/connect-history-api-fallback": "^1.5.4",
+				"@types/express": "^4.17.21",
+				"@types/serve-index": "^1.9.4",
+				"@types/serve-static": "^1.15.5",
+				"@types/sockjs": "^0.3.36",
+				"@types/ws": "^8.5.10",
 				"ansi-html-community": "^0.0.8",
-				"bonjour-service": "^1.0.11",
-				"chokidar": "^3.5.3",
+				"bonjour-service": "^1.2.1",
+				"chokidar": "^3.6.0",
 				"colorette": "^2.0.10",
 				"compression": "^1.7.4",
 				"connect-history-api-fallback": "^2.0.0",
 				"default-gateway": "^6.0.3",
 				"express": "^4.17.3",
 				"graceful-fs": "^4.2.6",
-				"html-entities": "^2.3.2",
+				"html-entities": "^2.4.0",
 				"http-proxy-middleware": "^2.0.3",
-				"ipaddr.js": "^2.0.1",
-				"launch-editor": "^2.6.0",
-				"open": "^8.0.9",
-				"p-retry": "^4.5.0",
-				"rimraf": "^3.0.2",
-				"schema-utils": "^4.0.0",
-				"selfsigned": "^2.1.1",
+				"ipaddr.js": "^2.1.0",
+				"launch-editor": "^2.6.1",
+				"open": "^10.0.3",
+				"p-retry": "^6.2.0",
+				"rimraf": "^5.0.5",
+				"schema-utils": "^4.2.0",
+				"selfsigned": "^2.4.1",
 				"serve-index": "^1.9.1",
 				"sockjs": "^0.3.24",
 				"spdy": "^4.0.2",
-				"webpack-dev-middleware": "^5.3.4",
-				"ws": "^8.13.0"
+				"webpack-dev-middleware": "^7.1.0",
+				"ws": "^8.16.0"
 			},
 			"bin": {
 				"webpack-dev-server": "bin/webpack-dev-server.js"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.37.0 || ^5.0.0"
+				"webpack": "^5.0.0"
 			},
 			"peerDependenciesMeta": {
 				"webpack": {
@@ -18013,6 +18221,47 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/webpack-dev-server/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/define-lazy-prop": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/glob": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"dev": true,
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/webpack-dev-server/node_modules/ipaddr.js": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
@@ -18020,6 +18269,84 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 10"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/is-wsl": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+			"dev": true,
+			"dependencies": {
+				"is-inside-container": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/open": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+			"integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+			"dev": true,
+			"dependencies": {
+				"default-browser": "^5.2.1",
+				"define-lazy-prop": "^3.0.0",
+				"is-inside-container": "^1.0.0",
+				"is-wsl": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/rimraf": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+			"integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+			"dev": true,
+			"dependencies": {
+				"glob": "^10.3.7"
+			},
+			"bin": {
+				"rimraf": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/webpack-merge": {

--- a/brainstorm/package.json
+++ b/brainstorm/package.json
@@ -79,7 +79,7 @@
 		"typescript": "~5.4",
 		"webpack": "^5.88.2",
 		"webpack-cli": "^5.1.4",
-		"webpack-dev-server": "^4.15.1"
+		"webpack-dev-server": "^5.0.4"
 	},
 	"jest-junit": {
 		"outputDirectory": "nyc",

--- a/brainstorm/package.json
+++ b/brainstorm/package.json
@@ -65,7 +65,7 @@
 		"dotenv-webpack": "^7.1.1",
 		"eslint": "^8.23.1",
 		"eslint-plugin-react": "^7.31.8",
-		"html-webpack-plugin": "^4.5.2",
+		"html-webpack-plugin": "^5.6.0",
 		"jest": "^29.2.2",
 		"jest-junit": "^16.0.0",
 		"jest-puppeteer": "^9.0.0",

--- a/item-counter-spe/package-lock.json
+++ b/item-counter-spe/package-lock.json
@@ -40,7 +40,7 @@
 				"dotenv-webpack": "^7.1.1",
 				"eslint": "^8.23.1",
 				"eslint-plugin-react": "^7.31.8",
-				"html-webpack-plugin": "^4.5.2",
+				"html-webpack-plugin": "^5.6.0",
 				"jest": "^29.2.2",
 				"jest-junit": "^16.0.0",
 				"jest-puppeteer": "^9.0.0",
@@ -3056,9 +3056,9 @@
 			}
 		},
 		"node_modules/@types/html-minifier-terser": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz",
-			"integrity": "sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
+			"integrity": "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==",
 			"dev": true
 		},
 		"node_modules/@types/http-errors": {
@@ -3221,66 +3221,11 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/source-list-map": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.6.tgz",
-			"integrity": "sha512-5JcVt1u5HDmlXkwOD2nslZVllBBc7HDuOICfiZah2Z0is8M8g+ddAEawbmd3VjedfDHBzxCaXLs07QEmb7y54g==",
-			"dev": true
-		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
 			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
 			"dev": true
-		},
-		"node_modules/@types/tapable": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.12.tgz",
-			"integrity": "sha512-bTHG8fcxEqv1M9+TD14P8ok8hjxoOCkfKc8XXLaaD05kI7ohpeI956jtDOD3XHKBQrlyPughUtzm1jtVhHpA5Q==",
-			"dev": true
-		},
-		"node_modules/@types/uglify-js": {
-			"version": "3.17.5",
-			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.17.5.tgz",
-			"integrity": "sha512-TU+fZFBTBcXj/GpDpDaBmgWk/gn96kMZ+uocaFUlV2f8a6WdMzzI44QBCmGcCiYR0Y6ZlNRiyUyKKt5nl/lbzQ==",
-			"dev": true,
-			"dependencies": {
-				"source-map": "^0.6.1"
-			}
-		},
-		"node_modules/@types/webpack": {
-			"version": "4.41.38",
-			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.38.tgz",
-			"integrity": "sha512-oOW7E931XJU1mVfCnxCVgv8GLFL768pDO5u2Gzk82i8yTIgX6i7cntyZOkZYb/JtYM8252SN9bQp9tgkVDSsRw==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*",
-				"@types/tapable": "^1",
-				"@types/uglify-js": "*",
-				"@types/webpack-sources": "*",
-				"anymatch": "^3.0.0",
-				"source-map": "^0.6.0"
-			}
-		},
-		"node_modules/@types/webpack-sources": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-3.2.3.tgz",
-			"integrity": "sha512-4nZOdMwSPHZ4pTEZzSp0AsTM4K7Qmu40UKW4tJDiOVs20UzYF9l+qUe4s0ftfN0pin06n+5cWWDJXH+sbhAiDw==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*",
-				"@types/source-list-map": "*",
-				"source-map": "^0.7.3"
-			}
-		},
-		"node_modules/@types/webpack-sources/node_modules/source-map": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-			"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 8"
-			}
 		},
 		"node_modules/@types/ws": {
 			"version": "8.5.10",
@@ -4114,27 +4059,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/array.prototype.reduce": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.7.tgz",
-			"integrity": "sha512-mzmiUCVwtiD4lgxYP8g7IYy8El8p2CSMePvIbTS7gchKir/L1fgJrk0yDKmAX6mnRQFKNADYIk8nNlTris5H1Q==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.7",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.2",
-				"es-array-method-boxes-properly": "^1.0.0",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.0.0",
-				"is-string": "^1.0.7"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/array.prototype.toreversed": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/array.prototype.toreversed/-/array.prototype.toreversed-1.1.2.tgz",
@@ -4888,15 +4812,15 @@
 			"dev": true
 		},
 		"node_modules/clean-css": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
-			"integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+			"integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
 			"dev": true,
 			"dependencies": {
 				"source-map": "~0.6.0"
 			},
 			"engines": {
-				"node": ">= 4.0"
+				"node": ">= 10.0"
 			}
 		},
 		"node_modules/cliui": {
@@ -6084,12 +6008,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/es-array-method-boxes-properly": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-			"dev": true
 		},
 		"node_modules/es-define-property": {
 			"version": "1.0.0",
@@ -7706,73 +7624,74 @@
 			"dev": true
 		},
 		"node_modules/html-minifier-terser": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
-			"integrity": "sha512-ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
+			"integrity": "sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==",
 			"dev": true,
 			"dependencies": {
-				"camel-case": "^4.1.1",
-				"clean-css": "^4.2.3",
-				"commander": "^4.1.1",
+				"camel-case": "^4.1.2",
+				"clean-css": "^5.2.2",
+				"commander": "^8.3.0",
 				"he": "^1.2.0",
-				"param-case": "^3.0.3",
+				"param-case": "^3.0.4",
 				"relateurl": "^0.2.7",
-				"terser": "^4.6.3"
+				"terser": "^5.10.0"
 			},
 			"bin": {
 				"html-minifier-terser": "cli.js"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=12"
+			}
+		},
+		"node_modules/html-minifier-terser/node_modules/commander": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+			"dev": true,
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/html-webpack-plugin": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.5.2.tgz",
-			"integrity": "sha512-q5oYdzjKUIPQVjOosjgvCHQOv9Ett9CYYHlgvJeXG0qQvdSojnBq4vAdQBwn1+yGveAwHCoe/rMR86ozX3+c2A==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.0.tgz",
+			"integrity": "sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==",
 			"dev": true,
 			"dependencies": {
-				"@types/html-minifier-terser": "^5.0.0",
-				"@types/tapable": "^1.0.5",
-				"@types/webpack": "^4.41.8",
-				"html-minifier-terser": "^5.0.1",
-				"loader-utils": "^1.2.3",
-				"lodash": "^4.17.20",
-				"pretty-error": "^2.1.1",
-				"tapable": "^1.1.3",
-				"util.promisify": "1.0.0"
+				"@types/html-minifier-terser": "^6.0.0",
+				"html-minifier-terser": "^6.0.2",
+				"lodash": "^4.17.21",
+				"pretty-error": "^4.0.0",
+				"tapable": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=6.9"
+				"node": ">=10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/html-webpack-plugin"
 			},
 			"peerDependencies": {
-				"webpack": "^4.0.0 || ^5.0.0"
+				"@rspack/core": "0.x || 1.x",
+				"webpack": "^5.20.0"
+			},
+			"peerDependenciesMeta": {
+				"@rspack/core": {
+					"optional": true
+				},
+				"webpack": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/html-webpack-plugin/node_modules/json5": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+		"node_modules/html-webpack-plugin/node_modules/tapable": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
 			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.0"
-			},
-			"bin": {
-				"json5": "lib/cli.js"
-			}
-		},
-		"node_modules/html-webpack-plugin/node_modules/loader-utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-			"integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-			"dev": true,
-			"dependencies": {
-				"big.js": "^5.2.2",
-				"emojis-list": "^3.0.0",
-				"json5": "^1.0.1"
-			},
 			"engines": {
-				"node": ">=4.0.0"
+				"node": ">=6"
 			}
 		},
 		"node_modules/htmlparser2": {
@@ -11407,27 +11326,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/object.getownpropertydescriptors": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.8.tgz",
-			"integrity": "sha512-qkHIGe4q0lSYMv0XI4SsBTJz3WaURhLvd0lKSgtVuOsJ2krg4SgMw3PIRQFMp07yi++UR3se2mkcLqsBNpBb/A==",
-			"dev": true,
-			"dependencies": {
-				"array.prototype.reduce": "^1.0.6",
-				"call-bind": "^1.0.7",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.2",
-				"es-object-atoms": "^1.0.0",
-				"gopd": "^1.0.1",
-				"safe-array-concat": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/object.hasown": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.4.tgz",
@@ -12142,13 +12040,13 @@
 			}
 		},
 		"node_modules/pretty-error": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.2.tgz",
-			"integrity": "sha512-EY5oDzmsX5wvuynAByrmY0P0hcp+QpnAKbJng2A2MPjVKXCxrDSUkzghVJ4ZGPIv+JC4gX8fPUWscC0RtjsWGw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
+			"integrity": "sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==",
 			"dev": true,
 			"dependencies": {
 				"lodash": "^4.17.20",
-				"renderkid": "^2.0.4"
+				"renderkid": "^3.0.0"
 			}
 		},
 		"node_modules/pretty-format": {
@@ -12648,37 +12546,16 @@
 			}
 		},
 		"node_modules/renderkid": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.7.tgz",
-			"integrity": "sha512-oCcFyxaMrKsKcTY59qnCAtmDVSLfPbrv6A3tVbPdFMMrv5jaK10V6m40cKsoPNhAqN6rmHW9sswW4o3ruSrwUQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
+			"integrity": "sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==",
 			"dev": true,
 			"dependencies": {
 				"css-select": "^4.1.3",
 				"dom-converter": "^0.2.0",
 				"htmlparser2": "^6.1.0",
 				"lodash": "^4.17.21",
-				"strip-ansi": "^3.0.1"
-			}
-		},
-		"node_modules/renderkid/node_modules/ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/renderkid/node_modules/strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
+				"strip-ansi": "^6.0.1"
 			}
 		},
 		"node_modules/require-directory": {
@@ -13956,20 +13833,21 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "4.8.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
-			"integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+			"version": "5.31.5",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.31.5.tgz",
+			"integrity": "sha512-YPmas0L0rE1UyLL/llTWA0SiDOqIcAQYLeUj7cJYzXHlRTAnMSg9pPe4VJ5PlKvTrPQsdVFuiRiwyeNlYgwh2Q==",
 			"dev": true,
 			"dependencies": {
+				"@jridgewell/source-map": "^0.3.3",
+				"acorn": "^8.8.2",
 				"commander": "^2.20.0",
-				"source-map": "~0.6.1",
-				"source-map-support": "~0.5.12"
+				"source-map-support": "~0.5.20"
 			},
 			"bin": {
 				"terser": "bin/terser"
 			},
 			"engines": {
-				"node": ">=6.0.0"
+				"node": ">=10"
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
@@ -14005,12 +13883,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/terser-webpack-plugin/node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
 		},
 		"node_modules/terser-webpack-plugin/node_modules/has-flag": {
 			"version": "4.0.0",
@@ -14053,16 +13925,6 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
-		"node_modules/terser-webpack-plugin/node_modules/source-map-support": {
-			"version": "0.5.21",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-			"dev": true,
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			}
-		},
 		"node_modules/terser-webpack-plugin/node_modules/supports-color": {
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -14078,29 +13940,21 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
-		"node_modules/terser-webpack-plugin/node_modules/terser": {
-			"version": "5.30.3",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.30.3.tgz",
-			"integrity": "sha512-STdUgOUx8rLbMGO9IOwHLpCqolkDITFFQSMYYwKE1N2lY6MVSaeoi10z/EhWxRc6ybqoVmKSkhKYH/XUpl7vSA==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/source-map": "^0.3.3",
-				"acorn": "^8.8.2",
-				"commander": "^2.20.0",
-				"source-map-support": "~0.5.20"
-			},
-			"bin": {
-				"terser": "bin/terser"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/terser/node_modules/commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
+		},
+		"node_modules/terser/node_modules/source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
 		},
 		"node_modules/test-exclude": {
 			"version": "6.0.0",
@@ -14624,16 +14478,6 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true
-		},
-		"node_modules/util.promisify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-			"dev": true,
-			"dependencies": {
-				"define-properties": "^1.1.2",
-				"object.getownpropertydescriptors": "^2.0.3"
-			}
 		},
 		"node_modules/utila": {
 			"version": "0.4.0",

--- a/item-counter-spe/package-lock.json
+++ b/item-counter-spe/package-lock.json
@@ -54,7 +54,7 @@
 				"typescript": "~5.4",
 				"webpack": "^5.88.2",
 				"webpack-cli": "^5.1.4",
-				"webpack-dev-server": "^4.15.1"
+				"webpack-dev-server": "^5.0.4"
 			},
 			"engines": {
 				"node": ">=20.0.0"
@@ -2693,6 +2693,60 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@jsonjoy.com/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/json-pack": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.1.0.tgz",
+			"integrity": "sha512-zlQONA+msXPPwHWZMKFVS78ewFczIll5lXiVPwFPCZUsrOKdxc2AvxU1HoNBmMRhqDZUR9HkC3UOm+6pME6Xsg==",
+			"dev": true,
+			"dependencies": {
+				"@jsonjoy.com/base64": "^1.1.1",
+				"@jsonjoy.com/util": "^1.1.2",
+				"hyperdyperid": "^1.2.0",
+				"thingies": "^1.20.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/util": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.3.0.tgz",
+			"integrity": "sha512-Cebt4Vk7k1xHy87kHY7KSPLT77A7Ev7IfOblyLZhtYEhrdQ6fX4EoLq3xOQ3O/DRMEh2ok5nyC180E+ABS8Wmw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
 		"node_modules/@leichtgewicht/ip-codec": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -3171,9 +3225,9 @@
 			}
 		},
 		"node_modules/@types/retry": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+			"integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
 			"dev": true
 		},
 		"node_modules/@types/semver": {
@@ -4614,6 +4668,21 @@
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true
 		},
+		"node_modules/bundle-name": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+			"integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+			"dev": true,
+			"dependencies": {
+				"run-applescript": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/bytes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -5489,6 +5558,34 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/default-browser": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+			"integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+			"dev": true,
+			"dependencies": {
+				"bundle-name": "^4.1.0",
+				"default-browser-id": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser-id": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+			"integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/default-gateway": {
@@ -7173,12 +7270,6 @@
 				"node": ">=14.14"
 			}
 		},
-		"node_modules/fs-monkey": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.5.tgz",
-			"integrity": "sha512-8uMbBjrhzW76TYgEV27Y5E//W2f/lTFmx78P2w19FZSxarhI/798APGQyuGCwmkNxgwGRhrLfvWyLBvNtuOmew==",
-			"dev": true
-		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -7812,6 +7903,15 @@
 				"node": ">=10.17.0"
 			}
 		},
+		"node_modules/hyperdyperid": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+			"integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.18"
+			}
+		},
 		"node_modules/iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -8185,6 +8285,39 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-inside-container": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"dev": true,
+			"dependencies": {
+				"is-docker": "^3.0.0"
+			},
+			"bin": {
+				"is-inside-container": "cli.js"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-inside-container/node_modules/is-docker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"dev": true,
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-map": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -8207,6 +8340,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-network-error": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.1.0.tgz",
+			"integrity": "sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-number": {
@@ -10874,15 +11019,22 @@
 			}
 		},
 		"node_modules/memfs": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
-			"integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.11.1.tgz",
+			"integrity": "sha512-LZcMTBAgqUUKNXZagcZxvXXfgF1bHX7Y7nQ0QyEiNbRJgE29GhgPd8Yna1VQcLlPiHt/5RFJMWYN9Uv/VPNvjQ==",
 			"dev": true,
 			"dependencies": {
-				"fs-monkey": "^1.0.4"
+				"@jsonjoy.com/json-pack": "^1.0.3",
+				"@jsonjoy.com/util": "^1.3.0",
+				"tree-dump": "^1.0.1",
+				"tslib": "^2.0.0"
 			},
 			"engines": {
 				"node": ">= 4.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
 			}
 		},
 		"node_modules/memory-fs": {
@@ -11048,9 +11200,9 @@
 			}
 		},
 		"node_modules/minipass": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-			"integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
 			"dev": true,
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -11484,16 +11636,20 @@
 			}
 		},
 		"node_modules/p-retry": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.0.tgz",
+			"integrity": "sha512-JA6nkq6hKyWLLasXQXUrO4z8BUZGUt/LjlJxx8Gb2+2ntodU/SS63YZ8b0LUTbQ8ZB9iwOfhEPhg4ykKnn2KsA==",
 			"dev": true,
 			"dependencies": {
-				"@types/retry": "0.12.0",
+				"@types/retry": "0.12.2",
+				"is-network-error": "^1.0.0",
 				"retry": "^0.13.1"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-try": {
@@ -11536,6 +11692,12 @@
 			"engines": {
 				"node": ">= 14"
 			}
+		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+			"integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+			"dev": true
 		},
 		"node_modules/param-case": {
 			"version": "3.0.4",
@@ -11644,16 +11806,16 @@
 			"dev": true
 		},
 		"node_modules/path-scurry": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.2.tgz",
-			"integrity": "sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^10.2.0",
 				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": ">=16 || 14 >=14.18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -12691,6 +12853,18 @@
 			"integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
 			"dependencies": {
 				"@babel/runtime": "^7.1.2"
+			}
+		},
+		"node_modules/run-applescript": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+			"integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/run-parallel": {
@@ -14006,6 +14180,18 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/thingies": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
+			"integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.18"
+			},
+			"peerDependencies": {
+				"tslib": "^2"
+			}
+		},
 		"node_modules/through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -14058,6 +14244,22 @@
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+		},
+		"node_modules/tree-dump": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.2.tgz",
+			"integrity": "sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
 		},
 		"node_modules/tree-kill": {
 			"version": "1.2.2",
@@ -14682,77 +14884,83 @@
 			}
 		},
 		"node_modules/webpack-dev-middleware": {
-			"version": "5.3.4",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
-			"integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.3.0.tgz",
+			"integrity": "sha512-xD2qnNew+F6KwOGZR7kWdbIou/ud7cVqLEXeK1q0nHcNsX/u7ul/fSdlOTX4ntSL5FNFy7ZJJXbf0piF591JYw==",
 			"dev": true,
 			"dependencies": {
 				"colorette": "^2.0.10",
-				"memfs": "^3.4.3",
+				"memfs": "^4.6.0",
 				"mime-types": "^2.1.31",
+				"on-finished": "^2.4.1",
 				"range-parser": "^1.2.1",
 				"schema-utils": "^4.0.0"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.0.0 || ^5.0.0"
+				"webpack": "^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"webpack": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/webpack-dev-server": {
-			"version": "4.15.2",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
-			"integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.0.4.tgz",
+			"integrity": "sha512-dljXhUgx3HqKP2d8J/fUMvhxGhzjeNVarDLcbO/EWMSgRizDkxHQDZQaLFL5VJY9tRBj2Gz+rvCEYYvhbqPHNA==",
 			"dev": true,
 			"dependencies": {
-				"@types/bonjour": "^3.5.9",
-				"@types/connect-history-api-fallback": "^1.3.5",
-				"@types/express": "^4.17.13",
-				"@types/serve-index": "^1.9.1",
-				"@types/serve-static": "^1.13.10",
-				"@types/sockjs": "^0.3.33",
-				"@types/ws": "^8.5.5",
+				"@types/bonjour": "^3.5.13",
+				"@types/connect-history-api-fallback": "^1.5.4",
+				"@types/express": "^4.17.21",
+				"@types/serve-index": "^1.9.4",
+				"@types/serve-static": "^1.15.5",
+				"@types/sockjs": "^0.3.36",
+				"@types/ws": "^8.5.10",
 				"ansi-html-community": "^0.0.8",
-				"bonjour-service": "^1.0.11",
-				"chokidar": "^3.5.3",
+				"bonjour-service": "^1.2.1",
+				"chokidar": "^3.6.0",
 				"colorette": "^2.0.10",
 				"compression": "^1.7.4",
 				"connect-history-api-fallback": "^2.0.0",
 				"default-gateway": "^6.0.3",
 				"express": "^4.17.3",
 				"graceful-fs": "^4.2.6",
-				"html-entities": "^2.3.2",
+				"html-entities": "^2.4.0",
 				"http-proxy-middleware": "^2.0.3",
-				"ipaddr.js": "^2.0.1",
-				"launch-editor": "^2.6.0",
-				"open": "^8.0.9",
-				"p-retry": "^4.5.0",
-				"rimraf": "^3.0.2",
-				"schema-utils": "^4.0.0",
-				"selfsigned": "^2.1.1",
+				"ipaddr.js": "^2.1.0",
+				"launch-editor": "^2.6.1",
+				"open": "^10.0.3",
+				"p-retry": "^6.2.0",
+				"rimraf": "^5.0.5",
+				"schema-utils": "^4.2.0",
+				"selfsigned": "^2.4.1",
 				"serve-index": "^1.9.1",
 				"sockjs": "^0.3.24",
 				"spdy": "^4.0.2",
-				"webpack-dev-middleware": "^5.3.4",
-				"ws": "^8.13.0"
+				"webpack-dev-middleware": "^7.1.0",
+				"ws": "^8.16.0"
 			},
 			"bin": {
 				"webpack-dev-server": "bin/webpack-dev-server.js"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.37.0 || ^5.0.0"
+				"webpack": "^5.0.0"
 			},
 			"peerDependenciesMeta": {
 				"webpack": {
@@ -14761,6 +14969,125 @@
 				"webpack-cli": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/define-lazy-prop": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/glob": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"dev": true,
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/is-wsl": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+			"dev": true,
+			"dependencies": {
+				"is-inside-container": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/open": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+			"integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+			"dev": true,
+			"dependencies": {
+				"default-browser": "^5.2.1",
+				"define-lazy-prop": "^3.0.0",
+				"is-inside-container": "^1.0.0",
+				"is-wsl": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/rimraf": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+			"integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+			"dev": true,
+			"dependencies": {
+				"glob": "^10.3.7"
+			},
+			"bin": {
+				"rimraf": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/webpack-merge": {

--- a/item-counter-spe/package.json
+++ b/item-counter-spe/package.json
@@ -64,7 +64,7 @@
 		"typescript": "~5.4",
 		"webpack": "^5.88.2",
 		"webpack-cli": "^5.1.4",
-		"webpack-dev-server": "^4.15.1"
+		"webpack-dev-server": "^5.0.4"
 	},
 	"jest-junit": {
 		"outputDirectory": "nyc",

--- a/item-counter-spe/package.json
+++ b/item-counter-spe/package.json
@@ -50,7 +50,7 @@
 		"dotenv-webpack": "^7.1.1",
 		"eslint": "^8.23.1",
 		"eslint-plugin-react": "^7.31.8",
-		"html-webpack-plugin": "^4.5.2",
+		"html-webpack-plugin": "^5.6.0",
 		"jest": "^29.2.2",
 		"jest-junit": "^16.0.0",
 		"jest-puppeteer": "^9.0.0",

--- a/item-counter/package-lock.json
+++ b/item-counter/package-lock.json
@@ -53,7 +53,7 @@
 				"typescript": "~5.4",
 				"webpack": "^5.88.2",
 				"webpack-cli": "^5.1.4",
-				"webpack-dev-server": "^4.15.1"
+				"webpack-dev-server": "^5.0.4"
 			},
 			"engines": {
 				"node": ">=20.0.0"
@@ -2262,6 +2262,60 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@jsonjoy.com/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/json-pack": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.1.0.tgz",
+			"integrity": "sha512-zlQONA+msXPPwHWZMKFVS78ewFczIll5lXiVPwFPCZUsrOKdxc2AvxU1HoNBmMRhqDZUR9HkC3UOm+6pME6Xsg==",
+			"dev": true,
+			"dependencies": {
+				"@jsonjoy.com/base64": "^1.1.1",
+				"@jsonjoy.com/util": "^1.1.2",
+				"hyperdyperid": "^1.2.0",
+				"thingies": "^1.20.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/util": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.3.0.tgz",
+			"integrity": "sha512-Cebt4Vk7k1xHy87kHY7KSPLT77A7Ev7IfOblyLZhtYEhrdQ6fX4EoLq3xOQ3O/DRMEh2ok5nyC180E+ABS8Wmw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
 		"node_modules/@leichtgewicht/ip-codec": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -2714,9 +2768,9 @@
 			}
 		},
 		"node_modules/@types/retry": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+			"integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
 			"dev": true
 		},
 		"node_modules/@types/semver": {
@@ -4159,6 +4213,21 @@
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true
 		},
+		"node_modules/bundle-name": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+			"integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+			"dev": true,
+			"dependencies": {
+				"run-applescript": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/bytes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -5036,6 +5105,34 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/default-browser": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+			"integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+			"dev": true,
+			"dependencies": {
+				"bundle-name": "^4.1.0",
+				"default-browser-id": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser-id": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+			"integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/default-gateway": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
@@ -5066,12 +5163,15 @@
 			}
 		},
 		"node_modules/define-lazy-prop": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-			"integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
 			"dev": true,
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/define-properties": {
@@ -6711,12 +6811,6 @@
 				"node": ">=14.14"
 			}
 		},
-		"node_modules/fs-monkey": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.5.tgz",
-			"integrity": "sha512-8uMbBjrhzW76TYgEV27Y5E//W2f/lTFmx78P2w19FZSxarhI/798APGQyuGCwmkNxgwGRhrLfvWyLBvNtuOmew==",
-			"dev": true
-		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -7352,6 +7446,15 @@
 				"node": ">=10.17.0"
 			}
 		},
+		"node_modules/hyperdyperid": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+			"integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.18"
+			}
+		},
 		"node_modules/iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -7646,15 +7749,15 @@
 			}
 		},
 		"node_modules/is-docker": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
 			"dev": true,
 			"bin": {
 				"is-docker": "cli.js"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -7726,6 +7829,24 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-inside-container": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"dev": true,
+			"dependencies": {
+				"is-docker": "^3.0.0"
+			},
+			"bin": {
+				"is-inside-container": "cli.js"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-map": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -7748,6 +7869,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-network-error": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.1.0.tgz",
+			"integrity": "sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-number": {
@@ -7957,15 +8090,18 @@
 			}
 		},
 		"node_modules/is-wsl": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
 			"dev": true,
 			"dependencies": {
-				"is-docker": "^2.0.0"
+				"is-inside-container": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/isarray": {
@@ -10311,15 +10447,22 @@
 			}
 		},
 		"node_modules/memfs": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
-			"integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.11.1.tgz",
+			"integrity": "sha512-LZcMTBAgqUUKNXZagcZxvXXfgF1bHX7Y7nQ0QyEiNbRJgE29GhgPd8Yna1VQcLlPiHt/5RFJMWYN9Uv/VPNvjQ==",
 			"dev": true,
 			"dependencies": {
-				"fs-monkey": "^1.0.4"
+				"@jsonjoy.com/json-pack": "^1.0.3",
+				"@jsonjoy.com/util": "^1.3.0",
+				"tree-dump": "^1.0.1",
+				"tslib": "^2.0.0"
 			},
 			"engines": {
 				"node": ">= 4.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
 			}
 		},
 		"node_modules/memory-fs": {
@@ -10485,9 +10628,9 @@
 			}
 		},
 		"node_modules/minipass": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-			"integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
 			"dev": true,
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -10849,17 +10992,18 @@
 			}
 		},
 		"node_modules/open": {
-			"version": "8.4.2",
-			"resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-			"integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+			"integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
 			"dev": true,
 			"dependencies": {
-				"define-lazy-prop": "^2.0.0",
-				"is-docker": "^2.1.1",
-				"is-wsl": "^2.2.0"
+				"default-browser": "^5.2.1",
+				"define-lazy-prop": "^3.0.0",
+				"is-inside-container": "^1.0.0",
+				"is-wsl": "^3.1.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -10922,16 +11066,20 @@
 			}
 		},
 		"node_modules/p-retry": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.0.tgz",
+			"integrity": "sha512-JA6nkq6hKyWLLasXQXUrO4z8BUZGUt/LjlJxx8Gb2+2ntodU/SS63YZ8b0LUTbQ8ZB9iwOfhEPhg4ykKnn2KsA==",
 			"dev": true,
 			"dependencies": {
-				"@types/retry": "0.12.0",
+				"@types/retry": "0.12.2",
+				"is-network-error": "^1.0.0",
 				"retry": "^0.13.1"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-try": {
@@ -10974,6 +11122,12 @@
 			"engines": {
 				"node": ">= 14"
 			}
+		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+			"integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+			"dev": true
 		},
 		"node_modules/param-case": {
 			"version": "3.0.4",
@@ -11082,16 +11236,16 @@
 			"dev": true
 		},
 		"node_modules/path-scurry": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.2.tgz",
-			"integrity": "sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^10.2.0",
 				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": ">=16 || 14 >=14.18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -12129,6 +12283,18 @@
 			"integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
 			"dependencies": {
 				"@babel/runtime": "^7.1.2"
+			}
+		},
+		"node_modules/run-applescript": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+			"integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/run-parallel": {
@@ -13444,6 +13610,18 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/thingies": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
+			"integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.18"
+			},
+			"peerDependencies": {
+				"tslib": "^2"
+			}
+		},
 		"node_modules/through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -13496,6 +13674,22 @@
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+		},
+		"node_modules/tree-dump": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.2.tgz",
+			"integrity": "sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
 		},
 		"node_modules/tree-kill": {
 			"version": "1.2.2",
@@ -14124,77 +14318,83 @@
 			}
 		},
 		"node_modules/webpack-dev-middleware": {
-			"version": "5.3.4",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
-			"integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.3.0.tgz",
+			"integrity": "sha512-xD2qnNew+F6KwOGZR7kWdbIou/ud7cVqLEXeK1q0nHcNsX/u7ul/fSdlOTX4ntSL5FNFy7ZJJXbf0piF591JYw==",
 			"dev": true,
 			"dependencies": {
 				"colorette": "^2.0.10",
-				"memfs": "^3.4.3",
+				"memfs": "^4.6.0",
 				"mime-types": "^2.1.31",
+				"on-finished": "^2.4.1",
 				"range-parser": "^1.2.1",
 				"schema-utils": "^4.0.0"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.0.0 || ^5.0.0"
+				"webpack": "^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"webpack": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/webpack-dev-server": {
-			"version": "4.15.2",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
-			"integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.0.4.tgz",
+			"integrity": "sha512-dljXhUgx3HqKP2d8J/fUMvhxGhzjeNVarDLcbO/EWMSgRizDkxHQDZQaLFL5VJY9tRBj2Gz+rvCEYYvhbqPHNA==",
 			"dev": true,
 			"dependencies": {
-				"@types/bonjour": "^3.5.9",
-				"@types/connect-history-api-fallback": "^1.3.5",
-				"@types/express": "^4.17.13",
-				"@types/serve-index": "^1.9.1",
-				"@types/serve-static": "^1.13.10",
-				"@types/sockjs": "^0.3.33",
-				"@types/ws": "^8.5.5",
+				"@types/bonjour": "^3.5.13",
+				"@types/connect-history-api-fallback": "^1.5.4",
+				"@types/express": "^4.17.21",
+				"@types/serve-index": "^1.9.4",
+				"@types/serve-static": "^1.15.5",
+				"@types/sockjs": "^0.3.36",
+				"@types/ws": "^8.5.10",
 				"ansi-html-community": "^0.0.8",
-				"bonjour-service": "^1.0.11",
-				"chokidar": "^3.5.3",
+				"bonjour-service": "^1.2.1",
+				"chokidar": "^3.6.0",
 				"colorette": "^2.0.10",
 				"compression": "^1.7.4",
 				"connect-history-api-fallback": "^2.0.0",
 				"default-gateway": "^6.0.3",
 				"express": "^4.17.3",
 				"graceful-fs": "^4.2.6",
-				"html-entities": "^2.3.2",
+				"html-entities": "^2.4.0",
 				"http-proxy-middleware": "^2.0.3",
-				"ipaddr.js": "^2.0.1",
-				"launch-editor": "^2.6.0",
-				"open": "^8.0.9",
-				"p-retry": "^4.5.0",
-				"rimraf": "^3.0.2",
-				"schema-utils": "^4.0.0",
-				"selfsigned": "^2.1.1",
+				"ipaddr.js": "^2.1.0",
+				"launch-editor": "^2.6.1",
+				"open": "^10.0.3",
+				"p-retry": "^6.2.0",
+				"rimraf": "^5.0.5",
+				"schema-utils": "^4.2.0",
+				"selfsigned": "^2.4.1",
 				"serve-index": "^1.9.1",
 				"sockjs": "^0.3.24",
 				"spdy": "^4.0.2",
-				"webpack-dev-middleware": "^5.3.4",
-				"ws": "^8.13.0"
+				"webpack-dev-middleware": "^7.1.0",
+				"ws": "^8.16.0"
 			},
 			"bin": {
 				"webpack-dev-server": "bin/webpack-dev-server.js"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.37.0 || ^5.0.0"
+				"webpack": "^5.0.0"
 			},
 			"peerDependenciesMeta": {
 				"webpack": {
@@ -14203,6 +14403,80 @@
 				"webpack-cli": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/glob": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"dev": true,
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/rimraf": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+			"integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+			"dev": true,
+			"dependencies": {
+				"glob": "^10.3.7"
+			},
+			"bin": {
+				"rimraf": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/webpack-merge": {

--- a/item-counter/package-lock.json
+++ b/item-counter/package-lock.json
@@ -39,7 +39,7 @@
 				"dotenv-webpack": "^7.1.1",
 				"eslint": "^8.23.1",
 				"eslint-plugin-react": "^7.31.8",
-				"html-webpack-plugin": "^4.5.2",
+				"html-webpack-plugin": "^5.6.0",
 				"jest": "^29.2.2",
 				"jest-junit": "^16.0.0",
 				"jest-puppeteer": "^9.0.0",
@@ -2593,9 +2593,9 @@
 			}
 		},
 		"node_modules/@types/html-minifier-terser": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz",
-			"integrity": "sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
+			"integrity": "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==",
 			"dev": true
 		},
 		"node_modules/@types/http-errors": {
@@ -2764,72 +2764,17 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/source-list-map": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.6.tgz",
-			"integrity": "sha512-5JcVt1u5HDmlXkwOD2nslZVllBBc7HDuOICfiZah2Z0is8M8g+ddAEawbmd3VjedfDHBzxCaXLs07QEmb7y54g==",
-			"dev": true
-		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
 			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
 			"dev": true
 		},
-		"node_modules/@types/tapable": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.12.tgz",
-			"integrity": "sha512-bTHG8fcxEqv1M9+TD14P8ok8hjxoOCkfKc8XXLaaD05kI7ohpeI956jtDOD3XHKBQrlyPughUtzm1jtVhHpA5Q==",
-			"dev": true
-		},
-		"node_modules/@types/uglify-js": {
-			"version": "3.17.5",
-			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.17.5.tgz",
-			"integrity": "sha512-TU+fZFBTBcXj/GpDpDaBmgWk/gn96kMZ+uocaFUlV2f8a6WdMzzI44QBCmGcCiYR0Y6ZlNRiyUyKKt5nl/lbzQ==",
-			"dev": true,
-			"dependencies": {
-				"source-map": "^0.6.1"
-			}
-		},
 		"node_modules/@types/uuid": {
 			"version": "9.0.8",
 			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
 			"integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
 			"dev": true
-		},
-		"node_modules/@types/webpack": {
-			"version": "4.41.38",
-			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.38.tgz",
-			"integrity": "sha512-oOW7E931XJU1mVfCnxCVgv8GLFL768pDO5u2Gzk82i8yTIgX6i7cntyZOkZYb/JtYM8252SN9bQp9tgkVDSsRw==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*",
-				"@types/tapable": "^1",
-				"@types/uglify-js": "*",
-				"@types/webpack-sources": "*",
-				"anymatch": "^3.0.0",
-				"source-map": "^0.6.0"
-			}
-		},
-		"node_modules/@types/webpack-sources": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-3.2.3.tgz",
-			"integrity": "sha512-4nZOdMwSPHZ4pTEZzSp0AsTM4K7Qmu40UKW4tJDiOVs20UzYF9l+qUe4s0ftfN0pin06n+5cWWDJXH+sbhAiDw==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*",
-				"@types/source-list-map": "*",
-				"source-map": "^0.7.3"
-			}
-		},
-		"node_modules/@types/webpack-sources/node_modules/source-map": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-			"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 8"
-			}
 		},
 		"node_modules/@types/ws": {
 			"version": "8.5.10",
@@ -3664,27 +3609,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/array.prototype.reduce": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.7.tgz",
-			"integrity": "sha512-mzmiUCVwtiD4lgxYP8g7IYy8El8p2CSMePvIbTS7gchKir/L1fgJrk0yDKmAX6mnRQFKNADYIk8nNlTris5H1Q==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.7",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.2",
-				"es-array-method-boxes-properly": "^1.0.0",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.0.0",
-				"is-string": "^1.0.7"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/array.prototype.toreversed": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/array.prototype.toreversed/-/array.prototype.toreversed-1.1.2.tgz",
@@ -4433,15 +4357,15 @@
 			"dev": true
 		},
 		"node_modules/clean-css": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
-			"integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+			"integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
 			"dev": true,
 			"dependencies": {
 				"source-map": "~0.6.0"
 			},
 			"engines": {
-				"node": ">= 4.0"
+				"node": ">= 10.0"
 			}
 		},
 		"node_modules/cliui": {
@@ -5622,12 +5546,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/es-array-method-boxes-properly": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-			"dev": true
 		},
 		"node_modules/es-define-property": {
 			"version": "1.0.0",
@@ -7244,73 +7162,74 @@
 			"dev": true
 		},
 		"node_modules/html-minifier-terser": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
-			"integrity": "sha512-ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
+			"integrity": "sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==",
 			"dev": true,
 			"dependencies": {
-				"camel-case": "^4.1.1",
-				"clean-css": "^4.2.3",
-				"commander": "^4.1.1",
+				"camel-case": "^4.1.2",
+				"clean-css": "^5.2.2",
+				"commander": "^8.3.0",
 				"he": "^1.2.0",
-				"param-case": "^3.0.3",
+				"param-case": "^3.0.4",
 				"relateurl": "^0.2.7",
-				"terser": "^4.6.3"
+				"terser": "^5.10.0"
 			},
 			"bin": {
 				"html-minifier-terser": "cli.js"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=12"
+			}
+		},
+		"node_modules/html-minifier-terser/node_modules/commander": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+			"dev": true,
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/html-webpack-plugin": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.5.2.tgz",
-			"integrity": "sha512-q5oYdzjKUIPQVjOosjgvCHQOv9Ett9CYYHlgvJeXG0qQvdSojnBq4vAdQBwn1+yGveAwHCoe/rMR86ozX3+c2A==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.0.tgz",
+			"integrity": "sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==",
 			"dev": true,
 			"dependencies": {
-				"@types/html-minifier-terser": "^5.0.0",
-				"@types/tapable": "^1.0.5",
-				"@types/webpack": "^4.41.8",
-				"html-minifier-terser": "^5.0.1",
-				"loader-utils": "^1.2.3",
-				"lodash": "^4.17.20",
-				"pretty-error": "^2.1.1",
-				"tapable": "^1.1.3",
-				"util.promisify": "1.0.0"
+				"@types/html-minifier-terser": "^6.0.0",
+				"html-minifier-terser": "^6.0.2",
+				"lodash": "^4.17.21",
+				"pretty-error": "^4.0.0",
+				"tapable": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=6.9"
+				"node": ">=10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/html-webpack-plugin"
 			},
 			"peerDependencies": {
-				"webpack": "^4.0.0 || ^5.0.0"
+				"@rspack/core": "0.x || 1.x",
+				"webpack": "^5.20.0"
+			},
+			"peerDependenciesMeta": {
+				"@rspack/core": {
+					"optional": true
+				},
+				"webpack": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/html-webpack-plugin/node_modules/json5": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+		"node_modules/html-webpack-plugin/node_modules/tapable": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
 			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.0"
-			},
-			"bin": {
-				"json5": "lib/cli.js"
-			}
-		},
-		"node_modules/html-webpack-plugin/node_modules/loader-utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-			"integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-			"dev": true,
-			"dependencies": {
-				"big.js": "^5.2.2",
-				"emojis-list": "^3.0.0",
-				"json5": "^1.0.1"
-			},
 			"engines": {
-				"node": ">=4.0.0"
+				"node": ">=6"
 			}
 		},
 		"node_modules/htmlparser2": {
@@ -10844,27 +10763,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/object.getownpropertydescriptors": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.8.tgz",
-			"integrity": "sha512-qkHIGe4q0lSYMv0XI4SsBTJz3WaURhLvd0lKSgtVuOsJ2krg4SgMw3PIRQFMp07yi++UR3se2mkcLqsBNpBb/A==",
-			"dev": true,
-			"dependencies": {
-				"array.prototype.reduce": "^1.0.6",
-				"call-bind": "^1.0.7",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.2",
-				"es-object-atoms": "^1.0.0",
-				"gopd": "^1.0.1",
-				"safe-array-concat": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/object.hasown": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.4.tgz",
@@ -11580,13 +11478,13 @@
 			}
 		},
 		"node_modules/pretty-error": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.2.tgz",
-			"integrity": "sha512-EY5oDzmsX5wvuynAByrmY0P0hcp+QpnAKbJng2A2MPjVKXCxrDSUkzghVJ4ZGPIv+JC4gX8fPUWscC0RtjsWGw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
+			"integrity": "sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==",
 			"dev": true,
 			"dependencies": {
 				"lodash": "^4.17.20",
-				"renderkid": "^2.0.4"
+				"renderkid": "^3.0.0"
 			}
 		},
 		"node_modules/pretty-format": {
@@ -12086,37 +11984,16 @@
 			}
 		},
 		"node_modules/renderkid": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.7.tgz",
-			"integrity": "sha512-oCcFyxaMrKsKcTY59qnCAtmDVSLfPbrv6A3tVbPdFMMrv5jaK10V6m40cKsoPNhAqN6rmHW9sswW4o3ruSrwUQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
+			"integrity": "sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==",
 			"dev": true,
 			"dependencies": {
 				"css-select": "^4.1.3",
 				"dom-converter": "^0.2.0",
 				"htmlparser2": "^6.1.0",
 				"lodash": "^4.17.21",
-				"strip-ansi": "^3.0.1"
-			}
-		},
-		"node_modules/renderkid/node_modules/ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/renderkid/node_modules/strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
+				"strip-ansi": "^6.0.1"
 			}
 		},
 		"node_modules/require-directory": {
@@ -13394,20 +13271,21 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "4.8.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
-			"integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+			"version": "5.31.5",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.31.5.tgz",
+			"integrity": "sha512-YPmas0L0rE1UyLL/llTWA0SiDOqIcAQYLeUj7cJYzXHlRTAnMSg9pPe4VJ5PlKvTrPQsdVFuiRiwyeNlYgwh2Q==",
 			"dev": true,
 			"dependencies": {
+				"@jridgewell/source-map": "^0.3.3",
+				"acorn": "^8.8.2",
 				"commander": "^2.20.0",
-				"source-map": "~0.6.1",
-				"source-map-support": "~0.5.12"
+				"source-map-support": "~0.5.20"
 			},
 			"bin": {
 				"terser": "bin/terser"
 			},
 			"engines": {
-				"node": ">=6.0.0"
+				"node": ">=10"
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
@@ -13443,12 +13321,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/terser-webpack-plugin/node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
 		},
 		"node_modules/terser-webpack-plugin/node_modules/has-flag": {
 			"version": "4.0.0",
@@ -13491,16 +13363,6 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
-		"node_modules/terser-webpack-plugin/node_modules/source-map-support": {
-			"version": "0.5.21",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-			"dev": true,
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			}
-		},
 		"node_modules/terser-webpack-plugin/node_modules/supports-color": {
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -13516,29 +13378,21 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
-		"node_modules/terser-webpack-plugin/node_modules/terser": {
-			"version": "5.30.3",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.30.3.tgz",
-			"integrity": "sha512-STdUgOUx8rLbMGO9IOwHLpCqolkDITFFQSMYYwKE1N2lY6MVSaeoi10z/EhWxRc6ybqoVmKSkhKYH/XUpl7vSA==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/source-map": "^0.3.3",
-				"acorn": "^8.8.2",
-				"commander": "^2.20.0",
-				"source-map-support": "~0.5.20"
-			},
-			"bin": {
-				"terser": "bin/terser"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/terser/node_modules/commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
+		},
+		"node_modules/terser/node_modules/source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
 		},
 		"node_modules/test-exclude": {
 			"version": "6.0.0",
@@ -14062,16 +13916,6 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true
-		},
-		"node_modules/util.promisify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-			"dev": true,
-			"dependencies": {
-				"define-properties": "^1.1.2",
-				"object.getownpropertydescriptors": "^2.0.3"
-			}
 		},
 		"node_modules/utila": {
 			"version": "0.4.0",

--- a/item-counter/package.json
+++ b/item-counter/package.json
@@ -53,7 +53,7 @@
 		"dotenv-webpack": "^7.1.1",
 		"eslint": "^8.23.1",
 		"eslint-plugin-react": "^7.31.8",
-		"html-webpack-plugin": "^4.5.2",
+		"html-webpack-plugin": "^5.6.0",
 		"jest": "^29.2.2",
 		"jest-junit": "^16.0.0",
 		"jest-puppeteer": "^9.0.0",

--- a/item-counter/package.json
+++ b/item-counter/package.json
@@ -67,7 +67,7 @@
 		"typescript": "~5.4",
 		"webpack": "^5.88.2",
 		"webpack-cli": "^5.1.4",
-		"webpack-dev-server": "^4.15.1"
+		"webpack-dev-server": "^5.0.4"
 	},
 	"jest-junit": {
 		"outputDirectory": "nyc",


### PR DESCRIPTION
Updates `webpack-dev-server`, resolving console errors reported when webpack-bundling our apps.

```shell
(node:295029) [DEP_WEBPACK_COMPILATION_ASSETS] DeprecationWarning: Compilation.assets will be frozen in future, all modifications are deprecated.
BREAKING CHANGE: No more changes should happen to Compilation.assets after sealing the Compilation.
        Do changes to assets earlier, e. g. in Compilation.hooks.processAssets.
        Make sure to select an appropriate stage from Compilation.PROCESS_ASSETS_STAGE_*.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

Also updates `webpack-dev-server` for good measure.