### PR TITLE
Drop dependabot frequency to weekly and group eslint updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,14 @@ updates:
       - "/item-counter"
       - "/item-counter-spe"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
+      # We want to update all Fluid dependencies simultaneously to keep them in sync.
       fluid-framework-dependencies:
         patterns:
           - "@fluidframework*" 
           - "fluid-framework"
-      typescript-eslint:
+      # To reduce noise, let's bundle all the eslint-related dependencies into a single PR.
+      eslint:
         patterns:
-          - "@typescript-eslint"
+          - "*eslint*"


### PR DESCRIPTION
To reduce noise, this PR reduces dependabot updates to weekly and groups all eslint-related updates into a single PR.