### PR TITLE
fix(brainstorm): lint and type fixes

### DIFF
--- a/brainstorm/src/app_load.tsx
+++ b/brainstorm/src/app_load.tsx
@@ -1,17 +1,17 @@
+import type { AzureClient } from "@fluidframework/azure-client";
 import type { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
-import { AzureClient } from "@fluidframework/azure-client";
-import { OdspClient } from "@fluidframework/odsp-client/beta";
-import React from "react";
+import type { OdspClient } from "@fluidframework/odsp-client/beta";
+import type { IFluidContainer } from "fluid-framework";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { createRoot } from "react-dom/client";
+
+import { loadFluidData } from "./infra/fluid.js";
 import { ReactApp } from "./react/ux.js";
 import { Items, appTreeConfiguration } from "./schema/app_schema.js";
+import { containerSchema } from "./schema/container_schema.js";
 import { sessionTreeConfiguration } from "./schema/session_schema.js";
 import { createUndoRedoStacks } from "./utils/undo.js";
-import { containerSchema } from "./schema/container_schema.js";
-import { loadFluidData } from "./infra/fluid.js";
-import { IFluidContainer } from "fluid-framework";
 
 export async function loadApp(
 	client: AzureClient | OdspClient,
@@ -39,7 +39,7 @@ export async function loadApp(
 	// create the root element for React
 	const app = document.createElement("div");
 	app.id = "app";
-	document.body.appendChild(app);
+	document.body.append(app);
 	const root = createRoot(app);
 
 	// Create undo/redo stacks for the app

--- a/brainstorm/src/index.tsx
+++ b/brainstorm/src/index.tsx
@@ -3,21 +3,23 @@
  * Licensed under the MIT License.
  */
 
-import { speStart } from "./start/spe_start.js";
 import { anonymousAzureStart } from "./start/azure_start.js";
+import { speStart } from "./start/spe_start.js";
 
 async function start() {
 	const client = process.env.FLUID_CLIENT;
 
 	switch (client) {
-		case "spe":
+		case "spe": {
 			// Start the app in SPE mode
 			await speStart();
 			break;
-		default:
+		}
+		default: {
 			// Start the app in Azure mode
 			await anonymousAzureStart();
 			break;
+		}
 	}
 }
 

--- a/brainstorm/src/infra/azure/azureClientProps.ts
+++ b/brainstorm/src/infra/azure/azureClientProps.ts
@@ -9,8 +9,8 @@ import type {
 	AzureLocalConnectionConfig,
 	ITelemetryBaseLogger,
 } from "@fluidframework/azure-client";
-import { InsecureTokenProvider } from "./azureTokenProvider.js";
-import { AzureFunctionTokenProvider, azureUser, user } from "./azureTokenProvider.js";
+
+import { InsecureTokenProvider, AzureFunctionTokenProvider, azureUser, user } from "./azureTokenProvider.js";
 
 const client = process.env.FLUID_CLIENT;
 const local = client === undefined || client === "local";
@@ -20,12 +20,12 @@ if (local) {
 
 const remoteConnectionConfig: AzureRemoteConnectionConfig = {
 	type: "remote",
-	tenantId: process.env.AZURE_TENANT_ID!,
+	tenantId: process.env.AZURE_TENANT_ID ?? "",
 	tokenProvider: new AzureFunctionTokenProvider(
-		process.env.AZURE_FUNCTION_TOKEN_PROVIDER_URL!,
+		process.env.AZURE_FUNCTION_TOKEN_PROVIDER_URL ?? "",
 		azureUser,
 	),
-	endpoint: process.env.AZURE_ORDERER!,
+	endpoint: process.env.AZURE_ORDERER ?? "",
 };
 
 const localConnectionConfig: AzureLocalConnectionConfig = {
@@ -34,9 +34,9 @@ const localConnectionConfig: AzureLocalConnectionConfig = {
 	endpoint: "http://localhost:7070",
 };
 
-const connectionConfig: AzureRemoteConnectionConfig | AzureLocalConnectionConfig = !local
-	? remoteConnectionConfig
-	: localConnectionConfig;
+const connectionConfig: AzureRemoteConnectionConfig | AzureLocalConnectionConfig = local
+	? localConnectionConfig
+	: remoteConnectionConfig;
 
 export function getClientProps(logger?: ITelemetryBaseLogger): AzureClientProps {
 	return {

--- a/brainstorm/src/infra/azure/azureClientProps.ts
+++ b/brainstorm/src/infra/azure/azureClientProps.ts
@@ -9,8 +9,13 @@ import type {
 	AzureLocalConnectionConfig,
 	ITelemetryBaseLogger,
 } from "@fluidframework/azure-client";
-import { InsecureTokenProvider } from "./azureTokenProvider.js";
-import { AzureFunctionTokenProvider, azureUser, user } from "./azureTokenProvider.js";
+
+import {
+	InsecureTokenProvider,
+	AzureFunctionTokenProvider,
+	azureUser,
+	user,
+} from "./azureTokenProvider.js";
 
 const client = process.env.FLUID_CLIENT;
 const local = client === undefined || client === "local";
@@ -20,12 +25,12 @@ if (local) {
 
 const remoteConnectionConfig: AzureRemoteConnectionConfig = {
 	type: "remote",
-	tenantId: process.env.AZURE_TENANT_ID!,
+	tenantId: process.env.AZURE_TENANT_ID ?? "",
 	tokenProvider: new AzureFunctionTokenProvider(
-		process.env.AZURE_FUNCTION_TOKEN_PROVIDER_URL!,
+		process.env.AZURE_FUNCTION_TOKEN_PROVIDER_URL ?? "",
 		azureUser,
 	),
-	endpoint: process.env.AZURE_ORDERER!,
+	endpoint: process.env.AZURE_ORDERER ?? "",
 };
 
 const localConnectionConfig: AzureLocalConnectionConfig = {
@@ -34,9 +39,9 @@ const localConnectionConfig: AzureLocalConnectionConfig = {
 	endpoint: "http://localhost:7070",
 };
 
-const connectionConfig: AzureRemoteConnectionConfig | AzureLocalConnectionConfig = !local
-	? remoteConnectionConfig
-	: localConnectionConfig;
+const connectionConfig: AzureRemoteConnectionConfig | AzureLocalConnectionConfig = local
+	? localConnectionConfig
+	: remoteConnectionConfig;
 
 export function getClientProps(logger?: ITelemetryBaseLogger): AzureClientProps {
 	return {

--- a/brainstorm/src/infra/azure/azureTokenProvider.ts
+++ b/brainstorm/src/infra/azure/azureTokenProvider.ts
@@ -3,12 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { AzureMember, ITokenProvider, ITokenResponse, IUser } from "@fluidframework/azure-client";
+import type { AzureMember, ITokenProvider, ITokenResponse, IUser } from "@fluidframework/azure-client";
 import { ScopeType } from "@fluidframework/protocol-definitions";
 import axios from "axios";
 import { KJUR as jsrsasign } from "jsrsasign";
-import { v4 as uuid } from "uuid";
 import { uniqueNamesGenerator, names } from "unique-names-generator";
+import { v4 as uuid } from "uuid";
 
 /**
  * Insecure user definition.
@@ -154,7 +154,7 @@ export function generateToken(
 	lifetime: number = 60 * 60,
 	ver = "1.0",
 ): string {
-	let userClaim = user ? user : generateUser();
+	let userClaim = user ?? generateUser();
 	if (userClaim.id === "" || userClaim.id === undefined) {
 		userClaim = generateUser();
 	}

--- a/brainstorm/src/infra/azure/azureTokenProvider.ts
+++ b/brainstorm/src/infra/azure/azureTokenProvider.ts
@@ -3,12 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import { AzureMember, ITokenProvider, ITokenResponse, IUser } from "@fluidframework/azure-client";
+import type {
+	AzureMember,
+	ITokenProvider,
+	ITokenResponse,
+	IUser,
+} from "@fluidframework/azure-client";
 import { ScopeType } from "@fluidframework/protocol-definitions";
 import axios from "axios";
 import { KJUR as jsrsasign } from "jsrsasign";
-import { v4 as uuid } from "uuid";
 import { uniqueNamesGenerator, names } from "unique-names-generator";
+import { v4 as uuid } from "uuid";
 
 /**
  * Insecure user definition.
@@ -154,7 +159,7 @@ export function generateToken(
 	lifetime: number = 60 * 60,
 	ver = "1.0",
 ): string {
-	let userClaim = user ? user : generateUser();
+	let userClaim = user ?? generateUser();
 	if (userClaim.id === "" || userClaim.id === undefined) {
 		userClaim = generateUser();
 	}

--- a/brainstorm/src/infra/fluid.ts
+++ b/brainstorm/src/infra/fluid.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
+import type { AzureClient, AzureContainerServices } from "@fluidframework/azure-client";
 import type { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
-import { AzureClient, AzureContainerServices } from "@fluidframework/azure-client";
-import { ContainerSchema, IFluidContainer } from "fluid-framework";
-import { OdspClient, OdspContainerServices } from "@fluidframework/odsp-client/beta";
+import type { OdspClient, OdspContainerServices } from "@fluidframework/odsp-client/beta";
+import type { ContainerSchema, IFluidContainer } from "fluid-framework";
 
 /**
  * This function will create a container if no container ID is passed.

--- a/brainstorm/src/infra/fluid.ts
+++ b/brainstorm/src/infra/fluid.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
+import { AzureClient, type AzureContainerServices } from "@fluidframework/azure-client";
 import type { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
-import { AzureClient, AzureContainerServices } from "@fluidframework/azure-client";
-import { ContainerSchema, IFluidContainer } from "fluid-framework";
-import { OdspClient, OdspContainerServices } from "@fluidframework/odsp-client/beta";
+import type { OdspClient, OdspContainerServices } from "@fluidframework/odsp-client/beta";
+import type { ContainerSchema, IFluidContainer } from "fluid-framework";
 
 /**
  * This function will create a container if no container ID is passed.

--- a/brainstorm/src/infra/spe/graphHelper.ts
+++ b/brainstorm/src/infra/spe/graphHelper.ts
@@ -1,10 +1,12 @@
-import { PublicClientApplication, InteractionType, AccountInfo } from "@azure/msal-browser";
+import type { PublicClientApplication, AccountInfo } from "@azure/msal-browser";
+import { InteractionType } from "@azure/msal-browser";
 import { Client } from "@microsoft/microsoft-graph-client";
+import type {
+	AuthCodeMSALBrowserAuthenticationProviderOptions} from "@microsoft/microsoft-graph-client/authProviders/authCodeMsalBrowser/index.js";
 import {
-	AuthCodeMSALBrowserAuthenticationProvider,
-	AuthCodeMSALBrowserAuthenticationProviderOptions,
+	AuthCodeMSALBrowserAuthenticationProvider
 } from "@microsoft/microsoft-graph-client/authProviders/authCodeMsalBrowser/index.js";
-import { Site } from "@microsoft/microsoft-graph-types";
+import type { Site } from "@microsoft/microsoft-graph-types";
 
 export interface FileStorageContainer {
 	containerTypeId: string;
@@ -56,19 +58,19 @@ export class GraphHelper {
 		try {
 			const response = await this.graphClient
 				.api("/storage/fileStorage/containers")
-				.filter("containerTypeId eq " + containerTypeId)
+				.filter(`containerTypeId eq ${ containerTypeId}`)
 				.version("beta")
 				.get();
 
 			const fileStorageContainers: FileStorageContainer[] = response.value;
 
-			if (fileStorageContainers.length == 0) {
+			if (fileStorageContainers.length === 0) {
 				throw new Error("TEST: no fileStorageContainers");
 			}
 
 			return fileStorageContainers[0].id;
 		} catch (error) {
-			console.error("Error while fetching file storage container ID: ", error);
+			console.error("Error while fetching file storage container ID:", error);
 			throw error; // re-throw the error if you want it to propagate
 		}
 	}
@@ -97,7 +99,7 @@ export class GraphHelper {
 			.api(`/drives/${driveId}/items/${id}/createLink`)
 			.post(permission);
 
-		console.log("createSharingLink response: ", response.link);
+		console.log("createSharingLink response:", response.link);
 
 		return response.shareId as string;
 	}

--- a/brainstorm/src/infra/spe/graphHelper.ts
+++ b/brainstorm/src/infra/spe/graphHelper.ts
@@ -1,10 +1,9 @@
-import { PublicClientApplication, InteractionType, AccountInfo } from "@azure/msal-browser";
+import type { PublicClientApplication, AccountInfo } from "@azure/msal-browser";
+import { InteractionType } from "@azure/msal-browser";
 import { Client } from "@microsoft/microsoft-graph-client";
-import {
-	AuthCodeMSALBrowserAuthenticationProvider,
-	AuthCodeMSALBrowserAuthenticationProviderOptions,
-} from "@microsoft/microsoft-graph-client/authProviders/authCodeMsalBrowser/index.js";
-import { Site } from "@microsoft/microsoft-graph-types";
+import type { AuthCodeMSALBrowserAuthenticationProviderOptions } from "@microsoft/microsoft-graph-client/authProviders/authCodeMsalBrowser/index.js";
+import { AuthCodeMSALBrowserAuthenticationProvider } from "@microsoft/microsoft-graph-client/authProviders/authCodeMsalBrowser/index.js";
+import type { Site } from "@microsoft/microsoft-graph-types";
 
 export interface FileStorageContainer {
 	containerTypeId: string;
@@ -56,19 +55,19 @@ export class GraphHelper {
 		try {
 			const response = await this.graphClient
 				.api("/storage/fileStorage/containers")
-				.filter("containerTypeId eq " + containerTypeId)
+				.filter(`containerTypeId eq ${containerTypeId}`)
 				.version("beta")
 				.get();
 
 			const fileStorageContainers: FileStorageContainer[] = response.value;
 
-			if (fileStorageContainers.length == 0) {
+			if (fileStorageContainers.length === 0) {
 				throw new Error("TEST: no fileStorageContainers");
 			}
 
 			return fileStorageContainers[0].id;
 		} catch (error) {
-			console.error("Error while fetching file storage container ID: ", error);
+			console.error("Error while fetching file storage container ID:", error);
 			throw error; // re-throw the error if you want it to propagate
 		}
 	}
@@ -97,7 +96,7 @@ export class GraphHelper {
 			.api(`/drives/${driveId}/items/${id}/createLink`)
 			.post(permission);
 
-		console.log("createSharingLink response: ", response.link);
+		console.log("createSharingLink response:", response.link);
 
 		return response.shareId as string;
 	}

--- a/brainstorm/src/infra/spe/speClientProps.ts
+++ b/brainstorm/src/infra/spe/speClientProps.ts
@@ -1,5 +1,5 @@
 import type { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
-import { IOdspTokenProvider, OdspClientProps } from "@fluidframework/odsp-client/beta";
+import type { IOdspTokenProvider, OdspClientProps } from "@fluidframework/odsp-client/beta";
 
 // Create the client props for the Fluid client
 export const getClientProps = (
@@ -9,9 +9,9 @@ export const getClientProps = (
 	logger?: ITelemetryBaseLogger,
 ): OdspClientProps => {
 	const connectionConfig = {
-		tokenProvider: tokenProvider,
-		siteUrl: siteUrl,
-		driveId: driveId,
+		tokenProvider,
+		siteUrl,
+		driveId,
 		filePath: "",
 	};
 

--- a/brainstorm/src/infra/spe/speTokenProvider.ts
+++ b/brainstorm/src/infra/spe/speTokenProvider.ts
@@ -1,9 +1,10 @@
-import {
+import type {
 	AuthenticationResult,
-	InteractionRequiredAuthError,
-	PublicClientApplication,
+	PublicClientApplication} from "@azure/msal-browser";
+import {
+	InteractionRequiredAuthError
 } from "@azure/msal-browser";
-import { IOdspTokenProvider, TokenResponse } from "@fluidframework/odsp-client/beta";
+import type { IOdspTokenProvider, TokenResponse } from "@fluidframework/odsp-client/beta";
 
 // Sample implementation of the IOdspTokenProvider interface
 // This class is used to provide the token for the Fluid container and
@@ -48,7 +49,7 @@ export class SampleOdspTokenProvider implements IOdspTokenProvider {
 					scopes: scope,
 				});
 			} else {
-				throw new Error(`MSAL error: ${error}`);
+				throw new TypeError(`MSAL error: ${error}`);
 			}
 		}
 		return response.accessToken;

--- a/brainstorm/src/infra/spe/speTokenProvider.ts
+++ b/brainstorm/src/infra/spe/speTokenProvider.ts
@@ -1,9 +1,6 @@
-import {
-	AuthenticationResult,
-	InteractionRequiredAuthError,
-	PublicClientApplication,
-} from "@azure/msal-browser";
-import { IOdspTokenProvider, TokenResponse } from "@fluidframework/odsp-client/beta";
+import type { AuthenticationResult, PublicClientApplication } from "@azure/msal-browser";
+import { InteractionRequiredAuthError } from "@azure/msal-browser";
+import type { IOdspTokenProvider, TokenResponse } from "@fluidframework/odsp-client/beta";
 
 // Sample implementation of the IOdspTokenProvider interface
 // This class is used to provide the token for the Fluid container and
@@ -48,7 +45,7 @@ export class SampleOdspTokenProvider implements IOdspTokenProvider {
 					scopes: scope,
 				});
 			} else {
-				throw new Error(`MSAL error: ${error}`);
+				throw new TypeError(`MSAL error: ${error}`);
 			}
 		}
 		return response.accessToken;

--- a/brainstorm/src/infra/tokenProvider.ts
+++ b/brainstorm/src/infra/tokenProvider.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { AzureMember, ITokenProvider, ITokenResponse, IUser } from "@fluidframework/azure-client";
+import type { AzureMember, ITokenProvider, ITokenResponse, IUser } from "@fluidframework/azure-client";
 import { ScopeType } from "@fluidframework/protocol-definitions";
 import axios from "axios";
 import { KJUR as jsrsasign } from "jsrsasign";
@@ -153,7 +153,7 @@ export function generateToken(
 	lifetime: number = 60 * 60,
 	ver = "1.0",
 ): string {
-	let userClaim = user ? user : generateUser();
+	let userClaim = user ?? generateUser();
 	if (userClaim.id === "" || userClaim.id === undefined) {
 		userClaim = generateUser();
 	}

--- a/brainstorm/src/infra/tokenProvider.ts
+++ b/brainstorm/src/infra/tokenProvider.ts
@@ -3,7 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { AzureMember, ITokenProvider, ITokenResponse, IUser } from "@fluidframework/azure-client";
+import type {
+	AzureMember,
+	ITokenProvider,
+	ITokenResponse,
+	IUser,
+} from "@fluidframework/azure-client";
 import { ScopeType } from "@fluidframework/protocol-definitions";
 import axios from "axios";
 import { KJUR as jsrsasign } from "jsrsasign";
@@ -153,7 +158,7 @@ export function generateToken(
 	lifetime: number = 60 * 60,
 	ver = "1.0",
 ): string {
-	let userClaim = user ? user : generateUser();
+	let userClaim = user ?? generateUser();
 	if (userClaim.id === "" || userClaim.id === undefined) {
 		userClaim = generateUser();
 	}

--- a/brainstorm/src/react/buttonux.tsx
+++ b/brainstorm/src/react/buttonux.tsx
@@ -3,9 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import React, { JSX } from "react";
-import { Items, Note } from "../schema/app_schema.js";
-import { moveItem, findNote } from "../utils/app_helpers.js";
 import {
 	ThumbLikeFilled,
 	DismissFilled,
@@ -15,9 +12,16 @@ import {
 	ArrowUndoFilled,
 	ArrowRedoFilled,
 } from "@fluentui/react-icons";
-import { Session } from "../schema/session_schema.js";
-import { getSelectedNotes } from "../utils/session_helpers.js";
 import { Tree } from "fluid-framework";
+import type { JSX } from "react";
+import type React from "react";
+
+import type { Items} from "../schema/app_schema.js";
+import { Note } from "../schema/app_schema.js";
+import type { Session } from "../schema/session_schema.js";
+import { moveItem, findNote } from "../utils/app_helpers.js";
+import { getSelectedNotes } from "../utils/session_helpers.js";
+
 
 export function NewGroupButton(props: {
 	items: Items;
@@ -159,10 +163,10 @@ export function IconButton(props: {
 	return (
 		<button
 			className={
-				props.color +
-				" " +
-				props.background +
-				" hover:bg-gray-600 hover:text-white font-bold px-2 py-1 rounded inline-flex items-center h-6 grow"
+				`${props.color 
+				} ${ 
+				props.background 
+				} hover:bg-gray-600 hover:text-white font-bold px-2 py-1 rounded inline-flex items-center h-6 grow`
 			}
 			onClick={(e) => handleClick(e)}
 		>
@@ -178,11 +182,7 @@ IconButton.defaultProps = {
 };
 
 function IconButtonText(props: { children: React.ReactNode }): JSX.Element {
-	if (props.children == undefined) {
-		return <span></span>;
-	} else {
-		return <span className="text-sm pl-2 leading-none">{props.children}</span>;
-	}
+	return props.children === undefined ? <span></span> : <span className="text-sm pl-2 leading-none">{props.children}</span>;
 }
 
 function MiniX(): JSX.Element {

--- a/brainstorm/src/react/buttonux.tsx
+++ b/brainstorm/src/react/buttonux.tsx
@@ -3,9 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import React, { JSX } from "react";
-import { Items, Note } from "../schema/app_schema.js";
-import { moveItem, findNote } from "../utils/app_helpers.js";
 import {
 	ThumbLikeFilled,
 	DismissFilled,
@@ -15,9 +12,15 @@ import {
 	ArrowUndoFilled,
 	ArrowRedoFilled,
 } from "@fluentui/react-icons";
-import { Session } from "../schema/session_schema.js";
-import { getSelectedNotes } from "../utils/session_helpers.js";
 import { Tree } from "fluid-framework";
+import type { JSX } from "react";
+import type React from "react";
+
+import type { Items } from "../schema/app_schema.js";
+import { Note } from "../schema/app_schema.js";
+import type { Session } from "../schema/session_schema.js";
+import { moveItem, findNote } from "../utils/app_helpers.js";
+import { getSelectedNotes } from "../utils/session_helpers.js";
 
 export function NewGroupButton(props: {
 	items: Items;
@@ -158,12 +161,9 @@ export function IconButton(props: {
 
 	return (
 		<button
-			className={
-				props.color +
-				" " +
-				props.background +
-				" hover:bg-gray-600 hover:text-white font-bold px-2 py-1 rounded inline-flex items-center h-6 grow"
-			}
+			className={`${props.color} ${
+				props.background
+			} hover:bg-gray-600 hover:text-white font-bold px-2 py-1 rounded inline-flex items-center h-6 grow`}
 			onClick={(e) => handleClick(e)}
 		>
 			{props.icon}
@@ -178,11 +178,11 @@ IconButton.defaultProps = {
 };
 
 function IconButtonText(props: { children: React.ReactNode }): JSX.Element {
-	if (props.children == undefined) {
-		return <span></span>;
-	} else {
-		return <span className="text-sm pl-2 leading-none">{props.children}</span>;
-	}
+	return props.children === undefined ? (
+		<span></span>
+	) : (
+		<span className="text-sm pl-2 leading-none">{props.children}</span>
+	);
 }
 
 function MiniX(): JSX.Element {

--- a/brainstorm/src/react/canvasux.tsx
+++ b/brainstorm/src/react/canvasux.tsx
@@ -3,19 +3,24 @@
  * Licensed under the MIT License.
  */
 
-import React, { JSX, useEffect, useState } from "react";
-import { Note, Group, Items } from "../schema/app_schema.js";
-import { Session } from "../schema/session_schema.js";
-import {
-	ConnectionState,
+import type {
 	IFluidContainer,
 	IMember,
 	IServiceAudience,
-	Tree,
-	TreeView,
+	TreeView} from "fluid-framework";
+import {
+	ConnectionState,
+	Tree
 } from "fluid-framework";
-import { GroupView } from "./groupux.js";
-import { AddNoteButton, NoteView, RootNoteWrapper } from "./noteux.js";
+import type { JSX} from "react";
+import { useEffect, useState } from "react";
+
+import type { Items } from "../schema/app_schema.js";
+import { Note, Group } from "../schema/app_schema.js";
+import type { Session } from "../schema/session_schema.js";
+import type { undoRedo } from "../utils/undo.js";
+import { undefinedUserId } from "../utils/utils.js";
+
 import {
 	Floater,
 	NewGroupButton,
@@ -25,8 +30,8 @@ import {
 	UndoButton,
 	RedoButton,
 } from "./buttonux.js";
-import { undefinedUserId } from "../utils/utils.js";
-import { undoRedo } from "../utils/undo.js";
+import { GroupView } from "./groupux.js";
+import { AddNoteButton, NoteView, RootNoteWrapper } from "./noteux.js";
 
 export function Canvas(props: {
 	items: TreeView<typeof Items>;
@@ -56,14 +61,28 @@ export function Canvas(props: {
 
 	useEffect(() => {
 		const updateConnectionState = () => {
-			if (props.container.connectionState === ConnectionState.Connected) {
+			switch (props.container.connectionState) {
+			case ConnectionState.Connected: {
 				props.setConnectionState("connected");
-			} else if (props.container.connectionState === ConnectionState.Disconnected) {
+			
+			break;
+			}
+			case ConnectionState.Disconnected: {
 				props.setConnectionState("disconnected");
-			} else if (props.container.connectionState === ConnectionState.EstablishingConnection) {
+			
+			break;
+			}
+			case ConnectionState.EstablishingConnection: {
 				props.setConnectionState("connecting");
-			} else if (props.container.connectionState === ConnectionState.CatchingUp) {
+			
+			break;
+			}
+			case ConnectionState.CatchingUp: {
 				props.setConnectionState("catching up");
+			
+			break;
+			}
+			// No default
 			}
 		};
 		updateConnectionState();
@@ -76,17 +95,17 @@ export function Canvas(props: {
 	}, []);
 
 	const updateMembers = () => {
-		if (props.audience.getMyself() == undefined) return;
-		if (props.audience.getMyself()?.id == undefined) return;
-		if (props.audience.getMembers() == undefined) return;
+		if (props.audience.getMyself() === undefined) return;
+		if (props.audience.getMyself()?.id === undefined) return;
+		if (props.audience.getMembers() === undefined) return;
 		if (props.container.connectionState !== ConnectionState.Connected) return;
-		if (props.currentUser == undefinedUserId) {
+		if (props.currentUser === undefinedUserId) {
 			const user = props.audience.getMyself()?.id;
 			if (typeof user === "string") {
 				props.setCurrentUser(user);
 			}
 		}
-		props.setFluidMembers(Array.from(props.audience.getMembers().keys()));
+		props.setFluidMembers([...props.audience.getMembers().keys()]);
 	};
 
 	useEffect(() => {

--- a/brainstorm/src/react/canvasux.tsx
+++ b/brainstorm/src/react/canvasux.tsx
@@ -3,19 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import React, { JSX, useEffect, useState } from "react";
-import { Note, Group, Items } from "../schema/app_schema.js";
-import { Session } from "../schema/session_schema.js";
-import {
-	ConnectionState,
-	IFluidContainer,
-	IMember,
-	IServiceAudience,
-	Tree,
-	TreeView,
-} from "fluid-framework";
-import { GroupView } from "./groupux.js";
-import { AddNoteButton, NoteView, RootNoteWrapper } from "./noteux.js";
+import type { IFluidContainer, IMember, IServiceAudience, TreeView } from "fluid-framework";
+import { ConnectionState, Tree } from "fluid-framework";
+import type { JSX } from "react";
+import { useEffect, useState } from "react";
+
+import type { Items } from "../schema/app_schema.js";
+import { Note, Group } from "../schema/app_schema.js";
+import type { Session } from "../schema/session_schema.js";
+import type { undoRedo } from "../utils/undo.js";
+import { undefinedUserId } from "../utils/utils.js";
+
 import {
 	Floater,
 	NewGroupButton,
@@ -25,8 +23,8 @@ import {
 	UndoButton,
 	RedoButton,
 } from "./buttonux.js";
-import { undefinedUserId } from "../utils/utils.js";
-import { undoRedo } from "../utils/undo.js";
+import { GroupView } from "./groupux.js";
+import { AddNoteButton, NoteView, RootNoteWrapper } from "./noteux.js";
 
 export function Canvas(props: {
 	items: TreeView<typeof Items>;
@@ -56,14 +54,28 @@ export function Canvas(props: {
 
 	useEffect(() => {
 		const updateConnectionState = () => {
-			if (props.container.connectionState === ConnectionState.Connected) {
-				props.setConnectionState("connected");
-			} else if (props.container.connectionState === ConnectionState.Disconnected) {
-				props.setConnectionState("disconnected");
-			} else if (props.container.connectionState === ConnectionState.EstablishingConnection) {
-				props.setConnectionState("connecting");
-			} else if (props.container.connectionState === ConnectionState.CatchingUp) {
-				props.setConnectionState("catching up");
+			switch (props.container.connectionState) {
+				case ConnectionState.Connected: {
+					props.setConnectionState("connected");
+
+					break;
+				}
+				case ConnectionState.Disconnected: {
+					props.setConnectionState("disconnected");
+
+					break;
+				}
+				case ConnectionState.EstablishingConnection: {
+					props.setConnectionState("connecting");
+
+					break;
+				}
+				case ConnectionState.CatchingUp: {
+					props.setConnectionState("catching up");
+
+					break;
+				}
+				// No default
 			}
 		};
 		updateConnectionState();
@@ -76,17 +88,17 @@ export function Canvas(props: {
 	}, []);
 
 	const updateMembers = () => {
-		if (props.audience.getMyself() == undefined) return;
-		if (props.audience.getMyself()?.id == undefined) return;
-		if (props.audience.getMembers() == undefined) return;
+		if (props.audience.getMyself() === undefined) return;
+		if (props.audience.getMyself()?.id === undefined) return;
+		if (props.audience.getMembers() === undefined) return;
 		if (props.container.connectionState !== ConnectionState.Connected) return;
-		if (props.currentUser == undefinedUserId) {
+		if (props.currentUser === undefinedUserId) {
 			const user = props.audience.getMyself()?.id;
 			if (typeof user === "string") {
 				props.setCurrentUser(user);
 			}
 		}
-		props.setFluidMembers(Array.from(props.audience.getMembers().keys()));
+		props.setFluidMembers([...props.audience.getMembers().keys()]);
 	};
 
 	useEffect(() => {

--- a/brainstorm/src/react/groupux.tsx
+++ b/brainstorm/src/react/groupux.tsx
@@ -3,15 +3,21 @@
  * Licensed under the MIT License.
  */
 
-import React, { JSX, useEffect, useState } from "react";
-import { Group, Items, Note } from "../schema/app_schema.js";
-import { moveItem } from "../utils/app_helpers.js";
-import { ConnectableElement, useDrag, useDrop } from "react-dnd";
-import { DeleteButton } from "./buttonux.js";
-import { dragType } from "../utils/utils.js";
-import { Session } from "../schema/session_schema.js";
-import { ItemsView } from "./canvasux.js";
 import { Tree } from "fluid-framework";
+import type { JSX} from "react";
+import type React from "react";
+import { useEffect, useState } from "react";
+import type { ConnectableElement} from "react-dnd";
+import { useDrag, useDrop } from "react-dnd";
+
+import { Group, Items, Note } from "../schema/app_schema.js";
+import type { Session } from "../schema/session_schema.js";
+import { moveItem } from "../utils/app_helpers.js";
+import { dragType } from "../utils/utils.js";
+
+import { DeleteButton } from "./buttonux.js";
+import { ItemsView } from "./canvasux.js";
+
 
 export function GroupView(props: {
 	group: Group;
@@ -104,14 +110,14 @@ export function GroupView(props: {
 			onClick={(e) => handleClick(e)}
 			ref={attachRef}
 			className={
-				"transition-all border-l-4 border-dashed " +
-				(isOver && canDrop ? "border-gray-500" : "border-transparent")
+				`transition-all border-l-4 border-dashed ${ 
+				isOver && canDrop ? "border-gray-500" : "border-transparent"}`
 			}
 		>
 			<div
 				className={
-					"p-2 bg-gray-200 min-h-64 transition-all " +
-					(isOver && canDrop ? "translate-x-3" : "")
+					`p-2 bg-gray-200 min-h-64 transition-all ${ 
+					isOver && canDrop ? "translate-x-3" : ""}`
 				}
 				aria-label="Note Group"
 			>

--- a/brainstorm/src/react/groupux.tsx
+++ b/brainstorm/src/react/groupux.tsx
@@ -3,15 +3,20 @@
  * Licensed under the MIT License.
  */
 
-import React, { JSX, useEffect, useState } from "react";
-import { Group, Items, Note } from "../schema/app_schema.js";
-import { moveItem } from "../utils/app_helpers.js";
-import { ConnectableElement, useDrag, useDrop } from "react-dnd";
-import { DeleteButton } from "./buttonux.js";
-import { dragType } from "../utils/utils.js";
-import { Session } from "../schema/session_schema.js";
-import { ItemsView } from "./canvasux.js";
 import { Tree } from "fluid-framework";
+import type { JSX } from "react";
+import type React from "react";
+import { useEffect, useState } from "react";
+import type { ConnectableElement } from "react-dnd";
+import { useDrag, useDrop } from "react-dnd";
+
+import { Group, Items, Note } from "../schema/app_schema.js";
+import type { Session } from "../schema/session_schema.js";
+import { moveItem } from "../utils/app_helpers.js";
+import { dragType } from "../utils/utils.js";
+
+import { DeleteButton } from "./buttonux.js";
+import { ItemsView } from "./canvasux.js";
 
 export function GroupView(props: {
 	group: Group;
@@ -103,16 +108,14 @@ export function GroupView(props: {
 		<div
 			onClick={(e) => handleClick(e)}
 			ref={attachRef}
-			className={
-				"transition-all border-l-4 border-dashed " +
-				(isOver && canDrop ? "border-gray-500" : "border-transparent")
-			}
+			className={`transition-all border-l-4 border-dashed ${
+				isOver && canDrop ? "border-gray-500" : "border-transparent"
+			}`}
 		>
 			<div
-				className={
-					"p-2 bg-gray-200 min-h-64 transition-all " +
-					(isOver && canDrop ? "translate-x-3" : "")
-				}
+				className={`p-2 bg-gray-200 min-h-64 transition-all ${
+					isOver && canDrop ? "translate-x-3" : ""
+				}`}
 				aria-label="Note Group"
 			>
 				<GroupToolbar

--- a/brainstorm/src/react/noteux.tsx
+++ b/brainstorm/src/react/noteux.tsx
@@ -3,16 +3,22 @@
  * Licensed under the MIT License.
  */
 
-import React, { JSX, RefObject, useEffect, useRef, useState } from "react";
-import { Note, Group, Items } from "../schema/app_schema.js";
-import { moveItem } from "../utils/app_helpers.js";
-import { dragType, getRotation, selectAction } from "../utils/utils.js";
-import { testRemoteNoteSelection, updateRemoteNoteSelection } from "../utils/session_helpers.js";
-import { ConnectableElement, useDrag, useDrop } from "react-dnd";
-import { useTransition } from "react-transition-state";
 import { Tree } from "fluid-framework";
+import type { JSX, RefObject} from "react";
+import type React from "react";
+import { useEffect, useRef, useState } from "react";
+import type { ConnectableElement} from "react-dnd";
+import { useDrag, useDrop } from "react-dnd";
+import { useTransition } from "react-transition-state";
+
+import { Note, Group, Items } from "../schema/app_schema.js";
+import type { Session } from "../schema/session_schema.js";
+import { moveItem } from "../utils/app_helpers.js";
+import { testRemoteNoteSelection, updateRemoteNoteSelection } from "../utils/session_helpers.js";
+import { dragType, getRotation, selectAction } from "../utils/utils.js";
+
 import { IconButton, MiniThumb, DeleteButton } from "./buttonux.js";
-import { Session } from "../schema/session_schema.js";
+
 
 export function RootNoteWrapper(props: {
 	note: Note;
@@ -194,17 +200,17 @@ export function NoteView(props: {
 				<div
 					style={{ opacity: isDragging ? 0.5 : 1 }}
 					className={
-						"relative transition-all flex flex-col " +
-						bgColor +
-						" h-48 w-48 shadow-md hover:shadow-lg hover:rotate-0 p-2 " +
-						rotation +
-						" " +
-						(isOver && canDrop ? "translate-x-3" : "")
+						`relative transition-all flex flex-col ${ 
+						bgColor 
+						} h-48 w-48 shadow-md hover:shadow-lg hover:rotate-0 p-2 ${ 
+						rotation 
+						} ${ 
+						isOver && canDrop ? "translate-x-3" : ""}`
 					}
 					aria-label="Note"
 				>
 					<NoteToolbar
-						voted={props.note.votes.indexOf(props.clientId) > -1}
+						voted={props.note.votes.includes(props.clientId)}
 						toggleVote={() => props.note.toggleVote(props.clientId)}
 						voteCount={noteVoteCount}
 						deleteNote={props.note.delete}
@@ -222,13 +228,9 @@ export function NoteView(props: {
 }
 
 function NoteSelection(props: { show: boolean }): JSX.Element {
-	if (props.show) {
-		return (
+	return props.show ? (
 			<div className="absolute -top-2 -left-2 h-52 w-52 rounded border-dashed border-indigo-800 border-4" />
-		);
-	} else {
-		return <></>;
-	}
+		) : <></>;
 }
 
 function NoteTextArea(props: {
@@ -316,18 +318,18 @@ export function AddNoteButton(props: { target: Items; clientId: string }): JSX.E
 			<div
 				className={
 					isActive
-						? hoverEffectStyle + "border-gray-500"
-						: hoverEffectStyle + "border-transparent"
+						? `${hoverEffectStyle }border-gray-500`
+						: `${hoverEffectStyle }border-transparent`
 				}
 			></div>
 			<div
 				ref={drop as unknown as RefObject<HTMLDivElement>}
 				className={
-					"transition-all text-2xl place-content-center font-bold flex flex-col text-center cursor-pointer bg-transparent border-white border-dashed border-8 " +
-					size +
-					" p-4 hover:border-black" +
-					" " +
-					(isActive ? "translate-x-3" : "")
+					`transition-all text-2xl place-content-center font-bold flex flex-col text-center cursor-pointer bg-transparent border-white border-dashed border-8 ${ 
+					size 
+					} p-4 hover:border-black` +
+					` ${ 
+					isActive ? "translate-x-3" : ""}`
 				}
 				onClick={(e) => handleClick(e)}
 			>
@@ -343,19 +345,11 @@ function LikeButton(props: {
 	voteCount: number;
 }): JSX.Element {
 	const setColor = () => {
-		if (props.voted) {
-			return "text-white";
-		} else {
-			return undefined;
-		}
+		return props.voted ? "text-white" : undefined;
 	};
 
 	const setBackground = () => {
-		if (props.voted) {
-			return "bg-green-600";
-		} else {
-			return undefined;
-		}
+		return props.voted ? "bg-green-600" : undefined;
 	};
 
 	return (

--- a/brainstorm/src/react/noteux.tsx
+++ b/brainstorm/src/react/noteux.tsx
@@ -3,16 +3,21 @@
  * Licensed under the MIT License.
  */
 
-import React, { JSX, RefObject, useEffect, useRef, useState } from "react";
-import { Note, Group, Items } from "../schema/app_schema.js";
-import { moveItem } from "../utils/app_helpers.js";
-import { dragType, getRotation, selectAction } from "../utils/utils.js";
-import { testRemoteNoteSelection, updateRemoteNoteSelection } from "../utils/session_helpers.js";
-import { ConnectableElement, useDrag, useDrop } from "react-dnd";
-import { useTransition } from "react-transition-state";
 import { Tree } from "fluid-framework";
+import type { JSX, RefObject } from "react";
+import type React from "react";
+import { useEffect, useRef, useState } from "react";
+import type { ConnectableElement } from "react-dnd";
+import { useDrag, useDrop } from "react-dnd";
+import { useTransition } from "react-transition-state";
+
+import { Note, Group, Items } from "../schema/app_schema.js";
+import type { Session } from "../schema/session_schema.js";
+import { moveItem } from "../utils/app_helpers.js";
+import { testRemoteNoteSelection, updateRemoteNoteSelection } from "../utils/session_helpers.js";
+import { dragType, getRotation, selectAction } from "../utils/utils.js";
+
 import { IconButton, MiniThumb, DeleteButton } from "./buttonux.js";
-import { Session } from "../schema/session_schema.js";
 
 export function RootNoteWrapper(props: {
 	note: Note;
@@ -193,18 +198,15 @@ export function NoteView(props: {
 			>
 				<div
 					style={{ opacity: isDragging ? 0.5 : 1 }}
-					className={
-						"relative transition-all flex flex-col " +
-						bgColor +
-						" h-48 w-48 shadow-md hover:shadow-lg hover:rotate-0 p-2 " +
-						rotation +
-						" " +
-						(isOver && canDrop ? "translate-x-3" : "")
-					}
+					className={`relative transition-all flex flex-col ${
+						bgColor
+					} h-48 w-48 shadow-md hover:shadow-lg hover:rotate-0 p-2 ${rotation} ${
+						isOver && canDrop ? "translate-x-3" : ""
+					}`}
 					aria-label="Note"
 				>
 					<NoteToolbar
-						voted={props.note.votes.indexOf(props.clientId) > -1}
+						voted={props.note.votes.includes(props.clientId)}
 						toggleVote={() => props.note.toggleVote(props.clientId)}
 						voteCount={noteVoteCount}
 						deleteNote={props.note.delete}
@@ -222,13 +224,11 @@ export function NoteView(props: {
 }
 
 function NoteSelection(props: { show: boolean }): JSX.Element {
-	if (props.show) {
-		return (
-			<div className="absolute -top-2 -left-2 h-52 w-52 rounded border-dashed border-indigo-800 border-4" />
-		);
-	} else {
-		return <></>;
-	}
+	return props.show ? (
+		<div className="absolute -top-2 -left-2 h-52 w-52 rounded border-dashed border-indigo-800 border-4" />
+	) : (
+		<></>
+	);
 }
 
 function NoteTextArea(props: {
@@ -316,18 +316,16 @@ export function AddNoteButton(props: { target: Items; clientId: string }): JSX.E
 			<div
 				className={
 					isActive
-						? hoverEffectStyle + "border-gray-500"
-						: hoverEffectStyle + "border-transparent"
+						? `${hoverEffectStyle}border-gray-500`
+						: `${hoverEffectStyle}border-transparent`
 				}
 			></div>
 			<div
 				ref={drop as unknown as RefObject<HTMLDivElement>}
 				className={
-					"transition-all text-2xl place-content-center font-bold flex flex-col text-center cursor-pointer bg-transparent border-white border-dashed border-8 " +
-					size +
-					" p-4 hover:border-black" +
-					" " +
-					(isActive ? "translate-x-3" : "")
+					`transition-all text-2xl place-content-center font-bold flex flex-col text-center cursor-pointer bg-transparent border-white border-dashed border-8 ${
+						size
+					} p-4 hover:border-black` + ` ${isActive ? "translate-x-3" : ""}`
 				}
 				onClick={(e) => handleClick(e)}
 			>
@@ -343,19 +341,11 @@ function LikeButton(props: {
 	voteCount: number;
 }): JSX.Element {
 	const setColor = () => {
-		if (props.voted) {
-			return "text-white";
-		} else {
-			return undefined;
-		}
+		return props.voted ? "text-white" : undefined;
 	};
 
 	const setBackground = () => {
-		if (props.voted) {
-			return "bg-green-600";
-		} else {
-			return undefined;
-		}
+		return props.voted ? "bg-green-600" : undefined;
 	};
 
 	return (

--- a/brainstorm/src/react/ux.tsx
+++ b/brainstorm/src/react/ux.tsx
@@ -3,14 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import React, { JSX, useEffect, useState } from "react";
-import { Items } from "../schema/app_schema.js";
-import { Session } from "../schema/session_schema.js";
+import type { IFluidContainer, IMember, IServiceAudience, TreeView } from "fluid-framework";
+import type { JSX} from "react";
+import { useEffect, useState } from "react";
+
 import "../output.css";
-import { IFluidContainer, IMember, IServiceAudience, TreeView } from "fluid-framework";
+import type { Items } from "../schema/app_schema.js";
+import type { Session } from "../schema/session_schema.js";
+import type { undoRedo } from "../utils/undo.js";
 import { undefinedUserId } from "../utils/utils.js";
+
 import { Canvas } from "./canvasux.js";
-import { undoRedo } from "../utils/undo.js";
 
 export function ReactApp(props: {
 	items: TreeView<typeof Items>;

--- a/brainstorm/src/react/ux.tsx
+++ b/brainstorm/src/react/ux.tsx
@@ -3,14 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import React, { JSX, useEffect, useState } from "react";
-import { Items } from "../schema/app_schema.js";
-import { Session } from "../schema/session_schema.js";
+import type { IFluidContainer, IMember, IServiceAudience, TreeView } from "fluid-framework";
+import type { JSX } from "react";
+import { useEffect, useState } from "react";
+
 import "../output.css";
-import { IFluidContainer, IMember, IServiceAudience, TreeView } from "fluid-framework";
+import type { Items } from "../schema/app_schema.js";
+import type { Session } from "../schema/session_schema.js";
+import type { undoRedo } from "../utils/undo.js";
 import { undefinedUserId } from "../utils/utils.js";
+
 import { Canvas } from "./canvasux.js";
-import { undoRedo } from "../utils/undo.js";
 
 export function ReactApp(props: {
 	items: TreeView<typeof Items>;

--- a/brainstorm/src/schema/app_schema.ts
+++ b/brainstorm/src/schema/app_schema.ts
@@ -3,11 +3,12 @@
  * Licensed under the MIT License.
  */
 
+import type {
+	ValidateRecursiveSchema} from "fluid-framework";
 import {
 	TreeViewConfiguration,
 	SchemaFactory,
-	Tree,
-	ValidateRecursiveSchema,
+	Tree
 } from "fluid-framework";
 import { v4 as uuid } from "uuid";
 
@@ -42,12 +43,12 @@ export class Note extends sf.object(
 ) {
 	// Update the note text and also update the timestamp in the note
 	public readonly updateText = (text: string) => {
-		this.lastChanged = new Date().getTime();
+		this.lastChanged = Date.now();
 		this.text = text;
 	};
 
 	public readonly toggleVote = (user: string) => {
-		this.lastChanged = new Date().getTime();
+		this.lastChanged = Date.now();
 		const index = this.votes.indexOf(user);
 		if (index > -1) {
 			this.votes.removeAt(index);
@@ -73,7 +74,7 @@ export class Note extends sf.object(
 // Schema for a list of Notes and Groups.
 export class Items extends sf.arrayRecursive("Items", [() => Group, Note]) {
 	public readonly addNode = (author: string) => {
-		const timeStamp = new Date().getTime();
+		const timeStamp = Date.now();
 
 		// Define the note to add to the SharedTree - this must conform to
 		// the schema definition of a note
@@ -109,7 +110,7 @@ export class Items extends sf.arrayRecursive("Items", [() => Group, Note]) {
 	// Due to limitations of TypeScript, recursive schema may not produce type errors when declared incorrectly.
 	// Using ValidateRecursiveSchema helps ensure that mistakes made in the definition of a recursive schema (like `Items`)
 	// will introduce a compile error.
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	 
 	type _check = ValidateRecursiveSchema<typeof Items>;
 }
 
@@ -131,7 +132,7 @@ export class Group extends sf.objectRecursive("Group", {
 			// Run the deletion as a transaction to ensure that the tree is in a consistent state
 			Tree.runTransaction(parent, () => {
 				// Move the children of the group to the parent
-				if (this.items.length !== 0) {
+				if (this.items.length > 0) {
 					const index = parent.indexOf(this);
 					parent.moveRangeToIndex(index, 0, this.items.length, this.items);
 				}
@@ -145,7 +146,7 @@ export class Group extends sf.objectRecursive("Group", {
 }
 
 {
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	 
 	type _check = ValidateRecursiveSchema<typeof Group>;
 }
 

--- a/brainstorm/src/schema/app_schema.ts
+++ b/brainstorm/src/schema/app_schema.ts
@@ -3,12 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import {
-	TreeViewConfiguration,
-	SchemaFactory,
-	Tree,
-	ValidateRecursiveSchema,
-} from "fluid-framework";
+import type { ValidateRecursiveSchema } from "fluid-framework";
+import { TreeViewConfiguration, SchemaFactory, Tree } from "fluid-framework";
 import { v4 as uuid } from "uuid";
 
 // Schema is defined using a factory object that generates classes for objects as well
@@ -42,12 +38,12 @@ export class Note extends sf.object(
 ) {
 	// Update the note text and also update the timestamp in the note
 	public readonly updateText = (text: string) => {
-		this.lastChanged = new Date().getTime();
+		this.lastChanged = Date.now();
 		this.text = text;
 	};
 
 	public readonly toggleVote = (user: string) => {
-		this.lastChanged = new Date().getTime();
+		this.lastChanged = Date.now();
 		const index = this.votes.indexOf(user);
 		if (index > -1) {
 			this.votes.removeAt(index);
@@ -73,7 +69,7 @@ export class Note extends sf.object(
 // Schema for a list of Notes and Groups.
 export class Items extends sf.arrayRecursive("Items", [() => Group, Note]) {
 	public readonly addNode = (author: string) => {
-		const timeStamp = new Date().getTime();
+		const timeStamp = Date.now();
 
 		// Define the note to add to the SharedTree - this must conform to
 		// the schema definition of a note
@@ -131,7 +127,7 @@ export class Group extends sf.objectRecursive("Group", {
 			// Run the deletion as a transaction to ensure that the tree is in a consistent state
 			Tree.runTransaction(parent, () => {
 				// Move the children of the group to the parent
-				if (this.items.length !== 0) {
+				if (this.items.length > 0) {
 					const index = parent.indexOf(this);
 					parent.moveRangeToIndex(index, 0, this.items.length, this.items);
 				}

--- a/brainstorm/src/schema/container_schema.ts
+++ b/brainstorm/src/schema/container_schema.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { ContainerSchema, SharedTree } from "fluid-framework";
+import type { ContainerSchema} from "fluid-framework";
+import { SharedTree } from "fluid-framework";
 
 // Define the schema of our Container. This includes the DDSes/DataObjects
 // that we want to create dynamically and any

--- a/brainstorm/src/schema/container_schema.ts
+++ b/brainstorm/src/schema/container_schema.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { ContainerSchema, SharedTree } from "fluid-framework";
+import type { ContainerSchema } from "fluid-framework";
+import { SharedTree } from "fluid-framework";
 
 // Define the schema of our Container. This includes the DDSes/DataObjects
 // that we want to create dynamically and any

--- a/brainstorm/src/start/azure_start.ts
+++ b/brainstorm/src/start/azure_start.ts
@@ -1,16 +1,17 @@
 import { AzureClient } from "@fluidframework/azure-client";
+import { AttachState } from "fluid-framework";
+
 import { loadApp } from "../app_load.js";
 import { getClientProps } from "../infra/azure/azureClientProps.js";
-import { AttachState } from "fluid-framework";
 
 export async function anonymousAzureStart() {
 	// Get the root container id from the URL
 	// If there is no container id, then the app will make
 	// a new container.
-	let containerId = location.hash.substring(1);
+	let containerId = location.hash.slice(1);
 
 	// Initialize Devtools logger if in development mode
-	let telemetryLogger = undefined;
+	let telemetryLogger;
 	if (process.env.NODE_ENV === "development") {
 		const { createDevtoolsLogger } = await import("@fluidframework/devtools/beta");
 		telemetryLogger = createDevtoolsLogger();
@@ -29,6 +30,6 @@ export async function anonymousAzureStart() {
 		containerId = await container.attach();
 
 		// The newly attached container is given a unique ID that can be used to access the container in another session
-		history.replaceState(undefined, "", "#" + containerId);
+		history.replaceState(undefined, "", `#${ containerId}`);
 	}
 }

--- a/brainstorm/src/start/azure_start.ts
+++ b/brainstorm/src/start/azure_start.ts
@@ -1,16 +1,17 @@
 import { AzureClient } from "@fluidframework/azure-client";
+import { AttachState } from "fluid-framework";
+
 import { loadApp } from "../app_load.js";
 import { getClientProps } from "../infra/azure/azureClientProps.js";
-import { AttachState } from "fluid-framework";
 
 export async function anonymousAzureStart() {
 	// Get the root container id from the URL
 	// If there is no container id, then the app will make
 	// a new container.
-	let containerId = location.hash.substring(1);
+	let containerId = location.hash.slice(1);
 
 	// Initialize Devtools logger if in development mode
-	let telemetryLogger = undefined;
+	let telemetryLogger;
 	if (process.env.NODE_ENV === "development") {
 		const { createDevtoolsLogger } = await import("@fluidframework/devtools/beta");
 		telemetryLogger = createDevtoolsLogger();
@@ -29,6 +30,6 @@ export async function anonymousAzureStart() {
 		containerId = await container.attach();
 
 		// The newly attached container is given a unique ID that can be used to access the container in another session
-		history.replaceState(undefined, "", "#" + containerId);
+		history.replaceState(undefined, "", `#${containerId}`);
 	}
 }

--- a/brainstorm/src/start/error_ux.tsx
+++ b/brainstorm/src/start/error_ux.tsx
@@ -1,11 +1,10 @@
-import React from "react";
 import { createRoot } from "react-dom/client";
 
 export function showErrorMessage(message?: string, ...optionalParams: string[]) {
 	// create the root element for React
 	const error = document.createElement("div");
 	error.id = "app";
-	document.body.appendChild(error);
+	document.body.append(error);
 	const root = createRoot(error);
 
 	// Render the error message

--- a/brainstorm/src/start/spe_start.ts
+++ b/brainstorm/src/start/spe_start.ts
@@ -1,31 +1,31 @@
-import { AccountInfo, PublicClientApplication } from "@azure/msal-browser";
-import { authHelper } from "../infra/spe/authHelper.js";
-import { showErrorMessage } from "./error_ux.js";
+import type { AccountInfo, PublicClientApplication } from "@azure/msal-browser";
 import { OdspClient } from "@fluidframework/odsp-client/beta";
+import { AttachState } from "fluid-framework";
+
+import { loadApp } from "../app_load.js";
+import { authHelper } from "../infra/spe/authHelper.js";
 import { GraphHelper } from "../infra/spe/graphHelper.js";
 import { getClientProps } from "../infra/spe/speClientProps.js";
 import { SampleOdspTokenProvider } from "../infra/spe/speTokenProvider.js";
-import { loadApp } from "../app_load.js";
-import { AttachState } from "fluid-framework";
+
+import { showErrorMessage } from "./error_ux.js";
+
 
 export async function speStart() {
 	const msalInstance = await authHelper();
 
 	// Handle the login redirect flows
 	const tokenResponse = await msalInstance.handleRedirectPromise().catch((error: Error) => {
-		console.log("Error in handleRedirectPromise: " + error.message);
+		console.log(`Error in handleRedirectPromise: ${ error.message}`);
 	});
 
 	// If the tokenResponse is not null, then the user is signed in
 	// and the tokenResponse is the result of the redirect.
-	if (tokenResponse !== null) {
-		const account = msalInstance.getAllAccounts()[0];
-		signedInSpeStart(msalInstance, account);
-	} else {
+	if (tokenResponse === null) {
 		const currentAccounts = msalInstance.getAllAccounts();
 		if (currentAccounts.length === 0) {
 			// no accounts signed-in, attempt to sign a user in
-			msalInstance.loginRedirect({
+			await msalInstance.loginRedirect({
 				scopes: ["FileStorageContainer.Selected", "Files.ReadWrite"],
 			});
 		} else if (currentAccounts.length > 1 || currentAccounts.length === 1) {
@@ -34,8 +34,11 @@ export async function speStart() {
 			// this is just a sample. But a real app would need to handle the multiple accounts case.
 			// For now, just use the first account.
 			const account = msalInstance.getAllAccounts()[0];
-			signedInSpeStart(msalInstance, account);
+			await signedInSpeStart(msalInstance, account);
 		}
+	} else {
+		const account = msalInstance.getAllAccounts()[0];
+		await signedInSpeStart(msalInstance, account);
 	}
 }
 
@@ -54,7 +57,7 @@ async function signedInSpeStart(msalInstance: PublicClientApplication, account: 
 	// and the Fluid container id. If there is no hash, then the app will create a new Fluid container
 	// in a later step.
 	const getContainerInfo = async () => {
-		const shareId = location.hash.substring(1);
+		const shareId = location.hash.slice(1);
 		if (shareId.length > 0) {
 			try {
 				return await graphHelper.getSharedItem(shareId);
@@ -101,7 +104,7 @@ async function signedInSpeStart(msalInstance: PublicClientApplication, account: 
 	}
 
 	// Initialize Devtools logger if in development mode
-	let telemetryLogger = undefined;
+	let telemetryLogger;
 	if (process.env.NODE_ENV === "development") {
 		const { createDevtoolsLogger } = await import("@fluidframework/devtools/beta");
 		telemetryLogger = createDevtoolsLogger();
@@ -141,6 +144,6 @@ async function signedInSpeStart(msalInstance: PublicClientApplication, account: 
 		);
 
 		// Set the URL hash to the sharing id.
-		history.replaceState(undefined, "", "#" + shareId);
+		history.replaceState(undefined, "", `#${ shareId}`);
 	}
 }

--- a/brainstorm/src/start/spe_start.ts
+++ b/brainstorm/src/start/spe_start.ts
@@ -1,31 +1,30 @@
-import { AccountInfo, PublicClientApplication } from "@azure/msal-browser";
-import { authHelper } from "../infra/spe/authHelper.js";
-import { showErrorMessage } from "./error_ux.js";
+import type { AccountInfo, PublicClientApplication } from "@azure/msal-browser";
 import { OdspClient } from "@fluidframework/odsp-client/beta";
+import { AttachState } from "fluid-framework";
+
+import { loadApp } from "../app_load.js";
+import { authHelper } from "../infra/spe/authHelper.js";
 import { GraphHelper } from "../infra/spe/graphHelper.js";
 import { getClientProps } from "../infra/spe/speClientProps.js";
 import { SampleOdspTokenProvider } from "../infra/spe/speTokenProvider.js";
-import { loadApp } from "../app_load.js";
-import { AttachState } from "fluid-framework";
+
+import { showErrorMessage } from "./error_ux.js";
 
 export async function speStart() {
 	const msalInstance = await authHelper();
 
 	// Handle the login redirect flows
 	const tokenResponse = await msalInstance.handleRedirectPromise().catch((error: Error) => {
-		console.log("Error in handleRedirectPromise: " + error.message);
+		console.log(`Error in handleRedirectPromise: ${error.message}`);
 	});
 
 	// If the tokenResponse is not null, then the user is signed in
 	// and the tokenResponse is the result of the redirect.
-	if (tokenResponse !== null) {
-		const account = msalInstance.getAllAccounts()[0];
-		signedInSpeStart(msalInstance, account);
-	} else {
+	if (tokenResponse === null) {
 		const currentAccounts = msalInstance.getAllAccounts();
 		if (currentAccounts.length === 0) {
 			// no accounts signed-in, attempt to sign a user in
-			msalInstance.loginRedirect({
+			await msalInstance.loginRedirect({
 				scopes: ["FileStorageContainer.Selected", "Files.ReadWrite"],
 			});
 		} else if (currentAccounts.length > 1 || currentAccounts.length === 1) {
@@ -34,8 +33,11 @@ export async function speStart() {
 			// this is just a sample. But a real app would need to handle the multiple accounts case.
 			// For now, just use the first account.
 			const account = msalInstance.getAllAccounts()[0];
-			signedInSpeStart(msalInstance, account);
+			await signedInSpeStart(msalInstance, account);
 		}
+	} else {
+		const account = msalInstance.getAllAccounts()[0];
+		await signedInSpeStart(msalInstance, account);
 	}
 }
 
@@ -54,7 +56,7 @@ async function signedInSpeStart(msalInstance: PublicClientApplication, account: 
 	// and the Fluid container id. If there is no hash, then the app will create a new Fluid container
 	// in a later step.
 	const getContainerInfo = async () => {
-		const shareId = location.hash.substring(1);
+		const shareId = location.hash.slice(1);
 		if (shareId.length > 0) {
 			try {
 				return await graphHelper.getSharedItem(shareId);
@@ -101,7 +103,7 @@ async function signedInSpeStart(msalInstance: PublicClientApplication, account: 
 	}
 
 	// Initialize Devtools logger if in development mode
-	let telemetryLogger = undefined;
+	let telemetryLogger;
 	if (process.env.NODE_ENV === "development") {
 		const { createDevtoolsLogger } = await import("@fluidframework/devtools/beta");
 		telemetryLogger = createDevtoolsLogger();
@@ -141,6 +143,6 @@ async function signedInSpeStart(msalInstance: PublicClientApplication, account: 
 		);
 
 		// Set the URL hash to the sharing id.
-		history.replaceState(undefined, "", "#" + shareId);
+		history.replaceState(undefined, "", `#${shareId}`);
 	}
 }

--- a/brainstorm/src/utils/app_helpers.ts
+++ b/brainstorm/src/utils/app_helpers.ts
@@ -4,7 +4,9 @@
  */
 
 import { Tree, TreeStatus } from "fluid-framework";
-import { Note, Group, Items } from "../schema/app_schema.js";
+
+import type { Group} from "../schema/app_schema.js";
+import { Note, Items } from "../schema/app_schema.js";
 
 // Move a note from one position in a sequence to another position in the same sequence or
 // in a different sequence. The index being passed here is the desired index after the move.
@@ -14,8 +16,8 @@ export function moveItem(item: Note | Group, destinationIndex: number, destinati
 	// is asynchronous - the state may have changed during the drag but this function
 	// is operating based on the state at the moment the drag began
 	if (
-		Tree.status(destination) != TreeStatus.InDocument ||
-		Tree.status(item) != TreeStatus.InDocument
+		Tree.status(destination) !== TreeStatus.InDocument ||
+		Tree.status(item) !== TreeStatus.InDocument
 	)
 		return;
 
@@ -25,7 +27,7 @@ export function moveItem(item: Note | Group, destinationIndex: number, destinati
 
 	const index = source.indexOf(item);
 
-	if (destinationIndex == Infinity) {
+	if (destinationIndex === Infinity) {
 		destination.moveToEnd(index, source);
 	} else {
 		// test that the destination index is valid

--- a/brainstorm/src/utils/app_helpers.ts
+++ b/brainstorm/src/utils/app_helpers.ts
@@ -4,7 +4,9 @@
  */
 
 import { Tree, TreeStatus } from "fluid-framework";
-import { Note, Group, Items } from "../schema/app_schema.js";
+
+import type { Group } from "../schema/app_schema.js";
+import { Note, Items } from "../schema/app_schema.js";
 
 // Move a note from one position in a sequence to another position in the same sequence or
 // in a different sequence. The index being passed here is the desired index after the move.
@@ -14,8 +16,8 @@ export function moveItem(item: Note | Group, destinationIndex: number, destinati
 	// is asynchronous - the state may have changed during the drag but this function
 	// is operating based on the state at the moment the drag began
 	if (
-		Tree.status(destination) != TreeStatus.InDocument ||
-		Tree.status(item) != TreeStatus.InDocument
+		Tree.status(destination) !== TreeStatus.InDocument ||
+		Tree.status(item) !== TreeStatus.InDocument
 	)
 		return;
 
@@ -25,7 +27,7 @@ export function moveItem(item: Note | Group, destinationIndex: number, destinati
 
 	const index = source.indexOf(item);
 
-	if (destinationIndex == Infinity) {
+	if (destinationIndex === Infinity) {
 		destination.moveToEnd(index, source);
 	} else {
 		// test that the destination index is valid

--- a/brainstorm/src/utils/session_helpers.ts
+++ b/brainstorm/src/utils/session_helpers.ts
@@ -3,8 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { Note } from "../schema/app_schema.js";
-import { Session, Client } from "../schema/session_schema.js";
+import type { Note } from "../schema/app_schema.js";
+import type { Session} from "../schema/session_schema.js";
+import { Client } from "../schema/session_schema.js";
+
 import { selectAction, undefinedUserId } from "./utils.js";
 
 export const testRemoteNoteSelection = (
@@ -13,23 +15,19 @@ export const testRemoteNoteSelection = (
 	clientId: string,
 	fluidMembers: string[],
 ): { selected: boolean; remoteSelected: boolean } => {
-	if (clientId == undefinedUserId) return { selected: false, remoteSelected: false };
+	if (clientId === undefinedUserId) return { selected: false, remoteSelected: false };
 
 	let selected = false;
 	let remoteSelected = false;
 
 	for (const c of session.clients) {
-		if (c.clientId == clientId) {
-			if (c.selected.indexOf(note.id) != -1) {
+		if (c.clientId === clientId && c.selected.includes(note.id)) {
 				selected = true;
 			}
-		}
 
-		if (c.clientId != clientId && fluidMembers.indexOf(c.clientId) != -1) {
-			if (c.selected.indexOf(note.id) != -1) {
+		if (c.clientId !== clientId && fluidMembers.includes(c.clientId) && c.selected.includes(note.id)) {
 				remoteSelected = true;
 			}
-		}
 	}
 
 	return { selected, remoteSelected };
@@ -41,31 +39,31 @@ export const updateRemoteNoteSelection = (
 	session: Session,
 	clientId: string,
 ) => {
-	if (clientId == undefinedUserId) return;
+	if (clientId === undefinedUserId) return;
 
 	// Handle removed items and bail
-	if (action == selectAction.REMOVE) {
+	if (action === selectAction.REMOVE) {
 		for (const c of session.clients) {
 			if (c.clientId === clientId) {
 				const i = c.selected.indexOf(note.id);
-				if (i != -1) c.selected.removeAt(i);
+				if (i !== -1) c.selected.removeAt(i);
 				return;
 			}
 		}
 		return;
 	}
 
-	if (action == selectAction.MULTI) {
+	if (action === selectAction.MULTI) {
 		for (const c of session.clients) {
 			if (c.clientId === clientId) {
 				const i = c.selected.indexOf(note.id);
-				if (i == -1) c.selected.insertAtEnd(note.id);
+				if (i === -1) c.selected.insertAtEnd(note.id);
 				return;
 			}
 		}
 	}
 
-	if (action == selectAction.SINGLE) {
+	if (action === selectAction.SINGLE) {
 		console.log(clientId);
 		for (const c of session.clients) {
 			if (c.clientId === clientId) {
@@ -77,7 +75,7 @@ export const updateRemoteNoteSelection = (
 	}
 
 	const s = new Client({
-		clientId: clientId,
+		clientId,
 		selected: [note.id],
 	});
 
@@ -86,8 +84,8 @@ export const updateRemoteNoteSelection = (
 
 export const getSelectedNotes = (session: Session, clientId: string): string[] => {
 	for (const c of session.clients) {
-		if (c.clientId == clientId) {
-			return c.selected.concat();
+		if (c.clientId === clientId) {
+			return [...c.selected];
 		}
 	}
 	return [];

--- a/brainstorm/src/utils/session_helpers.ts
+++ b/brainstorm/src/utils/session_helpers.ts
@@ -3,8 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { Note } from "../schema/app_schema.js";
-import { Session, Client } from "../schema/session_schema.js";
+import type { Note } from "../schema/app_schema.js";
+import type { Session } from "../schema/session_schema.js";
+import { Client } from "../schema/session_schema.js";
+
 import { selectAction, undefinedUserId } from "./utils.js";
 
 export const testRemoteNoteSelection = (
@@ -13,22 +15,22 @@ export const testRemoteNoteSelection = (
 	clientId: string,
 	fluidMembers: string[],
 ): { selected: boolean; remoteSelected: boolean } => {
-	if (clientId == undefinedUserId) return { selected: false, remoteSelected: false };
+	if (clientId === undefinedUserId) return { selected: false, remoteSelected: false };
 
 	let selected = false;
 	let remoteSelected = false;
 
 	for (const c of session.clients) {
-		if (c.clientId == clientId) {
-			if (c.selected.indexOf(note.id) != -1) {
-				selected = true;
-			}
+		if (c.clientId === clientId && c.selected.includes(note.id)) {
+			selected = true;
 		}
 
-		if (c.clientId != clientId && fluidMembers.indexOf(c.clientId) != -1) {
-			if (c.selected.indexOf(note.id) != -1) {
-				remoteSelected = true;
-			}
+		if (
+			c.clientId !== clientId &&
+			fluidMembers.includes(c.clientId) &&
+			c.selected.includes(note.id)
+		) {
+			remoteSelected = true;
 		}
 	}
 
@@ -41,31 +43,31 @@ export const updateRemoteNoteSelection = (
 	session: Session,
 	clientId: string,
 ) => {
-	if (clientId == undefinedUserId) return;
+	if (clientId === undefinedUserId) return;
 
 	// Handle removed items and bail
-	if (action == selectAction.REMOVE) {
+	if (action === selectAction.REMOVE) {
 		for (const c of session.clients) {
 			if (c.clientId === clientId) {
 				const i = c.selected.indexOf(note.id);
-				if (i != -1) c.selected.removeAt(i);
+				if (i !== -1) c.selected.removeAt(i);
 				return;
 			}
 		}
 		return;
 	}
 
-	if (action == selectAction.MULTI) {
+	if (action === selectAction.MULTI) {
 		for (const c of session.clients) {
 			if (c.clientId === clientId) {
 				const i = c.selected.indexOf(note.id);
-				if (i == -1) c.selected.insertAtEnd(note.id);
+				if (i === -1) c.selected.insertAtEnd(note.id);
 				return;
 			}
 		}
 	}
 
-	if (action == selectAction.SINGLE) {
+	if (action === selectAction.SINGLE) {
 		console.log(clientId);
 		for (const c of session.clients) {
 			if (c.clientId === clientId) {
@@ -77,7 +79,7 @@ export const updateRemoteNoteSelection = (
 	}
 
 	const s = new Client({
-		clientId: clientId,
+		clientId,
 		selected: [note.id],
 	});
 
@@ -86,8 +88,8 @@ export const updateRemoteNoteSelection = (
 
 export const getSelectedNotes = (session: Session, clientId: string): string[] => {
 	for (const c of session.clients) {
-		if (c.clientId == clientId) {
-			return c.selected.concat();
+		if (c.clientId === clientId) {
+			return [...c.selected];
 		}
 	}
 	return [];

--- a/brainstorm/src/utils/undo.ts
+++ b/brainstorm/src/utils/undo.ts
@@ -1,10 +1,11 @@
-import {
-	CommitKind,
+import type {
 	CommitMetadata,
 	Listenable,
 	Revertible,
 	RevertibleFactory,
-	TreeViewEvents,
+	TreeViewEvents} from "fluid-framework";
+import {
+	CommitKind
 } from "fluid-framework";
 
 /**
@@ -72,4 +73,4 @@ export function createUndoRedoStacks(events: Listenable<TreeViewEvents>): undoRe
 	return { undo, redo, dispose };
 }
 
-export type undoRedo = { undo: () => void; redo: () => void; dispose: () => void };
+export interface undoRedo { undo: () => void; redo: () => void; dispose: () => void }

--- a/brainstorm/src/utils/undo.ts
+++ b/brainstorm/src/utils/undo.ts
@@ -1,11 +1,11 @@
-import {
-	CommitKind,
+import type {
 	CommitMetadata,
 	Listenable,
 	Revertible,
 	RevertibleFactory,
 	TreeViewEvents,
 } from "fluid-framework";
+import { CommitKind } from "fluid-framework";
 
 /**
  * Create undo and redo stacks for a tree view. The stacks are populated with revertible objects.
@@ -72,4 +72,8 @@ export function createUndoRedoStacks(events: Listenable<TreeViewEvents>): undoRe
 	return { undo, redo, dispose };
 }
 
-export type undoRedo = { undo: () => void; redo: () => void; dispose: () => void };
+export interface undoRedo {
+	undo: () => void;
+	redo: () => void;
+	dispose: () => void;
+}

--- a/brainstorm/src/utils/utils.ts
+++ b/brainstorm/src/utils/utils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Note } from "../schema/app_schema.js";
+import type { Note } from "../schema/app_schema.js";
 
 export const undefinedUserId = "[UNDEFINED]";
 
@@ -25,7 +25,7 @@ export function getRotation(note: Note) {
 function hashCode(str: string): number {
 	let h = 0;
 	for (let i = 0; i < str.length; i++) {
-		h = 31 * h + str.charCodeAt(i);
+		h = 31 * h + (str.codePointAt(i) ?? 0);
 	}
 	return h;
 }

--- a/brainstorm/tsconfig.json
+++ b/brainstorm/tsconfig.json
@@ -7,7 +7,7 @@
 		"sourceMap": true,
 		// Set your preferences here for TypeScript
 		"strict": true,
-		"jsx": "react",
+		"jsx": "react-jsx",
 		"moduleResolution": "Node16",
 		"allowSyntheticDefaultImports": true,
 		"esModuleInterop": true

--- a/brainstorm/tsconfig.json
+++ b/brainstorm/tsconfig.json
@@ -7,7 +7,7 @@
 		"sourceMap": true,
 		// Set your preferences here for TypeScript
 		"strict": true,
-		"jsx": "react",
+		"jsx": "react-jsx",
 		"moduleResolution": "Node16",
 		"allowSyntheticDefaultImports": true,
 		"esModuleInterop": true,


### PR DESCRIPTION
## Summary

- Update tsconfig jsx from `"react"` to `"react-jsx"` (React 19 automatic transform)
- Convert `==` to `===` and `!=` to `!==` for strict equality
- Convert ternary expressions to nullish coalescing (`??`)
- Replace non-null assertions (`!`) with `?? ""` fallbacks
- Add `.catch()` handlers for floating promises
- Fix import ordering per import-x/order
- Apply consistent-type-imports (separate type imports)
- Use `codePointAt()` instead of `charCodeAt()`

These are independently valid code improvements, split out from the eslint-config-fluid adoption PR.

## Test plan

- [ ] `npm run compile` in brainstorm has no new TypeScript errors
- [ ] Dev server starts correctly