### PR TITLE
Update dependabot to allow updating all dependencies and group FF dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,30 +2,16 @@ version: 2
 updates:
   # Enable version updates for npm
   - package-ecosystem: "npm"
-    # Look for `package.json` and `lock` files in the `root` directory
-    directory: "/brainstorm"
+    # Look for `package.json` and `package-lock.json` files in these directories
+    directories:
+      - "/"
+      - "/brainstorm"
+      - "/item-counter"
+      - "/item-counter-spe"
     schedule:
       interval: "daily"
-    allow:
-      - dependency-name: "fluid-framework"
-      - dependency-name: "@fluidframework/*"
-
-  # Enable version updates for npm
-  - package-ecosystem: "npm"
-    # Look for `package.json` and `lock` files in the `root` directory
-    directory: "/item-counter"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "fluid-framework"
-      - dependency-name: "@fluidframework/*"
-
-  # Enable version updates for npm
-  - package-ecosystem: "npm"
-    # Look for `package.json` and `lock` files in the `root` directory
-    directory: "/item-counter-spe"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "fluid-framework"
-      - dependency-name: "@fluidframework/*"
+    groups:
+      fluid-framework-dependencies:
+        patterns:
+          - "@fluidframework"
+          - "fluid-framework"


### PR DESCRIPTION
Based on my read of https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

It seems atypical to repeat package-ecosystem for the same ecosystem (this is meant more for when multiple package-ecosystems are in play).  Merge these all together, and instead use `directories` to specify all directories with a package.json file.

Our allow rule only permits updating FF dependencies, but AFAICT there's no reason we wouldn't want updates to other dependencies too.  Drop allow field to allow all dependencies to be updated.

FF packages are best updated all in sync, rather than opening multiple PRs for each package individually (as recently happened with #1034 through #1043).  Use the groups field to encourage grouping these updates into a single PR.

Side note - I suspect that because item-counter-spe had been excluded, that was the reason it was the only one that dependabot was able to successfully update webpack for (since the other two examples were restricted to only updating FF dependencies).