### PR TITLE
Make sample SPE app work for single-tenant Entra Apps

### DIFF
--- a/item-counter-spe/README.md
+++ b/item-counter-spe/README.md
@@ -8,16 +8,24 @@ This app is designed to use SharePoint Embedded (SPE). The core application code
 this sample uses odsp-client to connect to Fluid Framework as opposed to azure-client. The differences are primarilly isolated to the
 infra folder, although the initialization flow for this app is different in that it includes auth while the AFR samples are anonymous.
 
-To use SPE you need to create an M365 developer account and configure SharePoint Embedded. The easiest way to get started is to install the SharePoint Embedded Visual Studio Code extension. From there you can create a new M365 developer tenant, create a new client app (with the require Microsoft Entra client ID) create new File Storage Container Types, and create new File Storage Containers.
+To use SPE you need to create an M365 developer account and configure SharePoint Embedded.
+The easiest way to get started is to install the SharePoint Embedded Visual Studio Code extension.
+From there you can create a new M365 developer tenant (which includes creating an Entra tenant), create a new client app
+(with the required Microsoft Entra client ID), create new File Storage Container Types, and create new File Storage Containers.
 
-This sample app requires that you have a Microsoft Entra client Id, have created a File Storage Container Type, and that the tenant you plan to use has a File Storage Container with that File Storage Container Type ID. Once you have done that, create a .env file in the item-counter-spe folder with the following content:
+This sample app requires that you have a Microsoft Entra tenant, a Microsoft Entra client Id for the app, have created
+a File Storage Container Type, and that the tenant you plan to use has a File Storage Container with that File Storage
+Container Type ID.
+Once you have done that, create a `.env` file in the item-counter-spe folder with the following content:
 
-```
+```plaintext
 SPE_CLIENT_ID='your client id'
 SPE_CONTAINER_TYPE_ID='your container type id'
+SPE_ENTRA_TENANT_ID='your entra tenant id
 ```
 
-With that in place, you can run this sample (`npm run dev`). Log in with the admin credentials for the tenant.
+With that in place, you can run this sample (`npm run dev`).
+Log in with the admin credentials for the tenant.
 
 ## Schema Definition
 

--- a/item-counter-spe/README.md
+++ b/item-counter-spe/README.md
@@ -21,7 +21,7 @@ Once you have done that, create a `.env` file in the item-counter-spe folder wit
 ```plaintext
 SPE_CLIENT_ID='your client id'
 SPE_CONTAINER_TYPE_ID='your container type id'
-SPE_ENTRA_TENANT_ID='your entra tenant id
+SPE_ENTRA_TENANT_ID='your entra tenant id'
 ```
 
 With that in place, you can run this sample (`npm run dev`).

--- a/item-counter-spe/src/index.tsx
+++ b/item-counter-spe/src/index.tsx
@@ -23,8 +23,7 @@ async function start() {
 	// If the tokenResponse is not null, then the user is signed in
 	// and the tokenResponse is the result of the redirect.
 	if (tokenResponse !== null) {
-		const account = msalInstance.getAllAccounts()[0];
-		signedInStart(msalInstance, account);
+		await signedInStart(msalInstance, tokenResponse.account);
 	} else {
 		const currentAccounts = msalInstance.getAllAccounts();
 		if (currentAccounts.length === 0) {
@@ -38,7 +37,7 @@ async function start() {
 			// this is just a sample. But a real app would need to handle the multiple accounts case.
 			// For now, just use the first account.
 			const account = msalInstance.getAllAccounts()[0];
-			signedInStart(msalInstance, account);
+			await signedInStart(msalInstance, account);
 		}
 	}
 }

--- a/item-counter-spe/src/infra/authHelper.ts
+++ b/item-counter-spe/src/infra/authHelper.ts
@@ -9,12 +9,17 @@ export async function authHelper(): Promise<PublicClientApplication> {
 		throw new Error("SPE_CLIENT_ID is not defined");
 	}
 
+	const tenantId = process.env.SPE_ENTRA_TENANT_ID;
+	if (!tenantId) {
+		throw new Error("SPE_ENTRA_TENANT_ID is not defined");
+	}
+
 	// Create the MSAL instance
 	const msalConfig = {
 		auth: {
 			clientId,
-			authority: "https://login.microsoftonline.com/common/",
-			tenantId: "common",
+			authority: `https://login.microsoftonline.com/${tenantId}/`,
+			tenantId
 		},
 	};
 


### PR DESCRIPTION
I believe this change still allows the app to live in the "common" Entra tenant owned by Microsoft, but now would require the user to pass its id explicitly.

I had to make this change to make the app work with an M365/Entra tenant from my developer account. 