### PR TITLE
Avoid needless npx, do an npm audit fix, improve readme

### DIFF
--- a/item-counter/README.md
+++ b/item-counter/README.md
@@ -19,6 +19,8 @@ Running this command from your terminal window will launch the Azure Fluid Relay
 npm run start
 ```
 
+This command starts the webpack development server, which will make the application available at [http://localhost:8080/](http://localhost:8080/).
+
 One important note is that you will need to use a token provider or, purely for testing and development, use the insecure token provider. There are instructions on how to set this up on the [Fluid Framework website](https://aka.ms/fluid).
 
 All the code required to set up the Fluid Framework and SharedTree data structure is in the infra folder. Most of this code will be the same for any app.

--- a/item-counter/package-lock.json
+++ b/item-counter/package-lock.json
@@ -25,6 +25,7 @@
 			"devDependencies": {
 				"@eslint/eslintrc": "^3.1.0",
 				"@eslint/js": "^9.12.0",
+				"@fluidframework/azure-local-service": "^2.3.1",
 				"@fluidframework/build-common": "^2.0.3",
 				"@fluidframework/devtools": "^2.3.1",
 				"@playwright/test": "^1.48.0",
@@ -88,6 +89,26 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@colors/colors": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.1.90"
+			}
+		},
+		"node_modules/@dabh/diagnostics": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+			"integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+			"dev": true,
+			"dependencies": {
+				"colorspace": "1.1.x",
+				"enabled": "2.0.x",
+				"kuler": "^2.0.0"
 			}
 		},
 		"node_modules/@discoveryjs/json-ext": {
@@ -283,6 +304,18 @@
 				"@fluidframework/routerlicious-driver": "~2.3.1",
 				"@fluidframework/runtime-utils": "~2.3.1",
 				"@fluidframework/telemetry-utils": "~2.3.1"
+			}
+		},
+		"node_modules/@fluidframework/azure-local-service": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-local-service/-/azure-local-service-2.3.1.tgz",
+			"integrity": "sha512-KA3oq1dEIw34yOiVjt6VMT+Ri8r99NGZCj4JlIDAcN550dUBz6oFCxnBY1AhsFf200tUEvhE4mZBzd7Y7Fn+CQ==",
+			"dev": true,
+			"dependencies": {
+				"tinylicious": "^5.0.0"
+			},
+			"bin": {
+				"azure-local-service": "lib/index.js"
 			}
 		},
 		"node_modules/@fluidframework/build-common": {
@@ -837,6 +870,191 @@
 				"uuid": "dist/bin/uuid"
 			}
 		},
+		"node_modules/@fluidframework/server-lambdas": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-5.0.0.tgz",
+			"integrity": "sha512-t0ouLtYi2y5DBYbp+WT4mIGXTSYK/1Yz+cb0prOtAUxYqsn+TAG/hr2DE8OyzHdL0RHZp/y2KX7X1jZhPxxGDg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^3.1.0",
+				"@fluidframework/gitresources": "~5.0.0",
+				"@fluidframework/protocol-base": "~5.0.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/server-lambdas-driver": "~5.0.0",
+				"@fluidframework/server-services-client": "~5.0.0",
+				"@fluidframework/server-services-core": "~5.0.0",
+				"@fluidframework/server-services-telemetry": "~5.0.0",
+				"@types/semver": "^7.5.0",
+				"assert": "^2.0.0",
+				"async": "^3.2.2",
+				"axios": "^1.6.2",
+				"buffer": "^6.0.3",
+				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
+				"json-stringify-safe": "^5.0.1",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"semver": "^7.5.3",
+				"sha.js": "^2.4.11",
+				"uuid": "^9.0.0"
+			}
+		},
+		"node_modules/@fluidframework/server-lambdas-driver": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-5.0.0.tgz",
+			"integrity": "sha512-tnMxsxKr2zajQ64Ew7zcTKclK2Rkp7cqK4ghiuYkzhdbt7ZxIMVmkSW3B5/DXDSxVoi4VR6q1BA6cMnGJMcwsw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^3.1.0",
+				"@fluidframework/server-services-client": "~5.0.0",
+				"@fluidframework/server-services-core": "~5.0.0",
+				"@fluidframework/server-services-telemetry": "~5.0.0",
+				"assert": "^2.0.0",
+				"async": "^3.2.2",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"serialize-error": "^8.1.0"
+			}
+		},
+		"node_modules/@fluidframework/server-lambdas/node_modules/semver": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@fluidframework/server-lambdas/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@fluidframework/server-local-server": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-5.0.0.tgz",
+			"integrity": "sha512-v+IBLojcZm1azQhiSEPCt3A2/xByiqDQ7/0gdkFenGrnEvnJ/9r/vv6ON0vAWFqDXov1Nu6kwEGA1bXIZTeHQw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^3.1.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/server-lambdas": "~5.0.0",
+				"@fluidframework/server-memory-orderer": "~5.0.0",
+				"@fluidframework/server-services-client": "~5.0.0",
+				"@fluidframework/server-services-core": "~5.0.0",
+				"@fluidframework/server-services-telemetry": "~5.0.0",
+				"@fluidframework/server-test-utils": "~5.0.0",
+				"debug": "^4.3.4",
+				"events_pkg": "npm:events@^3.1.0",
+				"jsrsasign": "^11.0.0",
+				"uuid": "^9.0.0"
+			}
+		},
+		"node_modules/@fluidframework/server-local-server/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@fluidframework/server-memory-orderer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-5.0.0.tgz",
+			"integrity": "sha512-S5G2TwHXlewGkZ3jAtUKr/vpku0LPvhApktOVtAidIGHlKJP0kjLiom/KZihKZT5h2KqIhFBy56JgkXPFYkNeQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^3.1.0",
+				"@fluidframework/protocol-base": "~5.0.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/server-lambdas": "~5.0.0",
+				"@fluidframework/server-services-client": "~5.0.0",
+				"@fluidframework/server-services-core": "~5.0.0",
+				"@fluidframework/server-services-telemetry": "~5.0.0",
+				"@types/debug": "^4.1.5",
+				"@types/double-ended-queue": "^2.1.0",
+				"@types/lodash": "^4.14.118",
+				"@types/node": "^18.17.1",
+				"@types/ws": "^6.0.1",
+				"assert": "^2.0.0",
+				"debug": "^4.3.4",
+				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
+				"lodash": "^4.17.21",
+				"sillyname": "^0.1.0",
+				"uuid": "^9.0.0",
+				"ws": "^7.4.6"
+			}
+		},
+		"node_modules/@fluidframework/server-memory-orderer/node_modules/@types/node": {
+			"version": "18.19.55",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.55.tgz",
+			"integrity": "sha512-zzw5Vw52205Zr/nmErSEkN5FLqXPuKX/k5d1D7RKHATGqU7y6YfX9QxZraUzUrFGqH6XzOzG196BC35ltJC4Cw==",
+			"dev": true,
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
+		},
+		"node_modules/@fluidframework/server-memory-orderer/node_modules/@types/ws": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
+			"integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@fluidframework/server-memory-orderer/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@fluidframework/server-memory-orderer/node_modules/ws": {
+			"version": "7.5.10",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+			"integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.3.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@fluidframework/server-services-client": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-5.0.0.tgz",
@@ -866,6 +1084,179 @@
 				"https://github.com/sponsors/ctavan"
 			],
 			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@fluidframework/server-services-core": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-5.0.0.tgz",
+			"integrity": "sha512-ztrGdRStwlfBFVsm+kChu6VuI764O4TbEEE1RX4gXpLlOsUVZfgYfeUiysdk5Zh7svDKT9n5LdE6VdjLvwb7IA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^3.1.0",
+				"@fluidframework/gitresources": "~5.0.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/server-services-client": "~5.0.0",
+				"@fluidframework/server-services-telemetry": "~5.0.0",
+				"@types/nconf": "^0.10.2",
+				"@types/node": "^18.17.1",
+				"debug": "^4.3.4",
+				"events": "^3.1.0",
+				"nconf": "^0.12.0"
+			}
+		},
+		"node_modules/@fluidframework/server-services-core/node_modules/@types/node": {
+			"version": "18.19.55",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.55.tgz",
+			"integrity": "sha512-zzw5Vw52205Zr/nmErSEkN5FLqXPuKX/k5d1D7RKHATGqU7y6YfX9QxZraUzUrFGqH6XzOzG196BC35ltJC4Cw==",
+			"dev": true,
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
+		},
+		"node_modules/@fluidframework/server-services-shared": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-5.0.0.tgz",
+			"integrity": "sha512-Qrmxq8IeUTq9n+5rpR4LY0MPZfKWXCw/MQj0Sc5xe0bx8tnPmqQ1W43uOC+or4HcWmigSYKkhPfp73BSzvNrfw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^3.1.0",
+				"@fluidframework/gitresources": "~5.0.0",
+				"@fluidframework/protocol-base": "~5.0.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/server-services-client": "~5.0.0",
+				"@fluidframework/server-services-core": "~5.0.0",
+				"@fluidframework/server-services-telemetry": "~5.0.0",
+				"@fluidframework/server-services-utils": "~5.0.0",
+				"@socket.io/redis-adapter": "^8.3.0",
+				"@socket.io/sticky": "^1.0.4",
+				"body-parser": "^1.17.1",
+				"debug": "^4.3.4",
+				"events": "^3.1.0",
+				"fast-redact": "^3.3.0",
+				"ioredis": "^5.2.3",
+				"lodash": "^4.17.21",
+				"nconf": "^0.12.0",
+				"notepack.io": "^2.3.0",
+				"serialize-error": "^8.1.0",
+				"socket.io": "^4.7.5",
+				"socket.io-adapter": "^2.5.4",
+				"socket.io-parser": "^4.2.4",
+				"uuid": "^9.0.0",
+				"winston": "^3.6.0"
+			}
+		},
+		"node_modules/@fluidframework/server-services-shared/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@fluidframework/server-services-telemetry": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-5.0.0.tgz",
+			"integrity": "sha512-lWymor6/GVgZpjtBOEUzCmjNJoro/oK2MKoT0MFgg70bhTgWKAOLRAkJZgq8GLGPCHW7ntZ/D+ve763kPu27CQ==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^3.1.0",
+				"json-stringify-safe": "^5.0.1",
+				"path-browserify": "^1.0.1",
+				"serialize-error": "^8.1.0",
+				"uuid": "^9.0.0"
+			}
+		},
+		"node_modules/@fluidframework/server-services-telemetry/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@fluidframework/server-services-utils": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-5.0.0.tgz",
+			"integrity": "sha512-5yuVl3Wqj8GpcT1NX+GFsvIwP3nSWD/KJP0J1EQi499T5RWwdsoCcDtZhe1T968NbPQAx/gnXyMtEVy5MfTkWA==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/server-services-client": "~5.0.0",
+				"@fluidframework/server-services-core": "~5.0.0",
+				"@fluidframework/server-services-telemetry": "~5.0.0",
+				"debug": "^4.3.4",
+				"express": "^4.19.2",
+				"ioredis": "^5.2.3",
+				"json-stringify-safe": "^5.0.1",
+				"jsonwebtoken": "^9.0.0",
+				"morgan": "^1.8.1",
+				"nconf": "^0.12.0",
+				"serialize-error": "^8.1.0",
+				"sillyname": "^0.1.0",
+				"split": "^1.0.0",
+				"uuid": "^9.0.0",
+				"winston": "^3.6.0",
+				"winston-transport": "^4.5.0"
+			}
+		},
+		"node_modules/@fluidframework/server-services-utils/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@fluidframework/server-test-utils": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-5.0.0.tgz",
+			"integrity": "sha512-FOZ1Faw6x8VALUZh/nY6zKCfpgbPK/ylpKf/uQ2oOV9sxGNQfo5NXyHlQP1b78wfx2OYyHY5njtvYl7i9tz/zg==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^3.1.0",
+				"@fluidframework/gitresources": "~5.0.0",
+				"@fluidframework/protocol-base": "~5.0.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/server-services-client": "~5.0.0",
+				"@fluidframework/server-services-core": "~5.0.0",
+				"@fluidframework/server-services-telemetry": "~5.0.0",
+				"@types/ioredis-mock": "^8.2.1",
+				"assert": "^2.0.0",
+				"debug": "^4.3.4",
+				"events": "^3.1.0",
+				"ioredis": "^5.2.3",
+				"ioredis-mock": "^8.2.3",
+				"lodash": "^4.17.21",
+				"string-hash": "^1.1.3",
+				"uuid": "^9.0.0"
+			}
+		},
+		"node_modules/@fluidframework/server-test-utils/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
 			"bin": {
 				"uuid": "dist/bin/uuid"
 			}
@@ -1088,6 +1479,18 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/nzakas"
 			}
+		},
+		"node_modules/@ioredis/as-callback": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@ioredis/as-callback/-/as-callback-3.0.0.tgz",
+			"integrity": "sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg==",
+			"dev": true
+		},
+		"node_modules/@ioredis/commands": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+			"integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+			"dev": true
 		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
@@ -1388,6 +1791,35 @@
 			"integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
 			"license": "MIT"
 		},
+		"node_modules/@socket.io/redis-adapter": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-8.3.0.tgz",
+			"integrity": "sha512-ly0cra+48hDmChxmIpnESKrc94LjRL80TEmZVscuQ/WWkRP81nNj8W8cCGMqbI4L6NCuAaPRSzZF1a9GlAxxnA==",
+			"dev": true,
+			"dependencies": {
+				"debug": "~4.3.1",
+				"notepack.io": "~3.0.1",
+				"uid2": "1.0.0"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"socket.io-adapter": "^2.5.4"
+			}
+		},
+		"node_modules/@socket.io/redis-adapter/node_modules/notepack.io": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-3.0.1.tgz",
+			"integrity": "sha512-TKC/8zH5pXIAMVQio2TvVDTtPRX+DJPHDqjRbxogtFiByHyzKmy96RA0JtCQJ+WouyyL4A10xomQzgbUT+1jCg==",
+			"dev": true
+		},
+		"node_modules/@socket.io/sticky": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@socket.io/sticky/-/sticky-1.0.4.tgz",
+			"integrity": "sha512-VuauT5CJLvzYtKIgouFSQ8rUaygseR+zRutnwh6ZA2QYcXx+8g52EoJ8V2SLxfo+Tfs3ELUDy08oEXxlWNrxaw==",
+			"dev": true
+		},
 		"node_modules/@tiny-calc/nano": {
 			"version": "0.0.0-alpha.5",
 			"resolved": "https://registry.npmjs.org/@tiny-calc/nano/-/nano-0.0.0-alpha.5.tgz",
@@ -1439,6 +1871,21 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/cookie": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+			"integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+			"dev": true
+		},
+		"node_modules/@types/cors": {
+			"version": "2.8.17",
+			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+			"integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/debug": {
 			"version": "4.1.12",
 			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -1447,6 +1894,12 @@
 			"dependencies": {
 				"@types/ms": "*"
 			}
+		},
+		"node_modules/@types/double-ended-queue": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@types/double-ended-queue/-/double-ended-queue-2.1.7.tgz",
+			"integrity": "sha512-OVbdb2iOJakEg/Ou6dVZsH0LLxlO+GFjc1FB2W8/jT7bnhoFVJwnZOqi/H26ospeMBaEbGiX3Qy2a7r6pfZKXQ==",
+			"dev": true
 		},
 		"node_modules/@types/estree": {
 			"version": "1.0.6",
@@ -1512,6 +1965,16 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/ioredis-mock": {
+			"version": "8.2.5",
+			"resolved": "https://registry.npmjs.org/@types/ioredis-mock/-/ioredis-mock-8.2.5.tgz",
+			"integrity": "sha512-cZyuwC9LGtg7s5G9/w6rpy3IOZ6F/hFR0pQlWYZESMo1xQUYbDpa6haqB4grTePjsGzcB/YLBFCjqRunK5wieg==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*",
+				"ioredis": ">=5"
+			}
+		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1524,6 +1987,12 @@
 			"integrity": "sha512-lppSlfK6etu+cuKs40K4rg8As79PH6hzIB+v55zSqImbSH3SE6Fm8MBHCiI91cWlAP3Z4igtJK1VL3fSN09blQ==",
 			"dev": true
 		},
+		"node_modules/@types/lodash": {
+			"version": "4.17.10",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.10.tgz",
+			"integrity": "sha512-YpS0zzoduEhuOWjAotS6A5AVCva7X4lVlYLF0FYHAY9sdraBfnatttHItlWeZdGhuEkf+OzMNg2ZYAx8t+52uQ==",
+			"dev": true
+		},
 		"node_modules/@types/mime": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -1534,6 +2003,12 @@
 			"version": "0.7.34",
 			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
 			"integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
+			"dev": true
+		},
+		"node_modules/@types/nconf": {
+			"version": "0.10.7",
+			"resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.7.tgz",
+			"integrity": "sha512-ltJgbQX0XgjkeDrz0anTCXLBLatppWYFCxp88ILEwybfAuyNWr0Qb+ceFFqZ0VDR8fguEjr0hH37ZF+AF4gsxw==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -1598,6 +2073,12 @@
 			"integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
 			"dev": true
 		},
+		"node_modules/@types/semver": {
+			"version": "7.5.8",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+			"integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+			"dev": true
+		},
 		"node_modules/@types/send": {
 			"version": "0.17.4",
 			"resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
@@ -1636,6 +2117,12 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
+		},
+		"node_modules/@types/triple-beam": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+			"integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+			"dev": true
 		},
 		"node_modules/@types/uuid": {
 			"version": "10.0.0",
@@ -2078,6 +2565,36 @@
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
 			"dev": true
 		},
+		"node_modules/abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"dev": true,
+			"dependencies": {
+				"event-target-shim": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6.5"
+			}
+		},
+		"node_modules/abstract-level": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.4.tgz",
+			"integrity": "sha512-eUP/6pbXBkMbXFdx4IH2fVgvB7M0JvR7/lIL33zcs0IBcwjdzSSl31TOJsaCzmKSSDF9h8QYSOJux4Nd4YJqFg==",
+			"dev": true,
+			"dependencies": {
+				"buffer": "^6.0.3",
+				"catering": "^2.1.0",
+				"is-buffer": "^2.0.5",
+				"level-supports": "^4.0.0",
+				"level-transcoder": "^1.0.1",
+				"module-error": "^1.0.1",
+				"queue-microtask": "^1.2.3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2119,6 +2636,27 @@
 			"dev": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/address": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
+			"integrity": "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/agentkeepalive": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+			"integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+			"dev": true,
+			"dependencies": {
+				"humanize-ms": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
 			}
 		},
 		"node_modules/ajv": {
@@ -2388,6 +2926,31 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/assert": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+			"integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"is-nan": "^1.3.2",
+				"object-is": "^1.1.5",
+				"object.assign": "^4.1.4",
+				"util": "^0.12.5"
+			}
+		},
+		"node_modules/async": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+			"dev": true
+		},
+		"node_modules/async-lock": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+			"integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+			"dev": true
+		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2443,6 +3006,33 @@
 				}
 			],
 			"license": "MIT"
+		},
+		"node_modules/base64id": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+			"integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+			"dev": true,
+			"engines": {
+				"node": "^4.5.0 || >= 5.9"
+			}
+		},
+		"node_modules/basic-auth": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+			"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "5.1.2"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/basic-auth/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"node_modules/batch": {
 			"version": "0.6.1",
@@ -2548,6 +3138,18 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/browser-level": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
+			"integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
+			"dev": true,
+			"dependencies": {
+				"abstract-level": "^1.0.2",
+				"catering": "^2.1.1",
+				"module-error": "^1.0.2",
+				"run-parallel-limit": "^1.1.0"
+			}
+		},
 		"node_modules/browserslist": {
 			"version": "4.23.0",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
@@ -2604,6 +3206,12 @@
 				"ieee754": "^1.2.1"
 			}
 		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"dev": true
+		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2632,6 +3240,25 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/bytewise": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+			"integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
+			"dev": true,
+			"dependencies": {
+				"bytewise-core": "^1.2.2",
+				"typewise": "^1.0.3"
+			}
+		},
+		"node_modules/bytewise-core": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+			"integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
+			"dev": true,
+			"dependencies": {
+				"typewise-core": "^1.2"
 			}
 		},
 		"node_modules/call-bind": {
@@ -2701,6 +3328,15 @@
 				}
 			]
 		},
+		"node_modules/catering": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
+			"integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2716,6 +3352,12 @@
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
+		},
+		"node_modules/charwise": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz",
+			"integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw==",
+			"dev": true
 		},
 		"node_modules/chokidar": {
 			"version": "3.6.0",
@@ -2762,6 +3404,23 @@
 				"node": ">=6.0"
 			}
 		},
+		"node_modules/classic-level": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.4.1.tgz",
+			"integrity": "sha512-qGx/KJl3bvtOHrGau2WklEZuXhS3zme+jf+fsu6Ej7W7IP/C49v7KNlWIsT1jZu0YnfzSIYDGcEWpCa1wKGWXQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"dependencies": {
+				"abstract-level": "^1.0.2",
+				"catering": "^2.1.0",
+				"module-error": "^1.0.1",
+				"napi-macros": "^2.2.2",
+				"node-gyp-build": "^4.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/clean-css": {
 			"version": "5.3.3",
 			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
@@ -2772,6 +3431,23 @@
 			},
 			"engines": {
 				"node": ">= 10.0"
+			}
+		},
+		"node_modules/clean-git-ref": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
+			"integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
+			"dev": true
+		},
+		"node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
 			}
 		},
 		"node_modules/clone-deep": {
@@ -2786,6 +3462,25 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/cluster-key-slot": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+			"integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/color": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^1.9.3",
+				"color-string": "^1.6.0"
 			}
 		},
 		"node_modules/color-convert": {
@@ -2806,11 +3501,46 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
+		"node_modules/color-string": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "^1.0.0",
+				"simple-swizzle": "^0.2.2"
+			}
+		},
+		"node_modules/color/node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/color/node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"dev": true
+		},
 		"node_modules/colorette": {
 			"version": "2.0.20",
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
 			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
 			"dev": true
+		},
+		"node_modules/colorspace": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+			"integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+			"dev": true,
+			"dependencies": {
+				"color": "^3.1.3",
+				"text-hex": "1.0.x"
+			}
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
@@ -2920,9 +3650,31 @@
 			}
 		},
 		"node_modules/cookie": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+			"integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie-parser": {
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+			"integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+			"dev": true,
+			"dependencies": {
+				"cookie": "0.7.2",
+				"cookie-signature": "1.0.6"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/cookie-parser/node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
@@ -3007,6 +3759,19 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"dev": true
+		},
+		"node_modules/cors": {
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+			"dev": true,
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
 		},
 		"node_modules/crc-32": {
 			"version": "1.2.0",
@@ -3224,6 +3989,21 @@
 				}
 			}
 		},
+		"node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"dev": true,
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3312,6 +4092,15 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/denque": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+			"integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
 		"node_modules/depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3337,10 +4126,33 @@
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
 		},
+		"node_modules/detect-port": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.6.1.tgz",
+			"integrity": "sha512-CmnVc+Hek2egPx1PeTFVta2W78xy2K/9Rkf6cC4T59S50tVnzKj+tnx5mmx5lwvCkujZ4uRrpRSuV+IVs3f90Q==",
+			"dev": true,
+			"dependencies": {
+				"address": "^1.0.1",
+				"debug": "4"
+			},
+			"bin": {
+				"detect": "bin/detect-port.js",
+				"detect-port": "bin/detect-port.js"
+			},
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
 		"node_modules/didyoumean": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
 			"integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+			"dev": true
+		},
+		"node_modules/diff3": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
 			"dev": true
 		},
 		"node_modules/dlv": {
@@ -3480,6 +4292,15 @@
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
 			"dev": true
 		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"node_modules/ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3498,6 +4319,12 @@
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true
 		},
+		"node_modules/enabled": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+			"dev": true
+		},
 		"node_modules/encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -3505,6 +4332,27 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/engine.io": {
+			"version": "6.6.2",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.2.tgz",
+			"integrity": "sha512-gmNvsYi9C8iErnZdVcJnvCpSKbWTt1E8+JZo8b+daLninywUWi5NQ5STSHZ9rFjFO7imNcvb8Pc5pe/wMR5xEw==",
+			"dev": true,
+			"dependencies": {
+				"@types/cookie": "^0.4.1",
+				"@types/cors": "^2.8.12",
+				"@types/node": ">=10.0.0",
+				"accepts": "~1.3.4",
+				"base64id": "2.0.0",
+				"cookie": "~0.7.2",
+				"cors": "~2.8.5",
+				"debug": "~4.3.1",
+				"engine.io-parser": "~5.2.1",
+				"ws": "~8.17.1"
+			},
+			"engines": {
+				"node": ">=10.2.0"
 			}
 		},
 		"node_modules/engine.io-client": {
@@ -3527,6 +4375,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/engine.io/node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/enhanced-resolve": {
@@ -3561,6 +4418,18 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/errno": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+			"integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+			"dev": true,
+			"dependencies": {
+				"prr": "~1.0.1"
+			},
+			"bin": {
+				"errno": "cli.js"
 			}
 		},
 		"node_modules/es-abstract": {
@@ -4017,6 +4886,15 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/eventemitter3": {
 			"version": "4.0.7",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -4051,9 +4929,9 @@
 			}
 		},
 		"node_modules/express": {
-			"version": "4.21.0",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-			"integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+			"version": "4.21.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+			"integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
 			"dev": true,
 			"dependencies": {
 				"accepts": "~1.3.8",
@@ -4061,7 +4939,7 @@
 				"body-parser": "1.20.3",
 				"content-disposition": "0.5.4",
 				"content-type": "~1.0.4",
-				"cookie": "0.6.0",
+				"cookie": "0.7.1",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
@@ -4162,6 +5040,15 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
+		"node_modules/fast-redact": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+			"integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/fast-uri": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
@@ -4196,6 +5083,32 @@
 			},
 			"engines": {
 				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/fecha": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+			"dev": true
+		},
+		"node_modules/fengari": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.4.tgz",
+			"integrity": "sha512-6ujqUuiIYmcgkGz8MGAdERU57EIluGGPSUgGPTsco657EHa+srq0S3/YUl/r9kx1+D+d4rGfYObd+m8K22gB1g==",
+			"dev": true,
+			"dependencies": {
+				"readline-sync": "^1.4.9",
+				"sprintf-js": "^1.1.1",
+				"tmp": "^0.0.33"
+			}
+		},
+		"node_modules/fengari-interop": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/fengari-interop/-/fengari-interop-0.1.3.tgz",
+			"integrity": "sha512-EtZ+oTu3kEwVJnoymFPBVLIbQcCoy9uWCVnMA6h3M/RqHkUBsLYp29+RRHf9rKr6GwjubWREU1O7RretFIXjHw==",
+			"dev": true,
+			"peerDependencies": {
+				"fengari": "^0.1.0"
 			}
 		},
 		"node_modules/file-entry-cache": {
@@ -4325,6 +5238,12 @@
 				"@fluidframework/shared-object-base": "~2.3.1",
 				"@fluidframework/tree": "~2.3.1"
 			}
+		},
+		"node_modules/fn.name": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+			"dev": true
 		},
 		"node_modules/follow-redirects": {
 			"version": "1.15.6",
@@ -4461,6 +5380,15 @@
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
 		"node_modules/get-intrinsic": {
@@ -4850,6 +5778,15 @@
 				}
 			}
 		},
+		"node_modules/humanize-ms": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "^2.0.0"
+			}
+		},
 		"node_modules/hyperdyperid": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
@@ -4961,6 +5898,15 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
+		"node_modules/ini": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+			"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/internal-slot": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
@@ -4984,6 +5930,62 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/ioredis": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.4.1.tgz",
+			"integrity": "sha512-2YZsvl7jopIa1gaePkeMtd9rAcSjOOjPtpcLlOeusyO+XH2SK5ZcT+UCrElPP+WVIInh2TzeI4XW9ENaSLVVHA==",
+			"dev": true,
+			"dependencies": {
+				"@ioredis/commands": "^1.1.1",
+				"cluster-key-slot": "^1.1.0",
+				"debug": "^4.3.4",
+				"denque": "^2.1.0",
+				"lodash.defaults": "^4.2.0",
+				"lodash.isarguments": "^3.1.0",
+				"redis-errors": "^1.2.0",
+				"redis-parser": "^3.0.0",
+				"standard-as-callback": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=12.22.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ioredis"
+			}
+		},
+		"node_modules/ioredis-mock": {
+			"version": "8.9.0",
+			"resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-8.9.0.tgz",
+			"integrity": "sha512-yIglcCkI1lvhwJVoMsR51fotZVsPsSk07ecTCgRTRlicG0Vq3lke6aAaHklyjmRNRsdYAgswqC2A0bPtQK4LSw==",
+			"dev": true,
+			"dependencies": {
+				"@ioredis/as-callback": "^3.0.0",
+				"@ioredis/commands": "^1.2.0",
+				"fengari": "^0.1.4",
+				"fengari-interop": "^0.1.3",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=12.22"
+			},
+			"peerDependencies": {
+				"@types/ioredis-mock": "^8",
+				"ioredis": "^5"
+			}
+		},
+		"node_modules/ioredis-mock/node_modules/semver": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/ipaddr.js": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
@@ -4991,6 +5993,22 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 10"
+			}
+		},
+		"node_modules/is-arguments": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-array-buffer": {
@@ -5008,6 +6026,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/is-arrayish": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+			"dev": true
 		},
 		"node_modules/is-async-function": {
 			"version": "2.0.0",
@@ -5062,6 +6086,29 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-buffer": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/is-callable": {
@@ -5220,6 +6267,22 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-nan": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-negative-zero": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -5333,6 +6396,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-string": {
@@ -5456,6 +6531,54 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/isomorphic-git": {
+			"version": "1.27.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.27.1.tgz",
+			"integrity": "sha512-X32ph5zIWfT75QAqW2l3JCIqnx9/GWd17bRRehmn3qmWc34OYbSXY6Cxv0o9bIIY+CWugoN4nQFHNA+2uYf2nA==",
+			"dev": true,
+			"dependencies": {
+				"async-lock": "^1.4.1",
+				"clean-git-ref": "^2.0.1",
+				"crc-32": "^1.2.0",
+				"diff3": "0.0.3",
+				"ignore": "^5.1.4",
+				"minimisted": "^2.0.0",
+				"pako": "^1.0.10",
+				"pify": "^4.0.1",
+				"readable-stream": "^3.4.0",
+				"sha.js": "^2.4.9",
+				"simple-get": "^4.0.1"
+			},
+			"bin": {
+				"isogit": "cli.cjs"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/isomorphic-git/node_modules/pify": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/isomorphic-git/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/iterator.prototype": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.2.tgz",
@@ -5540,6 +6663,40 @@
 			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
 			"license": "ISC"
 		},
+		"node_modules/jsonwebtoken": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+			"integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+			"dev": true,
+			"dependencies": {
+				"jws": "^3.2.2",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			}
+		},
+		"node_modules/jsonwebtoken/node_modules/semver": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/jsrsasign": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.1.0.tgz",
@@ -5561,6 +6718,27 @@
 			},
 			"engines": {
 				"node": ">=4.0"
+			}
+		},
+		"node_modules/jwa": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+			"dev": true,
+			"dependencies": {
+				"buffer-equal-constant-time": "1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+			"dev": true,
+			"dependencies": {
+				"jwa": "^1.4.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/jwt-decode": {
@@ -5590,6 +6768,12 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/kuler": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+			"dev": true
+		},
 		"node_modules/launch-editor": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.1.tgz",
@@ -5598,6 +6782,135 @@
 			"dependencies": {
 				"picocolors": "^1.0.0",
 				"shell-quote": "^1.8.1"
+			}
+		},
+		"node_modules/level": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/level/-/level-8.0.1.tgz",
+			"integrity": "sha512-oPBGkheysuw7DmzFQYyFe8NAia5jFLAgEnkgWnK3OXAuJr8qFT+xBQIwokAZPME2bhPFzS8hlYcL16m8UZrtwQ==",
+			"dev": true,
+			"dependencies": {
+				"abstract-level": "^1.0.4",
+				"browser-level": "^1.0.1",
+				"classic-level": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/level"
+			}
+		},
+		"node_modules/level-codec": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+			"integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
+			"dev": true,
+			"dependencies": {
+				"buffer": "^5.6.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/level-codec/node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
+		},
+		"node_modules/level-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+			"integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
+			"dev": true,
+			"dependencies": {
+				"errno": "~0.1.1"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/level-iterator-stream": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
+			"integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.5",
+				"xtend": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/level-post": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
+			"integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
+			"dev": true,
+			"dependencies": {
+				"ltgt": "^2.1.2"
+			}
+		},
+		"node_modules/level-sublevel": {
+			"version": "6.6.4",
+			"resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.4.tgz",
+			"integrity": "sha512-pcCrTUOiO48+Kp6F1+UAzF/OtWqLcQVTVF39HLdZ3RO8XBoXt+XVPKZO1vVr1aUoxHZA9OtD2e1v7G+3S5KFDA==",
+			"dev": true,
+			"dependencies": {
+				"bytewise": "~1.1.0",
+				"level-codec": "^9.0.0",
+				"level-errors": "^2.0.0",
+				"level-iterator-stream": "^2.0.3",
+				"ltgt": "~2.1.1",
+				"pull-defer": "^0.2.2",
+				"pull-level": "^2.0.3",
+				"pull-stream": "^3.6.8",
+				"typewiselite": "~1.0.0",
+				"xtend": "~4.0.0"
+			}
+		},
+		"node_modules/level-supports": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
+			"integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/level-transcoder": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
+			"integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
+			"dev": true,
+			"dependencies": {
+				"buffer": "^6.0.3",
+				"module-error": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/levn": {
@@ -5657,10 +6970,87 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
+		"node_modules/lodash.defaults": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+			"dev": true
+		},
+		"node_modules/lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+			"dev": true
+		},
+		"node_modules/lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+			"dev": true
+		},
+		"node_modules/lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+			"dev": true
+		},
+		"node_modules/lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+			"dev": true
+		},
+		"node_modules/lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+			"dev": true
+		},
+		"node_modules/lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+			"dev": true
+		},
+		"node_modules/lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+			"dev": true
+		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true
+		},
+		"node_modules/lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+			"dev": true
+		},
+		"node_modules/logform": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.6.1.tgz",
+			"integrity": "sha512-CdaO738xRapbKIMVn2m4F6KTj4j7ooJ8POVnebSgKo3KBz5axNXRAL7ZdRjIV6NOr2Uf4vjtRkxrFETOioCqSA==",
+			"dev": true,
+			"dependencies": {
+				"@colors/colors": "1.6.0",
+				"@types/triple-beam": "^1.3.2",
+				"fecha": "^4.2.0",
+				"ms": "^2.1.1",
+				"safe-stable-stringify": "^2.3.1",
+				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/looper": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
+			"integrity": "sha512-6DzMHJcjbQX/UPHc1rRCBfKlLwDkvuGZ715cIR36wSdYqWXFT35uLXq5P/2orl3tz+t+VOVPxw4yPinQlUDGDQ==",
 			"dev": true
 		},
 		"node_modules/loose-envify": {
@@ -5682,6 +7072,12 @@
 			"dependencies": {
 				"tslib": "^2.0.3"
 			}
+		},
+		"node_modules/ltgt": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
+			"integrity": "sha512-5VjHC5GsENtIi5rbJd+feEpDKhfr7j0odoUR2Uh978g+2p93nd5o34cTjQWohXsPsCZeqoDnIqEf88mPCe0Pfw==",
+			"dev": true
 		},
 		"node_modules/lz4js": {
 			"version": "0.2.0",
@@ -5751,12 +7147,12 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
 			"dependencies": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			},
 			"engines": {
@@ -5792,6 +7188,18 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/mini-css-extract-plugin": {
@@ -5832,6 +7240,24 @@
 				"node": "*"
 			}
 		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/minimisted": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
+			"integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
+			"dev": true,
+			"dependencies": {
+				"minimist": "^1.2.5"
+			}
+		},
 		"node_modules/minipass": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -5839,6 +7265,58 @@
 			"dev": true,
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/module-error": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
+			"integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/morgan": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+			"integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+			"dev": true,
+			"dependencies": {
+				"basic-auth": "~2.0.1",
+				"debug": "2.6.9",
+				"depd": "~2.0.0",
+				"on-finished": "~2.3.0",
+				"on-headers": "~1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/morgan/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/morgan/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true
+		},
+		"node_modules/morgan/node_modules/on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+			"dev": true,
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/ms": {
@@ -5888,11 +7366,32 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/napi-macros": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
+			"integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==",
+			"dev": true
+		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
+		},
+		"node_modules/nconf": {
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.1.tgz",
+			"integrity": "sha512-p2cfF+B3XXacQdswUYWZ0w6Vld0832A/tuqjLBu3H1sfUcby4N2oVbGhyuCkZv+t3iY3aiFEj7gZGqax9Q2c1w==",
+			"dev": true,
+			"dependencies": {
+				"async": "^3.0.0",
+				"ini": "^2.0.0",
+				"secure-keys": "^1.0.0",
+				"yargs": "^16.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
+			}
 		},
 		"node_modules/negotiator": {
 			"version": "0.6.3",
@@ -5948,6 +7447,17 @@
 				"node": ">= 6.13.0"
 			}
 		},
+		"node_modules/node-gyp-build": {
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
+			"integrity": "sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==",
+			"dev": true,
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
+			}
+		},
 		"node_modules/node-releases": {
 			"version": "2.0.14",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
@@ -5962,6 +7472,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/notepack.io": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.3.0.tgz",
+			"integrity": "sha512-9RiFDxeydHsWOqdthRUck2Kd4UW2NzVd2xxOulZiQ9mvge6ElsHXLpwD3HEJyql6sFEnEn/eMO7HSdS0M5mWkA==",
+			"dev": true
 		},
 		"node_modules/nth-check": {
 			"version": "2.1.1",
@@ -5998,6 +7514,22 @@
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
 			"integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
 			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object-is": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+			"integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -6105,6 +7637,24 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/one-time": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+			"dev": true,
+			"dependencies": {
+				"fn.name": "1.x.x"
+			}
+		},
 		"node_modules/open": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
@@ -6138,6 +7688,15 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/p-limit": {
@@ -6200,6 +7759,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
 			"integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+			"dev": true
+		},
+		"node_modules/pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
 			"dev": true
 		},
 		"node_modules/param-case": {
@@ -6696,6 +8261,15 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -6745,6 +8319,70 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+		},
+		"node_modules/prr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+			"integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+			"dev": true
+		},
+		"node_modules/pull-cat": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
+			"integrity": "sha512-i3w+xZ3DCtTVz8S62hBOuNLRHqVDsHMNZmgrZsjPnsxXUgbWtXEee84lo1XswE7W2a3WHyqsNuDJTjVLAQR8xg==",
+			"dev": true
+		},
+		"node_modules/pull-defer": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
+			"integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA==",
+			"dev": true
+		},
+		"node_modules/pull-level": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
+			"integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
+			"dev": true,
+			"dependencies": {
+				"level-post": "^1.0.7",
+				"pull-cat": "^1.1.9",
+				"pull-live": "^1.0.1",
+				"pull-pushable": "^2.0.0",
+				"pull-stream": "^3.4.0",
+				"pull-window": "^2.1.4",
+				"stream-to-pull-stream": "^1.7.1"
+			}
+		},
+		"node_modules/pull-live": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
+			"integrity": "sha512-tkNz1QT5gId8aPhV5+dmwoIiA1nmfDOzJDlOOUpU5DNusj6neNd3EePybJ5+sITr2FwyCs/FVpx74YMCfc8YeA==",
+			"dev": true,
+			"dependencies": {
+				"pull-cat": "^1.1.9",
+				"pull-stream": "^3.4.0"
+			}
+		},
+		"node_modules/pull-pushable": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
+			"integrity": "sha512-M7dp95enQ2kaHvfCt2+DJfyzgCSpWVR2h2kWYnVsW6ZpxQBx5wOu0QWOvQPVoPnBLUZYitYP2y7HyHkLQNeGXg==",
+			"dev": true
+		},
+		"node_modules/pull-stream": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.7.0.tgz",
+			"integrity": "sha512-Eco+/R004UaCK2qEDE8vGklcTG2OeZSVm1kTUQNrykEjDwcFXDZhygFDsW49DbXyJMEhHeRL3z5cRVqPAhXlIw==",
+			"dev": true
+		},
+		"node_modules/pull-window": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
+			"integrity": "sha512-cbDzN76BMlcGG46OImrgpkMf/VkCnupj8JhsrpBw3aWBM9ye345aYnqitmZCgauBkc0HbbRRn9hCnsa3k2FNUg==",
+			"dev": true,
+			"dependencies": {
+				"looper": "^2.0.0"
+			}
 		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
@@ -6903,6 +8541,15 @@
 				"node": ">=8.10.0"
 			}
 		},
+		"node_modules/readline-sync": {
+			"version": "1.4.10",
+			"resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+			"integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
 		"node_modules/rechoir": {
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
@@ -6913,6 +8560,27 @@
 			},
 			"engines": {
 				"node": ">= 10.13.0"
+			}
+		},
+		"node_modules/redis-errors": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+			"integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/redis-parser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+			"integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+			"dev": true,
+			"dependencies": {
+				"redis-errors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/reflect.getprototypeof": {
@@ -6979,6 +8647,15 @@
 				"htmlparser2": "^6.1.0",
 				"lodash": "^4.17.21",
 				"strip-ansi": "^6.0.1"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/require-from-string": {
@@ -7105,6 +8782,29 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"node_modules/run-parallel-limit": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
+			"integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"queue-microtask": "^1.2.2"
+			}
+		},
 		"node_modules/safe-array-concat": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
@@ -7157,6 +8857,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/safe-stable-stringify": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+			"integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/safer-buffer": {
@@ -7224,6 +8933,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true
+		},
+		"node_modules/secure-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
+			"integrity": "sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg==",
 			"dev": true
 		},
 		"node_modules/select-hose": {
@@ -7298,6 +9013,21 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true
+		},
+		"node_modules/serialize-error": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+			"integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+			"dev": true,
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.2",
@@ -7527,6 +9257,88 @@
 			"integrity": "sha512-GWA0Zont13ov+cMNw4T7nU4SCyW8jdhD3vjA5+qs8jr+09sCPxOf+FPS5zE0c9pYlCwD+NU/CiMimY462lgG9g==",
 			"license": "MIT"
 		},
+		"node_modules/simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/simple-get": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"decompress-response": "^6.0.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
+		"node_modules/simple-swizzle": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+			"integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+			"dev": true,
+			"dependencies": {
+				"is-arrayish": "^0.3.1"
+			}
+		},
+		"node_modules/socket.io": {
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.0.tgz",
+			"integrity": "sha512-8U6BEgGjQOfGz3HHTYaC/L1GaxDCJ/KM0XTkJly0EhZ5U/du9uNEZy4ZgYzEzIqlx2CMm25CrCqr1ck899eLNA==",
+			"dev": true,
+			"dependencies": {
+				"accepts": "~1.3.4",
+				"base64id": "~2.0.0",
+				"cors": "~2.8.5",
+				"debug": "~4.3.2",
+				"engine.io": "~6.6.0",
+				"socket.io-adapter": "~2.5.2",
+				"socket.io-parser": "~4.2.4"
+			},
+			"engines": {
+				"node": ">=10.2.0"
+			}
+		},
+		"node_modules/socket.io-adapter": {
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+			"integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+			"dev": true,
+			"dependencies": {
+				"debug": "~4.3.4",
+				"ws": "~8.17.1"
+			}
+		},
 		"node_modules/socket.io-client": {
 			"version": "4.8.0",
 			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.0.tgz",
@@ -7637,6 +9449,39 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/split": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"dev": true,
+			"dependencies": {
+				"through": "2"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+			"dev": true
+		},
+		"node_modules/stack-trace": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+			"integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/standard-as-callback": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+			"integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+			"dev": true
+		},
 		"node_modules/statuses": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -7645,6 +9490,22 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/stream-to-pull-stream": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
+			"integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
+			"dev": true,
+			"dependencies": {
+				"looper": "^3.0.0",
+				"pull-stream": "^3.2.3"
+			}
+		},
+		"node_modules/stream-to-pull-stream/node_modules/looper": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+			"integrity": "sha512-LJ9wplN/uSn72oJRsXTx+snxPet5c8XiZmOKCm906NVYu+ag6SB6vUcnJcWxgnl2NfbIyeobAn7Bwv6xRj2XJg==",
+			"dev": true
 		},
 		"node_modules/string_decoder": {
 			"version": "1.1.1",
@@ -7659,6 +9520,12 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
+		},
+		"node_modules/string-hash": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+			"integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
 			"dev": true
 		},
 		"node_modules/string-width": {
@@ -8085,6 +9952,12 @@
 				"source-map": "^0.6.0"
 			}
 		},
+		"node_modules/text-hex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+			"dev": true
+		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -8124,11 +9997,89 @@
 				"tslib": "^2"
 			}
 		},
+		"node_modules/through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+			"dev": true
+		},
 		"node_modules/thunky": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
 			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
 			"dev": true
+		},
+		"node_modules/tinylicious": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-5.0.0.tgz",
+			"integrity": "sha512-hPO+RCdkoLC9WNEG58nmbnwqzJcIzG6KUdcuZm/mpMeDmUAgPf7gvb+/uDJEloJhUEeG6kvyYt9avKntNqq7dw==",
+			"dev": true,
+			"dependencies": {
+				"@fluidframework/common-utils": "^3.1.0",
+				"@fluidframework/gitresources": "~5.0.0",
+				"@fluidframework/protocol-base": "~5.0.0",
+				"@fluidframework/protocol-definitions": "^3.2.0",
+				"@fluidframework/server-lambdas": "~5.0.0",
+				"@fluidframework/server-local-server": "~5.0.0",
+				"@fluidframework/server-memory-orderer": "~5.0.0",
+				"@fluidframework/server-services-client": "~5.0.0",
+				"@fluidframework/server-services-core": "~5.0.0",
+				"@fluidframework/server-services-shared": "~5.0.0",
+				"@fluidframework/server-services-telemetry": "~5.0.0",
+				"@fluidframework/server-services-utils": "~5.0.0",
+				"@fluidframework/server-test-utils": "~5.0.0",
+				"agentkeepalive": "^4.2.1",
+				"axios": "^1.6.2",
+				"body-parser": "^1.17.1",
+				"charwise": "^3.0.1",
+				"compression": "^1.7.2",
+				"cookie-parser": "^1.4.3",
+				"cors": "^2.8.4",
+				"detect-port": "^1.3.0",
+				"express": "^4.19.2",
+				"isomorphic-git": "^1.25.7",
+				"json-stringify-safe": "^5.0.1",
+				"level": "^8.0.0",
+				"level-sublevel": "6.6.4",
+				"lodash": "^4.17.21",
+				"morgan": "^1.8.1",
+				"nconf": "^0.12.0",
+				"socket.io": "^4.7.5",
+				"split": "^1.0.0",
+				"uuid": "^9.0.0",
+				"winston": "^3.6.0"
+			},
+			"bin": {
+				"tinylicious": "dist/index.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tinylicious/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
+			"dependencies": {
+				"os-tmpdir": "~1.0.2"
+			},
+			"engines": {
+				"node": ">=0.6.0"
+			}
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -8171,6 +10122,15 @@
 			},
 			"peerDependencies": {
 				"tslib": "2"
+			}
+		},
+		"node_modules/triple-beam": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/ts-api-utils": {
@@ -8247,6 +10207,18 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/type-is": {
@@ -8348,6 +10320,36 @@
 				"node": ">=14.17"
 			}
 		},
+		"node_modules/typewise": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+			"integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
+			"dev": true,
+			"dependencies": {
+				"typewise-core": "^1.2.0"
+			}
+		},
+		"node_modules/typewise-core": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+			"integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
+			"dev": true
+		},
+		"node_modules/typewiselite": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
+			"integrity": "sha512-J9alhjVHupW3Wfz6qFRGgQw0N3gr8hOkw6zm7FZ6UR1Cse/oD9/JVok7DNE9TT9IbciDHX2Ex9+ksE6cRmtymw==",
+			"dev": true
+		},
+		"node_modules/uid2": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/uid2/-/uid2-1.0.0.tgz",
+			"integrity": "sha512-+I6aJUv63YAcY9n4mQreLUt0d4lvwkkopDNmpomkAUz0fAkEMV9pRWxN0EjhW1YfRhcuyHg2v3mwddCDW1+LFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -8427,6 +10429,19 @@
 			"dev": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/util": {
+			"version": "0.12.5",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"is-arguments": "^1.0.4",
+				"is-generator-function": "^1.0.7",
+				"is-typed-array": "^1.1.3",
+				"which-typed-array": "^1.1.2"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -8881,6 +10896,98 @@
 			"integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
 			"dev": true
 		},
+		"node_modules/winston": {
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.15.0.tgz",
+			"integrity": "sha512-RhruH2Cj0bV0WgNL+lOfoUBI4DVfdUNjVnJGVovWZmrcKtrFTTRzgXYK2O9cymSGjrERCtaAeHwMNnUWXlwZow==",
+			"dev": true,
+			"dependencies": {
+				"@colors/colors": "^1.6.0",
+				"@dabh/diagnostics": "^2.0.2",
+				"async": "^3.2.3",
+				"is-stream": "^2.0.0",
+				"logform": "^2.6.0",
+				"one-time": "^1.0.0",
+				"readable-stream": "^3.4.0",
+				"safe-stable-stringify": "^2.3.1",
+				"stack-trace": "0.0.x",
+				"triple-beam": "^1.3.0",
+				"winston-transport": "^4.7.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/winston-transport": {
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.8.0.tgz",
+			"integrity": "sha512-qxSTKswC6llEMZKgCQdaWgDuMJQnhuvF5f2Nk3SNXc4byfQ+voo2mX1Px9dkNOuR8p0KAjfPG29PuYUSIb+vSA==",
+			"dev": true,
+			"dependencies": {
+				"logform": "^2.6.1",
+				"readable-stream": "^4.5.2",
+				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/winston-transport/node_modules/readable-stream": {
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+			"integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+			"dev": true,
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/winston-transport/node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/winston/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
 		"node_modules/wrap-ansi-cjs": {
 			"name": "wrap-ansi",
 			"version": "7.0.0",
@@ -8898,6 +11005,12 @@
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true
 		},
 		"node_modules/ws": {
 			"version": "8.17.1",
@@ -8928,6 +11041,24 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4"
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/yaml": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.1.tgz",
@@ -8938,6 +11069,33 @@
 			},
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/item-counter/package.json
+++ b/item-counter/package.json
@@ -15,8 +15,8 @@
 		"format": "prettier src --write",
 		"lint": "eslint src",
 		"start": "npm run dev",
-		"start:server": "npx @fluidframework/azure-local-service@^2.0.1",
-		"pretest": "npx playwright install --with-deps",
+		"start:server": "azure-local-service",
+		"pretest": "playwright install --with-deps",
 		"test": "playwright test",
 		"webpack": "cross-env FLUID_CLIENT='azure' webpack"
 	},
@@ -40,6 +40,7 @@
 	"devDependencies": {
 		"@eslint/eslintrc": "^3.1.0",
 		"@eslint/js": "^9.12.0",
+		"@fluidframework/azure-local-service": "^2.3.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/devtools": "^2.3.1",
 		"@playwright/test": "^1.48.0",


### PR DESCRIPTION
Use dev dependencies instead of npx so versions are controlled by package lock.

Ran npm audit to resolve three security vulnerabilities.

Add note to readme about dev server output.