### PR TITLE
fix(brainstorm): local state for likes is inconsistent with remote state

### DIFF
--- a/brainstorm/src/react/noteux.tsx
+++ b/brainstorm/src/react/noteux.tsx
@@ -89,10 +89,16 @@ export function NoteView(props: {
 		// Returns the cleanup function to be invoked when the component unmounts.
 		const unsubscribe = Tree.on(props.note, "nodeChanged", () => {
 			setNoteText(props.note.text);
-			setNoteVoteCount(props.note.votes.length);
 		});
 		return unsubscribe;
 	}, []);
+
+	useEffect(() => {
+		const unsubscribe = Tree.on(props.note.votes, "nodeChanged", () => {
+			setNoteVoteCount(props.note.votes.length);
+		});
+		return unsubscribe;
+	});
 
 	useEffect(() => {
 		testSelection(props.note, props.session, props.clientId, props.fluidMembers);

--- a/brainstorm/src/react/noteux.tsx
+++ b/brainstorm/src/react/noteux.tsx
@@ -98,7 +98,7 @@ export function NoteView(props: {
 			setNoteVoteCount(props.note.votes.length);
 		});
 		return unsubscribe;
-	});
+	}, []);
 
 	useEffect(() => {
 		testSelection(props.note, props.session, props.clientId, props.fluidMembers);


### PR DESCRIPTION
##  Description

Repro: 
- Start brainstorm app
- Add 2 clients
- Create a note and like it
    - See that remote like is updated but local state is not 
- Local state only updates after another change to node 
- Continue liking and unliking 
    - state inconsistencies 
    
Fix: changes to votes array are not considered as changes to Notes Tree Node. We instead need to treat the array as it's own Tree node. 
