### PR TITLE
Make a dependabot group for React

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,13 @@ updates:
         patterns:
           - "@fluidframework*" 
           - "fluid-framework"
-      # To reduce noise, let's bundle all the eslint-related dependencies into a single PR.
+      # To reduce noise, we bundle related dependencies into a single PR.
       eslint:
         patterns:
           - "*eslint*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"


### PR DESCRIPTION
These should all be updated in sync anyway, and with a group dependabot will also bundle the PRs for all examples into a single PR too.