### PR TITLE
Use objectRecursive for Group

### DIFF
--- a/brainstorm/src/schema/app_schema.ts
+++ b/brainstorm/src/schema/app_schema.ts
@@ -115,7 +115,7 @@ export class Items extends sf.arrayRecursive("Items", [() => Group, Note]) {
 }
 
 // Define the schema for the container of notes.
-export class Group extends sf.object("Group", {
+export class Group extends sf.objectRecursive("Group", {
 	id: sf.string,
 	name: sf.string,
 	items: Items,
@@ -143,6 +143,11 @@ export class Group extends sf.object("Group", {
 			});
 		}
 	};
+}
+
+{
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	type _check = ValidateRecursiveSchema<typeof Group>;
 }
 
 // Export the tree config appropriate for this schema.


### PR DESCRIPTION
Apply workaround noted in https://github.com/microsoft/FluidFramework/pull/22763/files#diff-4e56bb12cb4dab4f811a1f027a4cbb587a1c8d183ceeb15847059abd93323ae1R82 which will be needed to updated to fluid 2.4 when released.

Which this fix, brainstorm is confirmed to retain its existing 39 compile errors and 0 build errors when updating to a recent release candidate.