### PR TITLE
Remove unused dotenv dependency

### DIFF
--- a/brainstorm/package-lock.json
+++ b/brainstorm/package-lock.json
@@ -19,7 +19,6 @@
 				"@fluidframework/test-runtime-utils": "^2.2.0",
 				"@microsoft/microsoft-graph-client": "^3.0.7",
 				"axios": "^1.7.7",
-				"dotenv": "^16.0.2",
 				"fluid-framework": "^2.2.0",
 				"hashids": "^2.2.10",
 				"jsrsasign": "^11.1.0",
@@ -5879,17 +5878,6 @@
 			"dependencies": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
-			}
-		},
-		"node_modules/dotenv": {
-			"version": "16.4.5",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-			"integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/dotenv-defaults": {

--- a/brainstorm/package.json
+++ b/brainstorm/package.json
@@ -35,7 +35,6 @@
 		"@fluidframework/test-runtime-utils": "^2.2.0",
 		"@microsoft/microsoft-graph-client": "^3.0.7",
 		"axios": "^1.7.7",
-		"dotenv": "^16.0.2",
 		"fluid-framework": "^2.2.0",
 		"hashids": "^2.2.10",
 		"jsrsasign": "^11.1.0",

--- a/item-counter-spe/package-lock.json
+++ b/item-counter-spe/package-lock.json
@@ -18,7 +18,6 @@
 				"@fluidframework/test-runtime-utils": "^2.2.0",
 				"@microsoft/microsoft-graph-client": "^3.0.7",
 				"axios": "^1.7.7",
-				"dotenv": "^16.0.2",
 				"fluid-framework": "^2.2.0",
 				"guid-typescript": "^1.0.9",
 				"hashids": "^2.2.10",
@@ -3625,17 +3624,6 @@
 			"dependencies": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
-			}
-		},
-		"node_modules/dotenv": {
-			"version": "16.4.5",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-			"integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/dotenv-defaults": {

--- a/item-counter-spe/package.json
+++ b/item-counter-spe/package.json
@@ -29,7 +29,6 @@
 		"@fluidframework/test-runtime-utils": "^2.2.0",
 		"@microsoft/microsoft-graph-client": "^3.0.7",
 		"axios": "^1.7.7",
-		"dotenv": "^16.0.2",
 		"fluid-framework": "^2.2.0",
 		"guid-typescript": "^1.0.9",
 		"hashids": "^2.2.10",

--- a/item-counter/package-lock.json
+++ b/item-counter/package-lock.json
@@ -14,7 +14,6 @@
 				"@fluidframework/telemetry-utils": "^2.2.0",
 				"@fluidframework/test-runtime-utils": "^2.2.0",
 				"axios": "^1.7.7",
-				"dotenv": "^16.0.2",
 				"fluid-framework": "^2.2.0",
 				"guid-typescript": "^1.0.9",
 				"hashids": "^2.2.10",
@@ -3209,17 +3208,6 @@
 			"dependencies": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
-			}
-		},
-		"node_modules/dotenv": {
-			"version": "16.4.5",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-			"integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/dotenv-defaults": {

--- a/item-counter/package.json
+++ b/item-counter/package.json
@@ -29,7 +29,6 @@
 		"@fluidframework/telemetry-utils": "^2.2.0",
 		"@fluidframework/test-runtime-utils": "^2.2.0",
 		"axios": "^1.7.7",
-		"dotenv": "^16.0.2",
 		"fluid-framework": "^2.2.0",
 		"guid-typescript": "^1.0.9",
 		"hashids": "^2.2.10",


### PR DESCRIPTION
Looking at the dependabot bumps for `dotenv-webpack`, I realized we also had an unused dependency on `dotenv` (presumably from a prior implementation that used it instead).  Removing the unused dependency.