### PR TITLE
build: Update outdated dependencies

### DIFF
--- a/brainstorm/package-lock.json
+++ b/brainstorm/package-lock.json
@@ -59,7 +59,7 @@
 				"puppeteer": "^22.11.2",
 				"start-server-and-test": "^2.0.0",
 				"style-loader": "^4.0.0",
-				"tailwindcss": "^3.3.2",
+				"tailwindcss": "^3.4.9",
 				"ts-loader": "^8.0.0",
 				"typescript": "~5.4",
 				"webpack": "^5.88.2",
@@ -16735,9 +16735,9 @@
 			}
 		},
 		"node_modules/tailwindcss": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.3.tgz",
-			"integrity": "sha512-U7sxQk/n397Bmx4JHbJx/iSOOv5G+II3f1kpLpY2QeUv5DcPdcTsYLlusZfq1NthHS1c1cZoyFmmkex1rzke0A==",
+			"version": "3.4.9",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.9.tgz",
+			"integrity": "sha512-1SEOvRr6sSdV5IDf9iC+NU4dhwdqzF4zKKq3sAbasUWHEM6lsMhX+eNN5gkPx1BvLFEnZQEUFbXnGj8Qlp83Pg==",
 			"dev": true,
 			"dependencies": {
 				"@alloc/quick-lru": "^5.2.0",

--- a/brainstorm/package-lock.json
+++ b/brainstorm/package-lock.json
@@ -44,7 +44,7 @@
 				"@types/uuid": "^9.0.8",
 				"@typescript-eslint/eslint-plugin": "^5.38.0",
 				"@typescript-eslint/parser": "^5.38.0",
-				"copy-webpack-plugin": "^11.0.0",
+				"copy-webpack-plugin": "^12.0.2",
 				"cross-env": "^7.0.3",
 				"css-loader": "^7.1.2",
 				"dotenv-webpack": "^7.1.1",
@@ -4491,6 +4491,18 @@
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.35.tgz",
 			"integrity": "sha512-Ul3YyOTU++to8cgNkttakC0dWvpERr6RYoHO2W47DLbFvrwBDJUY31B1sImH6JZSYc4Kt4PyHtoPNu+vL2r2dA=="
 		},
+		"node_modules/@sindresorhus/merge-streams": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+			"integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@sinonjs/commons": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -6925,20 +6937,20 @@
 			"dev": true
 		},
 		"node_modules/copy-webpack-plugin": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
-			"integrity": "sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==",
+			"version": "12.0.2",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-12.0.2.tgz",
+			"integrity": "sha512-SNwdBeHyII+rWvee/bTnAYyO8vfVdcSTud4EIb6jcZ8inLeWucJE0DnxXQBjlQ5zlteuuvooGQy3LIyGxhvlOA==",
 			"dev": true,
 			"dependencies": {
-				"fast-glob": "^3.2.11",
+				"fast-glob": "^3.3.2",
 				"glob-parent": "^6.0.1",
-				"globby": "^13.1.1",
+				"globby": "^14.0.0",
 				"normalize-path": "^3.0.0",
-				"schema-utils": "^4.0.0",
-				"serialize-javascript": "^6.0.0"
+				"schema-utils": "^4.2.0",
+				"serialize-javascript": "^6.0.2"
 			},
 			"engines": {
-				"node": ">= 14.15.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -6949,31 +6961,44 @@
 			}
 		},
 		"node_modules/copy-webpack-plugin/node_modules/globby": {
-			"version": "13.2.2",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-			"integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+			"integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
 			"dev": true,
 			"dependencies": {
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.3.0",
+				"@sindresorhus/merge-streams": "^2.1.0",
+				"fast-glob": "^3.3.2",
 				"ignore": "^5.2.4",
-				"merge2": "^1.4.1",
-				"slash": "^4.0.0"
+				"path-type": "^5.0.0",
+				"slash": "^5.1.0",
+				"unicorn-magic": "^0.1.0"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/copy-webpack-plugin/node_modules/path-type": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+			"integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/copy-webpack-plugin/node_modules/slash": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
 			"dev": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">=14.16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -17423,6 +17448,18 @@
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
 			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
 			"devOptional": true
+		},
+		"node_modules/unicorn-magic": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+			"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/unique-names-generator": {
 			"version": "4.7.1",

--- a/brainstorm/package-lock.json
+++ b/brainstorm/package-lock.json
@@ -58,7 +58,7 @@
 				"prettier": "^2.7.1",
 				"puppeteer": "^22.11.2",
 				"start-server-and-test": "^2.0.0",
-				"style-loader": "^2",
+				"style-loader": "^4.0.0",
 				"tailwindcss": "^3.3.2",
 				"ts-loader": "^8.0.0",
 				"typescript": "~5.4",
@@ -16615,41 +16615,19 @@
 			}
 		},
 		"node_modules/style-loader": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-2.0.0.tgz",
-			"integrity": "sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-4.0.0.tgz",
+			"integrity": "sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==",
 			"dev": true,
-			"dependencies": {
-				"loader-utils": "^2.0.0",
-				"schema-utils": "^3.0.0"
-			},
 			"engines": {
-				"node": ">= 10.13.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.0.0 || ^5.0.0"
-			}
-		},
-		"node_modules/style-loader/node_modules/schema-utils": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-			"dev": true,
-			"dependencies": {
-				"@types/json-schema": "^7.0.8",
-				"ajv": "^6.12.5",
-				"ajv-keywords": "^3.5.2"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
+				"webpack": "^5.27.0"
 			}
 		},
 		"node_modules/stylis": {

--- a/brainstorm/package-lock.json
+++ b/brainstorm/package-lock.json
@@ -62,7 +62,7 @@
 				"tailwindcss": "^3.4.9",
 				"ts-loader": "^8.0.0",
 				"typescript": "~5.4",
-				"webpack": "^5.88.2",
+				"webpack": "^5.93.0",
 				"webpack-cli": "^5.1.4",
 				"webpack-dev-server": "^5.0.4"
 			},
@@ -5492,10 +5492,10 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/acorn-import-assertions": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-			"integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+		"node_modules/acorn-import-attributes": {
+			"version": "1.9.5",
+			"resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+			"integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
 			"dev": true,
 			"peerDependencies": {
 				"acorn": "^8"
@@ -17721,9 +17721,9 @@
 			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
 		},
 		"node_modules/webpack": {
-			"version": "5.91.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.91.0.tgz",
-			"integrity": "sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==",
+			"version": "5.93.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
+			"integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
 			"dev": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.3",
@@ -17732,10 +17732,10 @@
 				"@webassemblyjs/wasm-edit": "^1.12.1",
 				"@webassemblyjs/wasm-parser": "^1.12.1",
 				"acorn": "^8.7.1",
-				"acorn-import-assertions": "^1.9.0",
+				"acorn-import-attributes": "^1.9.5",
 				"browserslist": "^4.21.10",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.16.0",
+				"enhanced-resolve": "^5.17.0",
 				"es-module-lexer": "^1.2.1",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",

--- a/brainstorm/package-lock.json
+++ b/brainstorm/package-lock.json
@@ -53,7 +53,7 @@
 				"html-webpack-plugin": "^5.6.0",
 				"jest": "^29.2.2",
 				"jest-junit": "^16.0.0",
-				"jest-puppeteer": "^9.0.0",
+				"jest-puppeteer": "^10.0.1",
 				"mini-css-extract-plugin": "^2.9.0",
 				"prettier": "^2.7.1",
 				"puppeteer": "^22.11.2",
@@ -8621,9 +8621,9 @@
 			}
 		},
 		"node_modules/expect-puppeteer": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-9.0.2.tgz",
-			"integrity": "sha512-nv3RD8MOStXOf4bLpr1wiqxPMLL7MwXvtMeZBtGvg5bubAHiHcYBcvDTJwkUjdOWz3scjOnOOl5z6KZakMobCw==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-10.0.0.tgz",
+			"integrity": "sha512-E7sE6nVdEbrnpDOBMmcLgyqLJKt876AlBg1A+gsu5R8cWx+SLafreOgJAgzXg5Qko7Tk0cW5oZdRbHQLU738dg==",
 			"dev": true,
 			"engines": {
 				"node": ">=16"
@@ -11226,16 +11226,16 @@
 			}
 		},
 		"node_modules/jest-dev-server": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-9.0.2.tgz",
-			"integrity": "sha512-Zc/JB0IlNNrpXkhBw+h86cGrde/Mey52KvF+FER2eyrtYJTHObOwW7Iarxm3rPyTKby5+3Y2QZtl8pRz/5GCxg==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-10.0.0.tgz",
+			"integrity": "sha512-FtyBBDxrAIfTX3hyKSOwj5KU6Z7fFLew5pQYOFpwyf+qpPpULL8aYxtsFkbkAwcs+Mb7qhcNbVLeiWsLOd7CKw==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.2",
 				"cwd": "^0.10.0",
 				"find-process": "^1.4.7",
 				"prompts": "^2.4.2",
-				"spawnd": "^9.0.2",
+				"spawnd": "^10.0.0",
 				"tree-kill": "^1.2.2",
 				"wait-on": "^7.2.0"
 			},
@@ -11514,15 +11514,15 @@
 			}
 		},
 		"node_modules/jest-environment-puppeteer": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-9.0.2.tgz",
-			"integrity": "sha512-t7+W4LUiPoOz+xpKREgnu6IElMuRthOWTkrThDZqVKPmLhwbK3yx7OCiX8xT1Pw/Cv5WnSoNhwtN7czdCC3fQg==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-10.0.1.tgz",
+			"integrity": "sha512-FxMzVRyqieQqSy5CPWiwdK5t9dkRHid5eoRTVa8RtYeXLlpW6lU0dAmxEfPkdnDVCiPUhC2APeKOXq0J72bgag==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.2",
 				"cosmiconfig": "^8.3.6",
 				"deepmerge": "^4.3.1",
-				"jest-dev-server": "^9.0.2",
+				"jest-dev-server": "^10.0.0",
 				"jest-environment-node": "^29.7.0"
 			},
 			"engines": {
@@ -11877,13 +11877,13 @@
 			}
 		},
 		"node_modules/jest-puppeteer": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-9.0.2.tgz",
-			"integrity": "sha512-ZB0K/tH+0e7foRRn+VpKIufvkW1by8l7ifh62VOdOh5ijEf7yt8W2/PcBNNwP0RLm46AytiBkrIEenvWhxcBRQ==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-10.0.1.tgz",
+			"integrity": "sha512-FzC35XbqeuQEt1smXh1EOqhJaRkWqJkyWDMfGkcZ8C59QHXeJ7F/iOmiNqYi6l/OsycUuOPCk+IkjfGfS9YbrQ==",
 			"dev": true,
 			"dependencies": {
-				"expect-puppeteer": "^9.0.2",
-				"jest-environment-puppeteer": "^9.0.2"
+				"expect-puppeteer": "^10.0.0",
+				"jest-environment-puppeteer": "^10.0.1"
 			},
 			"engines": {
 				"node": ">=16"
@@ -16131,9 +16131,9 @@
 			}
 		},
 		"node_modules/spawnd": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-9.0.2.tgz",
-			"integrity": "sha512-nl8DVHEDQ57IcKakzpjanspVChkMpGLuVwMR/eOn9cXE55Qr6luD2Kn06sA0ootRMdgrU4tInN6lA6ohTNvysw==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-10.0.0.tgz",
+			"integrity": "sha512-6GKcakMTryb5b1SWCvdubCDHEsR2k+5VZUD5G19umZRarkvj1RyCGyizcqhjewI7cqZo8fTVD8HpnDZbVOLMtg==",
 			"dev": true,
 			"dependencies": {
 				"signal-exit": "^4.1.0",

--- a/brainstorm/package-lock.json
+++ b/brainstorm/package-lock.json
@@ -17,7 +17,6 @@
 				"@fluidframework/odsp-client": "^2.1.0",
 				"@fluidframework/telemetry-utils": "^2.1.0",
 				"@fluidframework/test-runtime-utils": "^2.1.0",
-				"@headlessui/react": "^1.7.18",
 				"@microsoft/microsoft-graph-client": "^3.0.7",
 				"axios": "^1.7.3",
 				"dotenv": "^16.0.2",
@@ -3295,22 +3294,6 @@
 				"@hapi/hoek": "^9.0.0"
 			}
 		},
-		"node_modules/@headlessui/react": {
-			"version": "1.7.19",
-			"resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.19.tgz",
-			"integrity": "sha512-Ll+8q3OlMJfJbAKM/+/Y2q6PPYbryqNTXDbryx7SXLIDamkF6iQFbriYHga0dY44PvDhvvBWCx1Xj4U5+G4hOw==",
-			"dependencies": {
-				"@tanstack/react-virtual": "^3.0.0-beta.60",
-				"client-only": "^0.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"peerDependencies": {
-				"react": "^16 || ^17 || ^18",
-				"react-dom": "^16 || ^17 || ^18"
-			}
-		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.11.14",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -4561,31 +4544,6 @@
 			"integrity": "sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==",
 			"dependencies": {
 				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@tanstack/react-virtual": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.4.0.tgz",
-			"integrity": "sha512-GZN4xn/Tg5w7gvYeVcMVCeL4pEyUhvg+Cp6KX2Z01C4FRNxIWMgIQ9ibgMarNQfo+gt0PVLcEER4A9sNv/jlow==",
-			"dependencies": {
-				"@tanstack/virtual-core": "3.4.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/tannerlinsley"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-			}
-		},
-		"node_modules/@tanstack/virtual-core": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.4.0.tgz",
-			"integrity": "sha512-75jXqXxqq5M5Veb9KP1STi8kA5u408uOOAefk2ftHDGCpUk3RP6zX++QqfbmHJTBiU72NQ+ghgCZVts/Wocz8Q==",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/tannerlinsley"
 			}
 		},
 		"node_modules/@tiny-calc/nano": {
@@ -6676,11 +6634,6 @@
 			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
 			"integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
 			"dev": true
-		},
-		"node_modules/client-only": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-			"integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
 		},
 		"node_modules/cliui": {
 			"version": "8.0.1",

--- a/brainstorm/package-lock.json
+++ b/brainstorm/package-lock.json
@@ -60,7 +60,7 @@
 				"start-server-and-test": "^2.0.0",
 				"style-loader": "^4.0.0",
 				"tailwindcss": "^3.4.9",
-				"ts-loader": "^8.0.0",
+				"ts-loader": "^9.5.1",
 				"typescript": "~5.4",
 				"webpack": "^5.93.0",
 				"webpack-cli": "^5.1.4",
@@ -6193,15 +6193,6 @@
 			"integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
 			"dev": true
 		},
-		"node_modules/big.js": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/binary-extensions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -7829,15 +7820,6 @@
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true
 		},
-		"node_modules/emojis-list": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-			"dev": true,
-			"engines": {
-				"node": ">= 4"
-			}
-		},
 		"node_modules/enabled": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
@@ -7904,17 +7886,16 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
-			"integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+			"version": "5.17.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+			"integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
 			"dev": true,
 			"dependencies": {
-				"graceful-fs": "^4.1.2",
-				"memory-fs": "^0.5.0",
-				"tapable": "^1.0.0"
+				"graceful-fs": "^4.2.4",
+				"tapable": "^2.2.0"
 			},
 			"engines": {
-				"node": ">=6.9.0"
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/entities": {
@@ -9786,15 +9767,6 @@
 				"webpack": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/html-webpack-plugin/node_modules/tapable": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/htmlparser2": {
@@ -13115,20 +13087,6 @@
 				"node": ">=6.11.5"
 			}
 		},
-		"node_modules/loader-utils": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-			"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-			"dev": true,
-			"dependencies": {
-				"big.js": "^5.2.2",
-				"emojis-list": "^3.0.0",
-				"json5": "^2.1.2"
-			},
-			"engines": {
-				"node": ">=8.9.0"
-			}
-		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -13335,46 +13293,6 @@
 				"url": "https://github.com/sponsors/streamich"
 			}
 		},
-		"node_modules/memory-fs": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
-			"integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-			"dev": true,
-			"dependencies": {
-				"errno": "^0.1.3",
-				"readable-stream": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=4.3.0 <5.0.0 || >=5.10"
-			}
-		},
-		"node_modules/memory-fs/node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true
-		},
-		"node_modules/memory-fs/node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-			"dev": true,
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/memory-fs/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
 		"node_modules/merge-descriptors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -13488,15 +13406,6 @@
 			},
 			"peerDependencies": {
 				"webpack": "^5.0.0"
-			}
-		},
-		"node_modules/mini-css-extract-plugin/node_modules/tapable": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/minimalistic-assert": {
@@ -16772,9 +16681,9 @@
 			}
 		},
 		"node_modules/tapable": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-			"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -17162,23 +17071,23 @@
 			"dev": true
 		},
 		"node_modules/ts-loader": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.4.0.tgz",
-			"integrity": "sha512-6nFY3IZ2//mrPc+ImY3hNWx1vCHyEhl6V+wLmL4CZcm6g1CqX7UKrkc6y0i4FwcfOhxyMPCfaEvh20f4r9GNpw==",
+			"version": "9.5.1",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.1.tgz",
+			"integrity": "sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.0",
-				"enhanced-resolve": "^4.0.0",
-				"loader-utils": "^2.0.0",
+				"enhanced-resolve": "^5.0.0",
 				"micromatch": "^4.0.0",
-				"semver": "^7.3.4"
+				"semver": "^7.3.4",
+				"source-map": "^0.7.4"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=12.0.0"
 			},
 			"peerDependencies": {
 				"typescript": "*",
-				"webpack": "*"
+				"webpack": "^5.0.0"
 			}
 		},
 		"node_modules/ts-loader/node_modules/ansi-styles": {
@@ -17249,6 +17158,15 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/ts-loader/node_modules/source-map": {
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+			"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/ts-loader/node_modules/supports-color": {
@@ -18045,19 +17963,6 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/webpack/node_modules/enhanced-resolve": {
-			"version": "5.17.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
-			"integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
-			"dev": true,
-			"dependencies": {
-				"graceful-fs": "^4.2.4",
-				"tapable": "^2.2.0"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
 		"node_modules/webpack/node_modules/schema-utils": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
@@ -18074,15 +17979,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
-			}
-		},
-		"node_modules/webpack/node_modules/tapable": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/webpack/node_modules/webpack-sources": {

--- a/brainstorm/package-lock.json
+++ b/brainstorm/package-lock.json
@@ -54,7 +54,7 @@
 				"jest": "^29.2.2",
 				"jest-junit": "^16.0.0",
 				"jest-puppeteer": "^9.0.0",
-				"mini-css-extract-plugin": "^1",
+				"mini-css-extract-plugin": "^2.9.0",
 				"prettier": "^2.7.1",
 				"puppeteer": "^22.11.2",
 				"start-server-and-test": "^2.0.0",
@@ -13471,42 +13471,32 @@
 			}
 		},
 		"node_modules/mini-css-extract-plugin": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.2.tgz",
-			"integrity": "sha512-WhDvO3SjGm40oV5y26GjMJYjd2UMqrLAGKy5YS2/3QKJy2F7jgynuHTir/tgUUOiNQu5saXHdc8reo7YuhhT4Q==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.0.tgz",
+			"integrity": "sha512-Zs1YsZVfemekSZG+44vBsYTLQORkPMwnlv+aehcxK/NLKC+EGhDB39/YePYYqx/sTk6NnYpuqikhSn7+JIevTA==",
 			"dev": true,
 			"dependencies": {
-				"loader-utils": "^2.0.0",
-				"schema-utils": "^3.0.0",
-				"webpack-sources": "^1.1.0"
+				"schema-utils": "^4.0.0",
+				"tapable": "^2.2.1"
 			},
 			"engines": {
-				"node": ">= 10.13.0"
+				"node": ">= 12.13.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.4.0 || ^5.0.0"
+				"webpack": "^5.0.0"
 			}
 		},
-		"node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+		"node_modules/mini-css-extract-plugin/node_modules/tapable": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
 			"dev": true,
-			"dependencies": {
-				"@types/json-schema": "^7.0.8",
-				"ajv": "^6.12.5",
-				"ajv-keywords": "^3.5.2"
-			},
 			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
+				"node": ">=6"
 			}
 		},
 		"node_modules/minimalistic-assert": {
@@ -16203,12 +16193,6 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/source-list-map": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-			"integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
-			"dev": true
-		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -18081,16 +18065,6 @@
 			},
 			"engines": {
 				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/webpack-sources": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-			"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
-			"dev": true,
-			"dependencies": {
-				"source-list-map": "^2.0.0",
-				"source-map": "~0.6.1"
 			}
 		},
 		"node_modules/webpack/node_modules/enhanced-resolve": {

--- a/brainstorm/package.json
+++ b/brainstorm/package.json
@@ -61,7 +61,7 @@
 		"@types/uuid": "^9.0.8",
 		"@typescript-eslint/eslint-plugin": "^5.38.0",
 		"@typescript-eslint/parser": "^5.38.0",
-		"copy-webpack-plugin": "^11.0.0",
+		"copy-webpack-plugin": "^12.0.2",
 		"cross-env": "^7.0.3",
 		"css-loader": "^7.1.2",
 		"dotenv-webpack": "^7.1.1",

--- a/brainstorm/package.json
+++ b/brainstorm/package.json
@@ -34,7 +34,6 @@
 		"@fluidframework/odsp-client": "^2.1.0",
 		"@fluidframework/telemetry-utils": "^2.1.0",
 		"@fluidframework/test-runtime-utils": "^2.1.0",
-		"@headlessui/react": "^1.7.18",
 		"@microsoft/microsoft-graph-client": "^3.0.7",
 		"axios": "^1.7.3",
 		"dotenv": "^16.0.2",

--- a/brainstorm/package.json
+++ b/brainstorm/package.json
@@ -77,7 +77,7 @@
 		"start-server-and-test": "^2.0.0",
 		"style-loader": "^4.0.0",
 		"tailwindcss": "^3.4.9",
-		"ts-loader": "^8.0.0",
+		"ts-loader": "^9.5.1",
 		"typescript": "~5.4",
 		"webpack": "^5.93.0",
 		"webpack-cli": "^5.1.4",

--- a/brainstorm/package.json
+++ b/brainstorm/package.json
@@ -69,7 +69,7 @@
 		"jest": "^29.2.2",
 		"jest-junit": "^16.0.0",
 		"jest-puppeteer": "^9.0.0",
-		"mini-css-extract-plugin": "^1",
+		"mini-css-extract-plugin": "^2.9.0",
 		"prettier": "^2.7.1",
 		"puppeteer": "^22.11.2",
 		"start-server-and-test": "^2.0.0",

--- a/brainstorm/package.json
+++ b/brainstorm/package.json
@@ -70,7 +70,7 @@
 		"html-webpack-plugin": "^5.6.0",
 		"jest": "^29.2.2",
 		"jest-junit": "^16.0.0",
-		"jest-puppeteer": "^9.0.0",
+		"jest-puppeteer": "^10.0.1",
 		"mini-css-extract-plugin": "^2.9.0",
 		"prettier": "^2.7.1",
 		"puppeteer": "^22.11.2",

--- a/brainstorm/package.json
+++ b/brainstorm/package.json
@@ -16,9 +16,11 @@
 		"dev:spe": "cross-env FLUID_CLIENT='spe' webpack-dev-server",
 		"format": "prettier src --write",
 		"lint": "eslint src",
-		"webpack": "cross-env webpack",
 		"start": "npm run dev",
-		"start:server": "npx @fluidframework/azure-local-service"
+		"start:server": "npx @fluidframework/azure-local-service",
+		"test": "start-server-and-test start:server 7070 test:jest",
+		"test:jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --reporters=default --reporters=jest-junit",
+		"webpack": "cross-env webpack"
 	},
 	"engines": {
 		"node": ">=20.0.0"

--- a/brainstorm/package.json
+++ b/brainstorm/package.json
@@ -74,7 +74,7 @@
 		"puppeteer": "^22.11.2",
 		"start-server-and-test": "^2.0.0",
 		"style-loader": "^4.0.0",
-		"tailwindcss": "^3.3.2",
+		"tailwindcss": "^3.4.9",
 		"ts-loader": "^8.0.0",
 		"typescript": "~5.4",
 		"webpack": "^5.88.2",

--- a/brainstorm/package.json
+++ b/brainstorm/package.json
@@ -73,7 +73,7 @@
 		"prettier": "^2.7.1",
 		"puppeteer": "^22.11.2",
 		"start-server-and-test": "^2.0.0",
-		"style-loader": "^2",
+		"style-loader": "^4.0.0",
 		"tailwindcss": "^3.3.2",
 		"ts-loader": "^8.0.0",
 		"typescript": "~5.4",

--- a/brainstorm/package.json
+++ b/brainstorm/package.json
@@ -77,7 +77,7 @@
 		"tailwindcss": "^3.4.9",
 		"ts-loader": "^8.0.0",
 		"typescript": "~5.4",
-		"webpack": "^5.88.2",
+		"webpack": "^5.93.0",
 		"webpack-cli": "^5.1.4",
 		"webpack-dev-server": "^5.0.4"
 	},

--- a/item-counter-spe/package-lock.json
+++ b/item-counter-spe/package-lock.json
@@ -49,7 +49,7 @@
 				"puppeteer": "^22.11.2",
 				"start-server-and-test": "^2.0.0",
 				"style-loader": "^4.0.0",
-				"tailwindcss": "^3.3.2",
+				"tailwindcss": "^3.4.9",
 				"ts-loader": "^8.0.0",
 				"typescript": "~5.4",
 				"webpack": "^5.88.2",
@@ -13725,9 +13725,9 @@
 			}
 		},
 		"node_modules/tailwindcss": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.3.tgz",
-			"integrity": "sha512-U7sxQk/n397Bmx4JHbJx/iSOOv5G+II3f1kpLpY2QeUv5DcPdcTsYLlusZfq1NthHS1c1cZoyFmmkex1rzke0A==",
+			"version": "3.4.9",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.9.tgz",
+			"integrity": "sha512-1SEOvRr6sSdV5IDf9iC+NU4dhwdqzF4zKKq3sAbasUWHEM6lsMhX+eNN5gkPx1BvLFEnZQEUFbXnGj8Qlp83Pg==",
 			"dev": true,
 			"dependencies": {
 				"@alloc/quick-lru": "^5.2.0",

--- a/item-counter-spe/package-lock.json
+++ b/item-counter-spe/package-lock.json
@@ -52,7 +52,7 @@
 				"tailwindcss": "^3.4.9",
 				"ts-loader": "^8.0.0",
 				"typescript": "~5.4",
-				"webpack": "^5.88.2",
+				"webpack": "^5.93.0",
 				"webpack-cli": "^5.1.4",
 				"webpack-dev-server": "^5.0.4"
 			},
@@ -3774,10 +3774,10 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/acorn-import-assertions": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-			"integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+		"node_modules/acorn-import-attributes": {
+			"version": "1.9.5",
+			"resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+			"integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
 			"dev": true,
 			"peerDependencies": {
 				"acorn": "^8"
@@ -14551,9 +14551,9 @@
 			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
 		},
 		"node_modules/webpack": {
-			"version": "5.91.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.91.0.tgz",
-			"integrity": "sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==",
+			"version": "5.93.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
+			"integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
 			"dev": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.3",
@@ -14562,10 +14562,10 @@
 				"@webassemblyjs/wasm-edit": "^1.12.1",
 				"@webassemblyjs/wasm-parser": "^1.12.1",
 				"acorn": "^8.7.1",
-				"acorn-import-assertions": "^1.9.0",
+				"acorn-import-attributes": "^1.9.5",
 				"browserslist": "^4.21.10",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.16.0",
+				"enhanced-resolve": "^5.17.0",
 				"es-module-lexer": "^1.2.1",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",

--- a/item-counter-spe/package-lock.json
+++ b/item-counter-spe/package-lock.json
@@ -48,7 +48,7 @@
 				"prettier": "^2.7.1",
 				"puppeteer": "^22.11.2",
 				"start-server-and-test": "^2.0.0",
-				"style-loader": "^2",
+				"style-loader": "^4.0.0",
 				"tailwindcss": "^3.3.2",
 				"ts-loader": "^8.0.0",
 				"typescript": "~5.4",
@@ -13614,41 +13614,19 @@
 			}
 		},
 		"node_modules/style-loader": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-2.0.0.tgz",
-			"integrity": "sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-4.0.0.tgz",
+			"integrity": "sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==",
 			"dev": true,
-			"dependencies": {
-				"loader-utils": "^2.0.0",
-				"schema-utils": "^3.0.0"
-			},
 			"engines": {
-				"node": ">= 10.13.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.0.0 || ^5.0.0"
-			}
-		},
-		"node_modules/style-loader/node_modules/schema-utils": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-			"dev": true,
-			"dependencies": {
-				"@types/json-schema": "^7.0.8",
-				"ajv": "^6.12.5",
-				"ajv-keywords": "^3.5.2"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
+				"webpack": "^5.27.0"
 			}
 		},
 		"node_modules/stylis": {

--- a/item-counter-spe/package-lock.json
+++ b/item-counter-spe/package-lock.json
@@ -43,7 +43,7 @@
 				"html-webpack-plugin": "^5.6.0",
 				"jest": "^29.2.2",
 				"jest-junit": "^16.0.0",
-				"jest-puppeteer": "^9.0.0",
+				"jest-puppeteer": "^10.0.1",
 				"mini-css-extract-plugin": "^2.9.0",
 				"prettier": "^2.7.1",
 				"puppeteer": "^22.11.2",
@@ -6586,9 +6586,9 @@
 			}
 		},
 		"node_modules/expect-puppeteer": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-9.0.2.tgz",
-			"integrity": "sha512-nv3RD8MOStXOf4bLpr1wiqxPMLL7MwXvtMeZBtGvg5bubAHiHcYBcvDTJwkUjdOWz3scjOnOOl5z6KZakMobCw==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-10.0.0.tgz",
+			"integrity": "sha512-E7sE6nVdEbrnpDOBMmcLgyqLJKt876AlBg1A+gsu5R8cWx+SLafreOgJAgzXg5Qko7Tk0cW5oZdRbHQLU738dg==",
 			"dev": true,
 			"engines": {
 				"node": ">=16"
@@ -8953,16 +8953,16 @@
 			}
 		},
 		"node_modules/jest-dev-server": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-9.0.2.tgz",
-			"integrity": "sha512-Zc/JB0IlNNrpXkhBw+h86cGrde/Mey52KvF+FER2eyrtYJTHObOwW7Iarxm3rPyTKby5+3Y2QZtl8pRz/5GCxg==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-10.0.0.tgz",
+			"integrity": "sha512-FtyBBDxrAIfTX3hyKSOwj5KU6Z7fFLew5pQYOFpwyf+qpPpULL8aYxtsFkbkAwcs+Mb7qhcNbVLeiWsLOd7CKw==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.2",
 				"cwd": "^0.10.0",
 				"find-process": "^1.4.7",
 				"prompts": "^2.4.2",
-				"spawnd": "^9.0.2",
+				"spawnd": "^10.0.0",
 				"tree-kill": "^1.2.2",
 				"wait-on": "^7.2.0"
 			},
@@ -9241,15 +9241,15 @@
 			}
 		},
 		"node_modules/jest-environment-puppeteer": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-9.0.2.tgz",
-			"integrity": "sha512-t7+W4LUiPoOz+xpKREgnu6IElMuRthOWTkrThDZqVKPmLhwbK3yx7OCiX8xT1Pw/Cv5WnSoNhwtN7czdCC3fQg==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-10.0.1.tgz",
+			"integrity": "sha512-FxMzVRyqieQqSy5CPWiwdK5t9dkRHid5eoRTVa8RtYeXLlpW6lU0dAmxEfPkdnDVCiPUhC2APeKOXq0J72bgag==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.2",
 				"cosmiconfig": "^8.3.6",
 				"deepmerge": "^4.3.1",
-				"jest-dev-server": "^9.0.2",
+				"jest-dev-server": "^10.0.0",
 				"jest-environment-node": "^29.7.0"
 			},
 			"engines": {
@@ -9595,13 +9595,13 @@
 			}
 		},
 		"node_modules/jest-puppeteer": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-9.0.2.tgz",
-			"integrity": "sha512-ZB0K/tH+0e7foRRn+VpKIufvkW1by8l7ifh62VOdOh5ijEf7yt8W2/PcBNNwP0RLm46AytiBkrIEenvWhxcBRQ==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-10.0.1.tgz",
+			"integrity": "sha512-FzC35XbqeuQEt1smXh1EOqhJaRkWqJkyWDMfGkcZ8C59QHXeJ7F/iOmiNqYi6l/OsycUuOPCk+IkjfGfS9YbrQ==",
 			"dev": true,
 			"dependencies": {
-				"expect-puppeteer": "^9.0.2",
-				"jest-environment-puppeteer": "^9.0.2"
+				"expect-puppeteer": "^10.0.0",
+				"jest-environment-puppeteer": "^10.0.1"
 			},
 			"engines": {
 				"node": ">=16"
@@ -13162,9 +13162,9 @@
 			}
 		},
 		"node_modules/spawnd": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-9.0.2.tgz",
-			"integrity": "sha512-nl8DVHEDQ57IcKakzpjanspVChkMpGLuVwMR/eOn9cXE55Qr6luD2Kn06sA0ootRMdgrU4tInN6lA6ohTNvysw==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-10.0.0.tgz",
+			"integrity": "sha512-6GKcakMTryb5b1SWCvdubCDHEsR2k+5VZUD5G19umZRarkvj1RyCGyizcqhjewI7cqZo8fTVD8HpnDZbVOLMtg==",
 			"dev": true,
 			"dependencies": {
 				"signal-exit": "^4.1.0",

--- a/item-counter-spe/package-lock.json
+++ b/item-counter-spe/package-lock.json
@@ -44,7 +44,7 @@
 				"jest": "^29.2.2",
 				"jest-junit": "^16.0.0",
 				"jest-puppeteer": "^9.0.0",
-				"mini-css-extract-plugin": "^1",
+				"mini-css-extract-plugin": "^2.9.0",
 				"prettier": "^2.7.1",
 				"puppeteer": "^22.11.2",
 				"start-server-and-test": "^2.0.0",
@@ -10973,42 +10973,32 @@
 			}
 		},
 		"node_modules/mini-css-extract-plugin": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.2.tgz",
-			"integrity": "sha512-WhDvO3SjGm40oV5y26GjMJYjd2UMqrLAGKy5YS2/3QKJy2F7jgynuHTir/tgUUOiNQu5saXHdc8reo7YuhhT4Q==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.0.tgz",
+			"integrity": "sha512-Zs1YsZVfemekSZG+44vBsYTLQORkPMwnlv+aehcxK/NLKC+EGhDB39/YePYYqx/sTk6NnYpuqikhSn7+JIevTA==",
 			"dev": true,
 			"dependencies": {
-				"loader-utils": "^2.0.0",
-				"schema-utils": "^3.0.0",
-				"webpack-sources": "^1.1.0"
+				"schema-utils": "^4.0.0",
+				"tapable": "^2.2.1"
 			},
 			"engines": {
-				"node": ">= 10.13.0"
+				"node": ">= 12.13.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.4.0 || ^5.0.0"
+				"webpack": "^5.0.0"
 			}
 		},
-		"node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+		"node_modules/mini-css-extract-plugin/node_modules/tapable": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
 			"dev": true,
-			"dependencies": {
-				"@types/json-schema": "^7.0.8",
-				"ajv": "^6.12.5",
-				"ajv-keywords": "^3.5.2"
-			},
 			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
+				"node": ">=6"
 			}
 		},
 		"node_modules/minimalistic-assert": {
@@ -13225,12 +13215,6 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/source-list-map": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-			"integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
-			"dev": true
-		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -14893,16 +14877,6 @@
 			},
 			"engines": {
 				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/webpack-sources": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-			"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
-			"dev": true,
-			"dependencies": {
-				"source-list-map": "^2.0.0",
-				"source-map": "~0.6.1"
 			}
 		},
 		"node_modules/webpack/node_modules/enhanced-resolve": {

--- a/item-counter-spe/package-lock.json
+++ b/item-counter-spe/package-lock.json
@@ -34,7 +34,7 @@
 				"@types/react-dom": "^18.3.0",
 				"@typescript-eslint/eslint-plugin": "^5.38.0",
 				"@typescript-eslint/parser": "^5.38.0",
-				"copy-webpack-plugin": "^11.0.0",
+				"copy-webpack-plugin": "^12.0.2",
 				"cross-env": "^7.0.3",
 				"css-loader": "^7.1.2",
 				"dotenv-webpack": "^7.1.1",
@@ -2911,6 +2911,18 @@
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.35.tgz",
 			"integrity": "sha512-Ul3YyOTU++to8cgNkttakC0dWvpERr6RYoHO2W47DLbFvrwBDJUY31B1sImH6JZSYc4Kt4PyHtoPNu+vL2r2dA=="
 		},
+		"node_modules/@sindresorhus/merge-streams": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+			"integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@sinonjs/commons": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -5008,20 +5020,20 @@
 			"dev": true
 		},
 		"node_modules/copy-webpack-plugin": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
-			"integrity": "sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==",
+			"version": "12.0.2",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-12.0.2.tgz",
+			"integrity": "sha512-SNwdBeHyII+rWvee/bTnAYyO8vfVdcSTud4EIb6jcZ8inLeWucJE0DnxXQBjlQ5zlteuuvooGQy3LIyGxhvlOA==",
 			"dev": true,
 			"dependencies": {
-				"fast-glob": "^3.2.11",
+				"fast-glob": "^3.3.2",
 				"glob-parent": "^6.0.1",
-				"globby": "^13.1.1",
+				"globby": "^14.0.0",
 				"normalize-path": "^3.0.0",
-				"schema-utils": "^4.0.0",
-				"serialize-javascript": "^6.0.0"
+				"schema-utils": "^4.2.0",
+				"serialize-javascript": "^6.0.2"
 			},
 			"engines": {
-				"node": ">= 14.15.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -5032,31 +5044,44 @@
 			}
 		},
 		"node_modules/copy-webpack-plugin/node_modules/globby": {
-			"version": "13.2.2",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-			"integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+			"integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
 			"dev": true,
 			"dependencies": {
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.3.0",
+				"@sindresorhus/merge-streams": "^2.1.0",
+				"fast-glob": "^3.3.2",
 				"ignore": "^5.2.4",
-				"merge2": "^1.4.1",
-				"slash": "^4.0.0"
+				"path-type": "^5.0.0",
+				"slash": "^5.1.0",
+				"unicorn-magic": "^0.1.0"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/copy-webpack-plugin/node_modules/path-type": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+			"integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/copy-webpack-plugin/node_modules/slash": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
 			"dev": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">=14.16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -14306,6 +14331,18 @@
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
 			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
 			"dev": true
+		},
+		"node_modules/unicorn-magic": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+			"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/universalify": {
 			"version": "2.0.1",

--- a/item-counter-spe/package-lock.json
+++ b/item-counter-spe/package-lock.json
@@ -50,7 +50,7 @@
 				"start-server-and-test": "^2.0.0",
 				"style-loader": "^4.0.0",
 				"tailwindcss": "^3.4.9",
-				"ts-loader": "^8.0.0",
+				"ts-loader": "^9.5.1",
 				"typescript": "~5.4",
 				"webpack": "^5.93.0",
 				"webpack-cli": "^5.1.4",
@@ -4402,15 +4402,6 @@
 			"integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
 			"dev": true
 		},
-		"node_modules/big.js": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/binary-extensions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -5833,15 +5824,6 @@
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true
 		},
-		"node_modules/emojis-list": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-			"dev": true,
-			"engines": {
-				"node": ">= 4"
-			}
-		},
 		"node_modules/encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -5881,17 +5863,16 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
-			"integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+			"version": "5.17.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+			"integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
 			"dev": true,
 			"dependencies": {
-				"graceful-fs": "^4.1.2",
-				"memory-fs": "^0.5.0",
-				"tapable": "^1.0.0"
+				"graceful-fs": "^4.2.4",
+				"tapable": "^2.2.0"
 			},
 			"engines": {
-				"node": ">=6.9.0"
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/entities": {
@@ -5922,18 +5903,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/errno": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
-			"integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-			"dev": true,
-			"dependencies": {
-				"prr": "~1.0.1"
-			},
-			"bin": {
-				"errno": "cli.js"
 			}
 		},
 		"node_modules/error-ex": {
@@ -7679,15 +7648,6 @@
 				"webpack": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/html-webpack-plugin/node_modules/tapable": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/htmlparser2": {
@@ -10697,20 +10657,6 @@
 				"node": ">=6.11.5"
 			}
 		},
-		"node_modules/loader-utils": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-			"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-			"dev": true,
-			"dependencies": {
-				"big.js": "^5.2.2",
-				"emojis-list": "^3.0.0",
-				"json5": "^2.1.2"
-			},
-			"engines": {
-				"node": ">=8.9.0"
-			}
-		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -10876,19 +10822,6 @@
 				"url": "https://github.com/sponsors/streamich"
 			}
 		},
-		"node_modules/memory-fs": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
-			"integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-			"dev": true,
-			"dependencies": {
-				"errno": "^0.1.3",
-				"readable-stream": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=4.3.0 <5.0.0 || >=5.10"
-			}
-		},
 		"node_modules/merge-descriptors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -10990,15 +10923,6 @@
 			},
 			"peerDependencies": {
 				"webpack": "^5.0.0"
-			}
-		},
-		"node_modules/mini-css-extract-plugin/node_modules/tapable": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/minimalistic-assert": {
@@ -12156,12 +12080,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-		},
-		"node_modules/prr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-			"dev": true
 		},
 		"node_modules/ps-tree": {
 			"version": "1.2.0",
@@ -13762,9 +13680,9 @@
 			}
 		},
 		"node_modules/tapable": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-			"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -14066,23 +13984,23 @@
 			"dev": true
 		},
 		"node_modules/ts-loader": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.4.0.tgz",
-			"integrity": "sha512-6nFY3IZ2//mrPc+ImY3hNWx1vCHyEhl6V+wLmL4CZcm6g1CqX7UKrkc6y0i4FwcfOhxyMPCfaEvh20f4r9GNpw==",
+			"version": "9.5.1",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.1.tgz",
+			"integrity": "sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.0",
-				"enhanced-resolve": "^4.0.0",
-				"loader-utils": "^2.0.0",
+				"enhanced-resolve": "^5.0.0",
 				"micromatch": "^4.0.0",
-				"semver": "^7.3.4"
+				"semver": "^7.3.4",
+				"source-map": "^0.7.4"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=12.0.0"
 			},
 			"peerDependencies": {
 				"typescript": "*",
-				"webpack": "*"
+				"webpack": "^5.0.0"
 			}
 		},
 		"node_modules/ts-loader/node_modules/ansi-styles": {
@@ -14153,6 +14071,15 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/ts-loader/node_modules/source-map": {
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+			"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/ts-loader/node_modules/supports-color": {
@@ -14857,19 +14784,6 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/webpack/node_modules/enhanced-resolve": {
-			"version": "5.17.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
-			"integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
-			"dev": true,
-			"dependencies": {
-				"graceful-fs": "^4.2.4",
-				"tapable": "^2.2.0"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
 		"node_modules/webpack/node_modules/schema-utils": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
@@ -14886,15 +14800,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
-			}
-		},
-		"node_modules/webpack/node_modules/tapable": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/webpack/node_modules/webpack-sources": {

--- a/item-counter-spe/package.json
+++ b/item-counter-spe/package.json
@@ -54,7 +54,7 @@
 		"jest": "^29.2.2",
 		"jest-junit": "^16.0.0",
 		"jest-puppeteer": "^9.0.0",
-		"mini-css-extract-plugin": "^1",
+		"mini-css-extract-plugin": "^2.9.0",
 		"prettier": "^2.7.1",
 		"puppeteer": "^22.11.2",
 		"start-server-and-test": "^2.0.0",

--- a/item-counter-spe/package.json
+++ b/item-counter-spe/package.json
@@ -58,7 +58,7 @@
 		"prettier": "^2.7.1",
 		"puppeteer": "^22.11.2",
 		"start-server-and-test": "^2.0.0",
-		"style-loader": "^2",
+		"style-loader": "^4.0.0",
 		"tailwindcss": "^3.3.2",
 		"ts-loader": "^8.0.0",
 		"typescript": "~5.4",

--- a/item-counter-spe/package.json
+++ b/item-counter-spe/package.json
@@ -60,7 +60,7 @@
 		"start-server-and-test": "^2.0.0",
 		"style-loader": "^4.0.0",
 		"tailwindcss": "^3.4.9",
-		"ts-loader": "^8.0.0",
+		"ts-loader": "^9.5.1",
 		"typescript": "~5.4",
 		"webpack": "^5.93.0",
 		"webpack-cli": "^5.1.4",

--- a/item-counter-spe/package.json
+++ b/item-counter-spe/package.json
@@ -44,7 +44,7 @@
 		"@types/react-dom": "^18.3.0",
 		"@typescript-eslint/eslint-plugin": "^5.38.0",
 		"@typescript-eslint/parser": "^5.38.0",
-		"copy-webpack-plugin": "^11.0.0",
+		"copy-webpack-plugin": "^12.0.2",
 		"cross-env": "^7.0.3",
 		"css-loader": "^7.1.2",
 		"dotenv-webpack": "^7.1.1",

--- a/item-counter-spe/package.json
+++ b/item-counter-spe/package.json
@@ -12,8 +12,8 @@
 		"dev": "cross-env webpack-dev-server",
 		"format": "prettier src --write",
 		"lint": "eslint src",
-		"webpack": "cross-env FLUID_CLIENT='azure' webpack",
-		"start": "npm run dev"
+		"start": "npm run dev",
+		"webpack": "cross-env FLUID_CLIENT='azure' webpack"
 	},
 	"engines": {
 		"node": ">=20.0.0"

--- a/item-counter-spe/package.json
+++ b/item-counter-spe/package.json
@@ -53,7 +53,7 @@
 		"html-webpack-plugin": "^5.6.0",
 		"jest": "^29.2.2",
 		"jest-junit": "^16.0.0",
-		"jest-puppeteer": "^9.0.0",
+		"jest-puppeteer": "^10.0.1",
 		"mini-css-extract-plugin": "^2.9.0",
 		"prettier": "^2.7.1",
 		"puppeteer": "^22.11.2",

--- a/item-counter-spe/package.json
+++ b/item-counter-spe/package.json
@@ -62,7 +62,7 @@
 		"tailwindcss": "^3.4.9",
 		"ts-loader": "^8.0.0",
 		"typescript": "~5.4",
-		"webpack": "^5.88.2",
+		"webpack": "^5.93.0",
 		"webpack-cli": "^5.1.4",
 		"webpack-dev-server": "^5.0.4"
 	},

--- a/item-counter-spe/package.json
+++ b/item-counter-spe/package.json
@@ -59,7 +59,7 @@
 		"puppeteer": "^22.11.2",
 		"start-server-and-test": "^2.0.0",
 		"style-loader": "^4.0.0",
-		"tailwindcss": "^3.3.2",
+		"tailwindcss": "^3.4.9",
 		"ts-loader": "^8.0.0",
 		"typescript": "~5.4",
 		"webpack": "^5.88.2",

--- a/item-counter/package-lock.json
+++ b/item-counter/package-lock.json
@@ -43,7 +43,7 @@
 				"jest": "^29.2.2",
 				"jest-junit": "^16.0.0",
 				"jest-puppeteer": "^9.0.0",
-				"mini-css-extract-plugin": "^1",
+				"mini-css-extract-plugin": "^2.9.0",
 				"prettier": "^2.7.1",
 				"puppeteer": "^22.11.2",
 				"start-server-and-test": "^2.0.0",
@@ -10401,42 +10401,32 @@
 			}
 		},
 		"node_modules/mini-css-extract-plugin": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.2.tgz",
-			"integrity": "sha512-WhDvO3SjGm40oV5y26GjMJYjd2UMqrLAGKy5YS2/3QKJy2F7jgynuHTir/tgUUOiNQu5saXHdc8reo7YuhhT4Q==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.0.tgz",
+			"integrity": "sha512-Zs1YsZVfemekSZG+44vBsYTLQORkPMwnlv+aehcxK/NLKC+EGhDB39/YePYYqx/sTk6NnYpuqikhSn7+JIevTA==",
 			"dev": true,
 			"dependencies": {
-				"loader-utils": "^2.0.0",
-				"schema-utils": "^3.0.0",
-				"webpack-sources": "^1.1.0"
+				"schema-utils": "^4.0.0",
+				"tapable": "^2.2.1"
 			},
 			"engines": {
-				"node": ">= 10.13.0"
+				"node": ">= 12.13.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.4.0 || ^5.0.0"
+				"webpack": "^5.0.0"
 			}
 		},
-		"node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+		"node_modules/mini-css-extract-plugin/node_modules/tapable": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
 			"dev": true,
-			"dependencies": {
-				"@types/json-schema": "^7.0.8",
-				"ajv": "^6.12.5",
-				"ajv-keywords": "^3.5.2"
-			},
 			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
+				"node": ">=6"
 			}
 		},
 		"node_modules/minimalistic-assert": {
@@ -12664,12 +12654,6 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/source-list-map": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-			"integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
-			"dev": true
-		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -14282,16 +14266,6 @@
 			},
 			"engines": {
 				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/webpack-sources": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-			"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
-			"dev": true,
-			"dependencies": {
-				"source-list-map": "^2.0.0",
-				"source-map": "~0.6.1"
 			}
 		},
 		"node_modules/webpack/node_modules/enhanced-resolve": {

--- a/item-counter/package-lock.json
+++ b/item-counter/package-lock.json
@@ -51,7 +51,7 @@
 				"tailwindcss": "^3.4.9",
 				"ts-loader": "^8.0.0",
 				"typescript": "~5.4",
-				"webpack": "^5.88.2",
+				"webpack": "^5.93.0",
 				"webpack-cli": "^5.1.4",
 				"webpack-dev-server": "^5.0.4"
 			},
@@ -3323,10 +3323,10 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/acorn-import-assertions": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-			"integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+		"node_modules/acorn-import-attributes": {
+			"version": "1.9.5",
+			"resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+			"integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
 			"dev": true,
 			"peerDependencies": {
 				"acorn": "^8"
@@ -13985,9 +13985,9 @@
 			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
 		},
 		"node_modules/webpack": {
-			"version": "5.91.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.91.0.tgz",
-			"integrity": "sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==",
+			"version": "5.93.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
+			"integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
 			"dev": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.3",
@@ -13996,10 +13996,10 @@
 				"@webassemblyjs/wasm-edit": "^1.12.1",
 				"@webassemblyjs/wasm-parser": "^1.12.1",
 				"acorn": "^8.7.1",
-				"acorn-import-assertions": "^1.9.0",
+				"acorn-import-attributes": "^1.9.5",
 				"browserslist": "^4.21.10",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.16.0",
+				"enhanced-resolve": "^5.17.0",
 				"es-module-lexer": "^1.2.1",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",

--- a/item-counter/package-lock.json
+++ b/item-counter/package-lock.json
@@ -42,7 +42,7 @@
 				"html-webpack-plugin": "^5.6.0",
 				"jest": "^29.2.2",
 				"jest-junit": "^16.0.0",
-				"jest-puppeteer": "^9.0.0",
+				"jest-puppeteer": "^10.0.1",
 				"mini-css-extract-plugin": "^2.9.0",
 				"prettier": "^2.7.1",
 				"puppeteer": "^22.11.2",
@@ -6127,9 +6127,9 @@
 			}
 		},
 		"node_modules/expect-puppeteer": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-9.0.2.tgz",
-			"integrity": "sha512-nv3RD8MOStXOf4bLpr1wiqxPMLL7MwXvtMeZBtGvg5bubAHiHcYBcvDTJwkUjdOWz3scjOnOOl5z6KZakMobCw==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-10.0.0.tgz",
+			"integrity": "sha512-E7sE6nVdEbrnpDOBMmcLgyqLJKt876AlBg1A+gsu5R8cWx+SLafreOgJAgzXg5Qko7Tk0cW5oZdRbHQLU738dg==",
 			"dev": true,
 			"engines": {
 				"node": ">=16"
@@ -8477,16 +8477,16 @@
 			}
 		},
 		"node_modules/jest-dev-server": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-9.0.2.tgz",
-			"integrity": "sha512-Zc/JB0IlNNrpXkhBw+h86cGrde/Mey52KvF+FER2eyrtYJTHObOwW7Iarxm3rPyTKby5+3Y2QZtl8pRz/5GCxg==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-10.0.0.tgz",
+			"integrity": "sha512-FtyBBDxrAIfTX3hyKSOwj5KU6Z7fFLew5pQYOFpwyf+qpPpULL8aYxtsFkbkAwcs+Mb7qhcNbVLeiWsLOd7CKw==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.2",
 				"cwd": "^0.10.0",
 				"find-process": "^1.4.7",
 				"prompts": "^2.4.2",
-				"spawnd": "^9.0.2",
+				"spawnd": "^10.0.0",
 				"tree-kill": "^1.2.2",
 				"wait-on": "^7.2.0"
 			},
@@ -8765,15 +8765,15 @@
 			}
 		},
 		"node_modules/jest-environment-puppeteer": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-9.0.2.tgz",
-			"integrity": "sha512-t7+W4LUiPoOz+xpKREgnu6IElMuRthOWTkrThDZqVKPmLhwbK3yx7OCiX8xT1Pw/Cv5WnSoNhwtN7czdCC3fQg==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-10.0.1.tgz",
+			"integrity": "sha512-FxMzVRyqieQqSy5CPWiwdK5t9dkRHid5eoRTVa8RtYeXLlpW6lU0dAmxEfPkdnDVCiPUhC2APeKOXq0J72bgag==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.2",
 				"cosmiconfig": "^8.3.6",
 				"deepmerge": "^4.3.1",
-				"jest-dev-server": "^9.0.2",
+				"jest-dev-server": "^10.0.0",
 				"jest-environment-node": "^29.7.0"
 			},
 			"engines": {
@@ -9128,13 +9128,13 @@
 			}
 		},
 		"node_modules/jest-puppeteer": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-9.0.2.tgz",
-			"integrity": "sha512-ZB0K/tH+0e7foRRn+VpKIufvkW1by8l7ifh62VOdOh5ijEf7yt8W2/PcBNNwP0RLm46AytiBkrIEenvWhxcBRQ==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-10.0.1.tgz",
+			"integrity": "sha512-FzC35XbqeuQEt1smXh1EOqhJaRkWqJkyWDMfGkcZ8C59QHXeJ7F/iOmiNqYi6l/OsycUuOPCk+IkjfGfS9YbrQ==",
 			"dev": true,
 			"dependencies": {
-				"expect-puppeteer": "^9.0.2",
-				"jest-environment-puppeteer": "^9.0.2"
+				"expect-puppeteer": "^10.0.0",
+				"jest-environment-puppeteer": "^10.0.1"
 			},
 			"engines": {
 				"node": ">=16"
@@ -12601,9 +12601,9 @@
 			}
 		},
 		"node_modules/spawnd": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-9.0.2.tgz",
-			"integrity": "sha512-nl8DVHEDQ57IcKakzpjanspVChkMpGLuVwMR/eOn9cXE55Qr6luD2Kn06sA0ootRMdgrU4tInN6lA6ohTNvysw==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-10.0.0.tgz",
+			"integrity": "sha512-6GKcakMTryb5b1SWCvdubCDHEsR2k+5VZUD5G19umZRarkvj1RyCGyizcqhjewI7cqZo8fTVD8HpnDZbVOLMtg==",
 			"dev": true,
 			"dependencies": {
 				"signal-exit": "^4.1.0",

--- a/item-counter/package-lock.json
+++ b/item-counter/package-lock.json
@@ -33,7 +33,7 @@
 				"@types/uuid": "^9.0.8",
 				"@typescript-eslint/eslint-plugin": "^5.38.0",
 				"@typescript-eslint/parser": "^5.38.0",
-				"copy-webpack-plugin": "^11.0.0",
+				"copy-webpack-plugin": "^12.0.2",
 				"cross-env": "^7.0.3",
 				"css-loader": "^7.1.2",
 				"dotenv-webpack": "^7.1.1",
@@ -2448,6 +2448,18 @@
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.35.tgz",
 			"integrity": "sha512-Ul3YyOTU++to8cgNkttakC0dWvpERr6RYoHO2W47DLbFvrwBDJUY31B1sImH6JZSYc4Kt4PyHtoPNu+vL2r2dA=="
 		},
+		"node_modules/@sindresorhus/merge-streams": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+			"integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@sinonjs/commons": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -4553,20 +4565,20 @@
 			"dev": true
 		},
 		"node_modules/copy-webpack-plugin": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
-			"integrity": "sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==",
+			"version": "12.0.2",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-12.0.2.tgz",
+			"integrity": "sha512-SNwdBeHyII+rWvee/bTnAYyO8vfVdcSTud4EIb6jcZ8inLeWucJE0DnxXQBjlQ5zlteuuvooGQy3LIyGxhvlOA==",
 			"dev": true,
 			"dependencies": {
-				"fast-glob": "^3.2.11",
+				"fast-glob": "^3.3.2",
 				"glob-parent": "^6.0.1",
-				"globby": "^13.1.1",
+				"globby": "^14.0.0",
 				"normalize-path": "^3.0.0",
-				"schema-utils": "^4.0.0",
-				"serialize-javascript": "^6.0.0"
+				"schema-utils": "^4.2.0",
+				"serialize-javascript": "^6.0.2"
 			},
 			"engines": {
-				"node": ">= 14.15.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4577,31 +4589,44 @@
 			}
 		},
 		"node_modules/copy-webpack-plugin/node_modules/globby": {
-			"version": "13.2.2",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-			"integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+			"integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
 			"dev": true,
 			"dependencies": {
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.3.0",
+				"@sindresorhus/merge-streams": "^2.1.0",
+				"fast-glob": "^3.3.2",
 				"ignore": "^5.2.4",
-				"merge2": "^1.4.1",
-				"slash": "^4.0.0"
+				"path-type": "^5.0.0",
+				"slash": "^5.1.0",
+				"unicorn-magic": "^0.1.0"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/copy-webpack-plugin/node_modules/path-type": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+			"integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/copy-webpack-plugin/node_modules/slash": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
 			"dev": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">=14.16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -13736,6 +13761,18 @@
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
 			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
 			"dev": true
+		},
+		"node_modules/unicorn-magic": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+			"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/universalify": {
 			"version": "2.0.1",

--- a/item-counter/package-lock.json
+++ b/item-counter/package-lock.json
@@ -49,7 +49,7 @@
 				"start-server-and-test": "^2.0.0",
 				"style-loader": "^4.0.0",
 				"tailwindcss": "^3.4.9",
-				"ts-loader": "^8.0.0",
+				"ts-loader": "^9.5.1",
 				"typescript": "~5.4",
 				"webpack": "^5.93.0",
 				"webpack-cli": "^5.1.4",
@@ -3952,15 +3952,6 @@
 			"integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
 			"dev": true
 		},
-		"node_modules/big.js": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/binary-extensions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -5374,15 +5365,6 @@
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true
 		},
-		"node_modules/emojis-list": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-			"dev": true,
-			"engines": {
-				"node": ">= 4"
-			}
-		},
 		"node_modules/encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -5422,17 +5404,16 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
-			"integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+			"version": "5.17.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+			"integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
 			"dev": true,
 			"dependencies": {
-				"graceful-fs": "^4.1.2",
-				"memory-fs": "^0.5.0",
-				"tapable": "^1.0.0"
+				"graceful-fs": "^4.2.4",
+				"tapable": "^2.2.0"
 			},
 			"engines": {
-				"node": ">=6.9.0"
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/entities": {
@@ -5463,18 +5444,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/errno": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
-			"integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-			"dev": true,
-			"dependencies": {
-				"prr": "~1.0.1"
-			},
-			"bin": {
-				"errno": "cli.js"
 			}
 		},
 		"node_modules/error-ex": {
@@ -7220,15 +7189,6 @@
 				"webpack": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/html-webpack-plugin/node_modules/tapable": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/htmlparser2": {
@@ -10160,20 +10120,6 @@
 				"node": ">=6.11.5"
 			}
 		},
-		"node_modules/loader-utils": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-			"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-			"dev": true,
-			"dependencies": {
-				"big.js": "^5.2.2",
-				"emojis-list": "^3.0.0",
-				"json5": "^2.1.2"
-			},
-			"engines": {
-				"node": ">=8.9.0"
-			}
-		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -10304,19 +10250,6 @@
 				"url": "https://github.com/sponsors/streamich"
 			}
 		},
-		"node_modules/memory-fs": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
-			"integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-			"dev": true,
-			"dependencies": {
-				"errno": "^0.1.3",
-				"readable-stream": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=4.3.0 <5.0.0 || >=5.10"
-			}
-		},
 		"node_modules/merge-descriptors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -10418,15 +10351,6 @@
 			},
 			"peerDependencies": {
 				"webpack": "^5.0.0"
-			}
-		},
-		"node_modules/mini-css-extract-plugin/node_modules/tapable": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/minimalistic-assert": {
@@ -11586,12 +11510,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-		},
-		"node_modules/prr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-			"dev": true
 		},
 		"node_modules/ps-tree": {
 			"version": "1.2.0",
@@ -13192,9 +13110,9 @@
 			}
 		},
 		"node_modules/tapable": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-			"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -13496,23 +13414,23 @@
 			"dev": true
 		},
 		"node_modules/ts-loader": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.4.0.tgz",
-			"integrity": "sha512-6nFY3IZ2//mrPc+ImY3hNWx1vCHyEhl6V+wLmL4CZcm6g1CqX7UKrkc6y0i4FwcfOhxyMPCfaEvh20f4r9GNpw==",
+			"version": "9.5.1",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.1.tgz",
+			"integrity": "sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.0",
-				"enhanced-resolve": "^4.0.0",
-				"loader-utils": "^2.0.0",
+				"enhanced-resolve": "^5.0.0",
 				"micromatch": "^4.0.0",
-				"semver": "^7.3.4"
+				"semver": "^7.3.4",
+				"source-map": "^0.7.4"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=12.0.0"
 			},
 			"peerDependencies": {
 				"typescript": "*",
-				"webpack": "*"
+				"webpack": "^5.0.0"
 			}
 		},
 		"node_modules/ts-loader/node_modules/ansi-styles": {
@@ -13583,6 +13501,15 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/ts-loader/node_modules/source-map": {
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+			"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/ts-loader/node_modules/supports-color": {
@@ -14246,19 +14173,6 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/webpack/node_modules/enhanced-resolve": {
-			"version": "5.17.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
-			"integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
-			"dev": true,
-			"dependencies": {
-				"graceful-fs": "^4.2.4",
-				"tapable": "^2.2.0"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
 		"node_modules/webpack/node_modules/schema-utils": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
@@ -14275,15 +14189,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
-			}
-		},
-		"node_modules/webpack/node_modules/tapable": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/webpack/node_modules/webpack-sources": {

--- a/item-counter/package-lock.json
+++ b/item-counter/package-lock.json
@@ -47,7 +47,7 @@
 				"prettier": "^2.7.1",
 				"puppeteer": "^22.11.2",
 				"start-server-and-test": "^2.0.0",
-				"style-loader": "^2",
+				"style-loader": "^4.0.0",
 				"tailwindcss": "^3.3.2",
 				"ts-loader": "^8.0.0",
 				"typescript": "~5.4",
@@ -13044,41 +13044,19 @@
 			}
 		},
 		"node_modules/style-loader": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-2.0.0.tgz",
-			"integrity": "sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-4.0.0.tgz",
+			"integrity": "sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==",
 			"dev": true,
-			"dependencies": {
-				"loader-utils": "^2.0.0",
-				"schema-utils": "^3.0.0"
-			},
 			"engines": {
-				"node": ">= 10.13.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.0.0 || ^5.0.0"
-			}
-		},
-		"node_modules/style-loader/node_modules/schema-utils": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-			"dev": true,
-			"dependencies": {
-				"@types/json-schema": "^7.0.8",
-				"ajv": "^6.12.5",
-				"ajv-keywords": "^3.5.2"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
+				"webpack": "^5.27.0"
 			}
 		},
 		"node_modules/stylis": {

--- a/item-counter/package-lock.json
+++ b/item-counter/package-lock.json
@@ -48,7 +48,7 @@
 				"puppeteer": "^22.11.2",
 				"start-server-and-test": "^2.0.0",
 				"style-loader": "^4.0.0",
-				"tailwindcss": "^3.3.2",
+				"tailwindcss": "^3.4.9",
 				"ts-loader": "^8.0.0",
 				"typescript": "~5.4",
 				"webpack": "^5.88.2",
@@ -13155,9 +13155,9 @@
 			}
 		},
 		"node_modules/tailwindcss": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.3.tgz",
-			"integrity": "sha512-U7sxQk/n397Bmx4JHbJx/iSOOv5G+II3f1kpLpY2QeUv5DcPdcTsYLlusZfq1NthHS1c1cZoyFmmkex1rzke0A==",
+			"version": "3.4.9",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.9.tgz",
+			"integrity": "sha512-1SEOvRr6sSdV5IDf9iC+NU4dhwdqzF4zKKq3sAbasUWHEM6lsMhX+eNN5gkPx1BvLFEnZQEUFbXnGj8Qlp83Pg==",
 			"dev": true,
 			"dependencies": {
 				"@alloc/quick-lru": "^5.2.0",

--- a/item-counter/package.json
+++ b/item-counter/package.json
@@ -62,7 +62,7 @@
 		"puppeteer": "^22.11.2",
 		"start-server-and-test": "^2.0.0",
 		"style-loader": "^4.0.0",
-		"tailwindcss": "^3.3.2",
+		"tailwindcss": "^3.4.9",
 		"ts-loader": "^8.0.0",
 		"typescript": "~5.4",
 		"webpack": "^5.88.2",

--- a/item-counter/package.json
+++ b/item-counter/package.json
@@ -49,7 +49,7 @@
 		"@types/uuid": "^9.0.8",
 		"@typescript-eslint/eslint-plugin": "^5.38.0",
 		"@typescript-eslint/parser": "^5.38.0",
-		"copy-webpack-plugin": "^11.0.0",
+		"copy-webpack-plugin": "^12.0.2",
 		"cross-env": "^7.0.3",
 		"css-loader": "^7.1.2",
 		"dotenv-webpack": "^7.1.1",

--- a/item-counter/package.json
+++ b/item-counter/package.json
@@ -65,7 +65,7 @@
 		"tailwindcss": "^3.4.9",
 		"ts-loader": "^8.0.0",
 		"typescript": "~5.4",
-		"webpack": "^5.88.2",
+		"webpack": "^5.93.0",
 		"webpack-cli": "^5.1.4",
 		"webpack-dev-server": "^5.0.4"
 	},

--- a/item-counter/package.json
+++ b/item-counter/package.json
@@ -15,9 +15,11 @@
 		"dev:azure": "cross-env FLUID_CLIENT='azure' webpack-dev-server",
 		"format": "prettier src --write",
 		"lint": "eslint src",
-		"webpack": "cross-env FLUID_CLIENT='azure' webpack",
 		"start": "npm run dev",
-		"start:server": "npx @fluidframework/azure-local-service@^2.0.1"
+		"start:server": "npx @fluidframework/azure-local-service@^2.0.1",
+		"test": "start-server-and-test start:server 7070 test:jest",
+		"test:jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --ci --reporters=default --reporters=jest-junit",
+		"webpack": "cross-env FLUID_CLIENT='azure' webpack"
 	},
 	"engines": {
 		"node": ">=20.0.0"

--- a/item-counter/package.json
+++ b/item-counter/package.json
@@ -57,7 +57,7 @@
 		"jest": "^29.2.2",
 		"jest-junit": "^16.0.0",
 		"jest-puppeteer": "^9.0.0",
-		"mini-css-extract-plugin": "^1",
+		"mini-css-extract-plugin": "^2.9.0",
 		"prettier": "^2.7.1",
 		"puppeteer": "^22.11.2",
 		"start-server-and-test": "^2.0.0",

--- a/item-counter/package.json
+++ b/item-counter/package.json
@@ -61,7 +61,7 @@
 		"prettier": "^2.7.1",
 		"puppeteer": "^22.11.2",
 		"start-server-and-test": "^2.0.0",
-		"style-loader": "^2",
+		"style-loader": "^4.0.0",
 		"tailwindcss": "^3.3.2",
 		"ts-loader": "^8.0.0",
 		"typescript": "~5.4",

--- a/item-counter/package.json
+++ b/item-counter/package.json
@@ -63,7 +63,7 @@
 		"start-server-and-test": "^2.0.0",
 		"style-loader": "^4.0.0",
 		"tailwindcss": "^3.4.9",
-		"ts-loader": "^8.0.0",
+		"ts-loader": "^9.5.1",
 		"typescript": "~5.4",
 		"webpack": "^5.93.0",
 		"webpack-cli": "^5.1.4",

--- a/item-counter/package.json
+++ b/item-counter/package.json
@@ -58,7 +58,7 @@
 		"html-webpack-plugin": "^5.6.0",
 		"jest": "^29.2.2",
 		"jest-junit": "^16.0.0",
-		"jest-puppeteer": "^9.0.0",
+		"jest-puppeteer": "^10.0.1",
 		"mini-css-extract-plugin": "^2.9.0",
 		"prettier": "^2.7.1",
 		"puppeteer": "^22.11.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,19 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "syncpack": "^11.2.1"
+        "syncpack": "^12.4.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.24.2",
+        "@babel/highlight": "^7.24.7",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -29,39 +29,27 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
-      "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/highlight/node_modules/chalk": {
@@ -78,78 +66,16 @@
         "node": ">=4"
       }
     },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@effect/data": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@effect/data/-/data-0.17.1.tgz",
-      "integrity": "sha512-QCYkLE5Y5Dm5Yax5R3GmW4ZIgTx7W+kSZ7yq5eqQ/mFWa8i4yxbLuu8cudqzdeZtRtTGZKlhDxfFfgVtMywXJg==",
-      "dev": true
-    },
-    "node_modules/@effect/io": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@effect/io/-/io-0.38.0.tgz",
-      "integrity": "sha512-qlVC9ASxNC+L2NKX5qOV9672CE5wWizfwBSFaX2XLI7CC118WRvohCTIPQ52n50Bj5TmR20+na+U9C7e4VkqzA==",
-      "dev": true,
-      "peerDependencies": {
-        "@effect/data": "^0.17.1"
-      }
-    },
-    "node_modules/@effect/match": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@effect/match/-/match-0.32.0.tgz",
-      "integrity": "sha512-04QfnIgCcMnnNbGxTv2xa9/7q1c5kgpsBodqTUZ8eX86A/EdE8Czz+JkVarG00/xE+nYhQLXOXCN9Zj+dtqVkQ==",
-      "dev": true,
-      "peerDependencies": {
-        "@effect/data": "^0.17.1",
-        "@effect/schema": "^0.33.0"
-      }
-    },
     "node_modules/@effect/schema": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@effect/schema/-/schema-0.33.1.tgz",
-      "integrity": "sha512-h+fQInui4q3we8fegAygL0Cs5B2DD/+oC3JWthOh8eLcbKkbYM9smCD/PsHuyQ+BaeWiSP5JdvREGlP4Sg+Ysw==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@effect/schema/-/schema-0.69.0.tgz",
+      "integrity": "sha512-dqVnriWqM8TT8d+5vgg1pH4ZOXfs7tQBVAY5N7PALzIOlZamsBKQCdwvMMqremjSkKITckF8/cIj1eQZHQeg7Q==",
       "dev": true,
       "dependencies": {
-        "fast-check": "^3.12.0"
+        "fast-check": "^3.20.0"
       },
       "peerDependencies": {
-        "@effect/data": "^0.17.1",
-        "@effect/io": "^0.38.0"
+        "effect": "^3.5.7"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -187,6 +113,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -206,18 +144,15 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "color-convert": "^1.9.0"
       },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": ">=4"
       }
     },
     "node_modules/argparse": {
@@ -226,51 +161,11 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -293,39 +188,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/builtins": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
-      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^7.0.0"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -336,31 +198,45 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+    "node_modules/chalk-template": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-1.1.0.tgz",
+      "integrity": "sha512-T2VJbcDuZQ0Tb2EWwSotMPJjgpy1/tGee1BTpUNsGZ/qgNjV2t7Mvu+d4600U564nbLesN1x2dPL+xii174Ekg==",
       "dev": true,
       "dependencies": {
-        "restore-cursor": "^3.1.0"
+        "chalk": "^5.2.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-spinners": {
@@ -375,83 +251,67 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
+        "color-name": "1.1.3"
       }
     },
     "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "node_modules/commander": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "dev": true,
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
-      "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "dependencies": {
-        "import-fresh": "^3.2.1",
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0"
+        "parse-json": "^5.2.0"
       },
       "engines": {
         "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "dev": true,
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+    "node_modules/effect": {
+      "version": "3.5.7",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.5.7.tgz",
+      "integrity": "sha512-PzEncc0R3ZZhqNTR+fXrSX+anF/4Ai6ftKie1ZrUUWY7WPE7d4KjB6wjpeWoGMOC7xWFPGSkBBUudyJN1mx3+g==",
+      "dev": true
     },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+    "node_modules/emoji-regex": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
+      "dev": true
     },
     "node_modules/enquirer": {
       "version": "2.4.1",
@@ -464,6 +324,15 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/error-ex": {
@@ -485,9 +354,9 @@
       }
     },
     "node_modules/fast-check": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.17.1.tgz",
-      "integrity": "sha512-jIKXJVe6ZO0SpwEgVtEVujTf8TwjI9wMXFJCjsDHUB3RroUbXBgF4kOSz3A7MW0UR26aqsoB8i9O2mjtjERAiA==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.20.0.tgz",
+      "integrity": "sha512-pZIjqLpOZgdSLecec4GKC3Zq5702MZ34upMKxojnNVSWA0K64V3pXOBT1Wdsrc3AphLtzRBbsi8bRWF4TUGmUg==",
       "dev": true,
       "funding": [
         {
@@ -543,6 +412,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
+      "integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -556,70 +437,50 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+      "integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
       "dev": true,
       "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.2",
+        "ignore": "^5.2.4",
+        "path-type": "^5.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
-      "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
       "dev": true,
       "dependencies": {
-        "lru-cache": "^7.5.1"
+        "lru-cache": "^10.0.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/ignore": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -640,12 +501,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -675,12 +530,15 @@
       }
     },
     "node_modules/is-interactive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -693,12 +551,12 @@
       }
     },
     "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
+      "integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -744,29 +602,38 @@
       "dev": true
     },
     "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
       "dev": true,
       "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -778,12 +645,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -800,33 +667,33 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm-package-arg": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-10.1.0.tgz",
-      "integrity": "sha512-uFyyCEmgBfZTtrKk/5xDfHp6+MdrqGotX/VoOyEEl3mBwiEE5FlBaePanazJSVMPT7vKepcjYBY2ztg9A3yPIA==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
+      "integrity": "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==",
       "dev": true,
       "dependencies": {
-        "hosted-git-info": "^6.0.0",
-        "proc-log": "^3.0.0",
+        "hosted-git-info": "^7.0.0",
+        "proc-log": "^4.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-name": "^5.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/onetime": {
@@ -845,26 +712,53 @@
       }
     },
     "node_modules/ora": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.0.1.tgz",
+      "integrity": "sha512-ANIvzobt1rls2BDny5fWZ3ZVKyD6nscLvfFRpQgfWsythlcsVUC9kL0zq6j2Z5z9wwp1kd7wpsD/T9qNPVLCaQ==",
       "dev": true,
       "dependencies": {
-        "bl": "^4.1.0",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.5.0",
-        "is-interactive": "^1.0.0",
-        "is-unicode-supported": "^0.1.0",
-        "log-symbols": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "wcwidth": "^1.0.1"
+        "chalk": "^5.3.0",
+        "cli-cursor": "^4.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/parent-module": {
@@ -898,18 +792,21 @@
       }
     },
     "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
       "dev": true
     },
     "node_modules/picomatch": {
@@ -925,9 +822,9 @@
       }
     },
     "node_modules/proc-log": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
-      "integrity": "sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
       "dev": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -995,20 +892,6 @@
         "node": ">=10.13"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -1019,16 +902,19 @@
       }
     },
     "node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
       "dev": true,
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/reusify": {
@@ -1064,48 +950,13 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -1124,21 +975,71 @@
       "dev": true
     },
     "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-ansi": {
@@ -1163,39 +1064,39 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "dependencies": {
-        "has-flag": "^4.0.0"
+        "has-flag": "^3.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/syncpack": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/syncpack/-/syncpack-11.2.1.tgz",
-      "integrity": "sha512-WoUtm+ZLmWUvy0cLJy8ds/smVRH3ivI6iANcGTPrsvareCc4SmRVMvr+TwjZyFm0FDGmEfMVsAX7z16+yxL6bQ==",
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/syncpack/-/syncpack-12.4.0.tgz",
+      "integrity": "sha512-iVDbuxW1zpjC8IuGLLgTjfgnAjr1iTd+In//RGUi49nKT8f6BWYSEAt496fj4eGNmYeajUiGngBHl15Jb++RBg==",
       "dev": true,
       "dependencies": {
-        "@effect/data": "0.17.1",
-        "@effect/io": "0.38.0",
-        "@effect/match": "0.32.0",
-        "@effect/schema": "0.33.1",
-        "chalk": "4.1.2",
-        "commander": "11.0.0",
-        "cosmiconfig": "8.2.0",
+        "@effect/schema": "0.69.0",
+        "chalk": "5.3.0",
+        "chalk-template": "1.1.0",
+        "commander": "12.1.0",
+        "cosmiconfig": "9.0.0",
+        "effect": "3.5.7",
         "enquirer": "2.4.1",
-        "globby": "11.1.0",
-        "minimatch": "9.0.3",
-        "npm-package-arg": "10.1.0",
-        "ora": "5.4.1",
+        "fast-check": "3.20.0",
+        "globby": "14.0.2",
+        "minimatch": "10.0.1",
+        "npm-package-arg": "11.0.3",
+        "ora": "8.0.1",
         "prompts": "2.4.2",
         "read-yaml-file": "2.1.0",
-        "semver": "7.5.4",
-        "tightrope": "0.1.0",
+        "semver": "7.6.3",
+        "tightrope": "0.2.0",
         "ts-toolbelt": "9.6.0"
       },
       "bin": {
@@ -1215,12 +1116,12 @@
       }
     },
     "node_modules/tightrope": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tightrope/-/tightrope-0.1.0.tgz",
-      "integrity": "sha512-HHHNYdCAIYwl1jOslQBT455zQpdeSo8/A346xpIb/uuqhSg+tCvYNsP5f11QW+z9VZ3vSX8YIfzTApjjuGH63w==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/tightrope/-/tightrope-0.2.0.tgz",
+      "integrity": "sha512-Kw36UHxJEELq2VUqdaSGR2/8cAsPgMtvX8uGVU6Jk26O66PhXec0A5ZnRYs47btbtwPDpXXF66+Fo3vimCM9aQ==",
       "dev": true,
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/to-regex-range": {
@@ -1241,38 +1142,26 @@
       "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
       "dev": true
     },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/validate-npm-package-name": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
-      "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
+      "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
       "dev": true,
-      "dependencies": {
-        "builtins": "^5.0.0"
-      },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
-    },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "dev": true,
-      "dependencies": {
-        "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=18.0.0"
   },
   "devDependencies": {
-    "syncpack": "^11.2.1"
+    "syncpack": "^12.4.0"
   },
   "scripts": {
     "fix-mismatches": "syncpack fix-mismatches --source */package.json",


### PR DESCRIPTION
Discovered via `npm outdated`. See package.json changes for the complete list of updates.

Also removes an unused dependency on `@headlessui/react`.