### PR TITLE
Update root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ To get started, clone the repository and navigate to one of the example folders.
 From the example root, you can install and start the example.
 
 1. Run `npm install` from the example root
-2. Run `npm run start` to start both the client and server
+2. Run `npm run start:server` to start the local server
+3. Run `npm start` in a new terminal window to start the client
 
 > For more details see the individual example README.md.
 
 ## Contributing
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+This project welcomes contributions and suggestions. Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
 the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
 


### PR DESCRIPTION
I previously had a PR for this change, but I saw it was closed. Still think this is a valid change however because if you follow the current README steps, you won't be able to run our examples. `npm run start` does not start local server/tinylicious for the examples, to start server you must run `npm run start:server`. 