### PR TITLE
fix(item-counter): lint and type fixes

### DIFF
--- a/item-counter/src/index.tsx
+++ b/item-counter/src/index.tsx
@@ -3,25 +3,25 @@
  * Licensed under the MIT License.
  */
 
-import React from "react";
+import { AttachState } from "fluid-framework";
 import { createRoot } from "react-dom/client";
+
 import { loadFluidData, containerSchema } from "./infra/fluid.js";
-import { treeConfiguration } from "./schema.js";
 import "./output.css";
 import { ReactApp } from "./react_app.js";
-import { AttachState } from "fluid-framework";
+import { treeConfiguration } from "./schema.js";
 
 async function start() {
 	// create the root element for React
 	const app = document.createElement("div");
 	app.id = "app";
-	document.body.appendChild(app);
+	document.body.append(app);
 	const root = createRoot(app);
 
 	// Get the root container id from the URL
 	// If there is no container id, then the app will make
 	// a new container.
-	let containerId = location.hash.substring(1);
+	let containerId = location.hash.slice(1);
 
 	// Initialize Fluid Container - this will either make a new container or load an existing one
 	const { container } = await loadFluidData(containerId, containerSchema);
@@ -46,7 +46,7 @@ async function start() {
 
 		// The newly attached container is given a unique ID that can be used to access the container in another session.
 		// This adds that id to the url.
-		history.replaceState(undefined, "", "#" + containerId);
+		history.replaceState(undefined, "", `#${ containerId}`);
 	}
 }
 

--- a/item-counter/src/infra/clientProps.ts
+++ b/item-counter/src/infra/clientProps.ts
@@ -9,6 +9,7 @@ import type {
 	AzureLocalConnectionConfig,
 	ITelemetryBaseLogger,
 } from "@fluidframework/azure-client";
+
 import {
 	AzureFunctionTokenProvider,
 	azureUser,
@@ -23,12 +24,12 @@ if (!useAzure) {
 
 const remoteConnectionConfig: AzureRemoteConnectionConfig = {
 	type: "remote",
-	tenantId: process.env.AZURE_TENANT_ID!,
+	tenantId: process.env.AZURE_TENANT_ID ?? "",
 	tokenProvider: new AzureFunctionTokenProvider(
-		process.env.AZURE_FUNCTION_TOKEN_PROVIDER_URL!,
+		process.env.AZURE_FUNCTION_TOKEN_PROVIDER_URL ?? "",
 		azureUser,
 	),
-	endpoint: process.env.AZURE_ORDERER!,
+	endpoint: process.env.AZURE_ORDERER ?? "",
 };
 
 const localConnectionConfig: AzureLocalConnectionConfig = {

--- a/item-counter/src/infra/fluid.ts
+++ b/item-counter/src/infra/fluid.ts
@@ -3,12 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import {
-	AzureClient,
-	AzureContainerServices,
-	type ITelemetryBaseLogger,
-} from "@fluidframework/azure-client";
-import { ContainerSchema, IFluidContainer, SharedTree } from "fluid-framework";
+import type { AzureContainerServices, ITelemetryBaseLogger } from "@fluidframework/azure-client";
+import { AzureClient } from "@fluidframework/azure-client";
+import type { ContainerSchema, IFluidContainer} from "fluid-framework";
+import { SharedTree } from "fluid-framework";
+
 import { getClientProps } from "./clientProps.js";
 
 async function initializeClient(): Promise<{

--- a/item-counter/src/infra/tokenProvider.ts
+++ b/item-counter/src/infra/tokenProvider.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { AzureMember, ITokenProvider, ITokenResponse, IUser } from "@fluidframework/azure-client";
+import type { AzureMember, ITokenProvider, ITokenResponse, IUser } from "@fluidframework/azure-client";
 import { ScopeType } from "@fluidframework/protocol-definitions";
 import axios from "axios";
 import { KJUR as jsrsasign } from "jsrsasign";
@@ -153,7 +153,7 @@ export function generateToken(
 	lifetime: number = 60 * 60,
 	ver = "1.0",
 ): string {
-	let userClaim = user ? user : generateUser();
+	let userClaim = user ?? generateUser();
 	if (userClaim.id === "" || userClaim.id === undefined) {
 		userClaim = generateUser();
 	}

--- a/item-counter/src/react_app.tsx
+++ b/item-counter/src/react_app.tsx
@@ -3,9 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import React, { JSX, ReactNode, useEffect, useState } from "react";
-import { TreeView, Tree } from "fluid-framework";
-import { StringArray } from "./schema.js";
+import type { TreeView} from "fluid-framework";
+import { Tree } from "fluid-framework";
+import type { JSX, ReactNode} from "react";
+import { useEffect, useState } from "react";
+
+import type { StringArray } from "./schema.js";
 
 export function ReactApp(props: { data: TreeView<typeof StringArray> }): JSX.Element {
 	return (

--- a/item-counter/tsconfig.json
+++ b/item-counter/tsconfig.json
@@ -7,7 +7,7 @@
 		"sourceMap": true,
 		// Set your preferences here for TypeScript
 		"strict": true,
-		"jsx": "react",
+		"jsx": "react-jsx",
 		"moduleResolution": "Node16",
 		"allowSyntheticDefaultImports": true,
 		"esModuleInterop": true,


### PR DESCRIPTION
## Summary

- Update tsconfig jsx from `"react"` to `"react-jsx"` (React 19 automatic transform)
- Replace non-null assertions (`!`) with `?? ""` fallbacks
- Convert ternary expression to nullish coalescing (`??`)
- Fix import ordering per import-x/order
- Apply consistent-type-imports (separate type imports)
- Split mixed type/value imports for correct TypeScript compilation

These are independently valid code improvements, split out from the eslint-config-fluid adoption PR.

## Test plan

- [ ] `npm run compile` in item-counter has no new TypeScript errors
- [ ] Dev server starts correctly