### PR TITLE
test: wait for brainstorm connection

### DIFF
--- a/brainstorm/test/App.test.ts
+++ b/brainstorm/test/App.test.ts
@@ -8,6 +8,7 @@ import { test, expect } from "@playwright/test";
 test.describe("brainstorm", () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto("/", { waitUntil: "domcontentloaded" });
+		await expect(page.getByText(/\| connected \| users: 1/)).toBeVisible();
 	});
 
 	test("Load the container (smoke test)", async ({ page }) => {
@@ -22,26 +23,26 @@ test.describe("brainstorm", () => {
 
 	test("Add group", async ({ page }) => {
 		let groups = await page.getByLabel("Note Group");
-		expect(groups).toHaveCount(0);
+		await expect(groups).toHaveCount(0);
 
 		// Click the "Add Group" button
 		await page.getByText("Add Group").click();
 
 		// Verify that a group was added.
 		groups = await page.getByLabel("Note Group");
-		expect(groups).toHaveCount(1);
+		await expect(groups).toHaveCount(1);
 	});
 
 	test("Add note", async ({ page }) => {
 		let notes = await page.getByLabel("Note");
-		expect(notes).toHaveCount(0);
+		await expect(notes).toHaveCount(0);
 
 		// Click the "Add Note" button
 		await page.getByText("Add Note").click();
 
 		// Verify that a note was added.
 		notes = await page.getByLabel("Note");
-		expect(notes).toHaveCount(1);
+		await expect(notes).toHaveCount(1);
 	});
 
 	test("Delete note", async ({ page }) => {
@@ -52,12 +53,12 @@ test.describe("brainstorm", () => {
 		await page.getByLabel("Note").click(); // Will time out if no note exists on the canvas.
 
 		let notes = await page.getByLabel("Note");
-		expect(notes).toHaveCount(1);
+		await expect(notes).toHaveCount(1);
 
 		// Click the "Delete" button.
 		await page.getByText("Delete Note").click();
 
 		notes = await page.getByLabel("Note");
-		expect(notes).toHaveCount(0);
+		await expect(notes).toHaveCount(0);
 	});
 });


### PR DESCRIPTION
## Summary

This fixes flakiness in the Brainstorm Playwright tests by:

- waiting for the Fluid client to report `connected | users: 1` before interacting with the page
- awaiting asynchronous locator count assertions

Without the readiness wait, a test can interact while the app still reports `disconnected | users: 0`. In that state, note selection is not recorded because the current user has not been initialized, so `Delete Note` leaves the note on the canvas.

Example failure: https://github.com/microsoft/FluidExamples/pull/1954/checks?check_run_id=92014027055

## Reproduction

From `brainstorm`, run the tests repeatedly with parallel workers:

```powershell
$env:CI='true'; npx playwright test --grep 'Delete note' --repeat-each=20 --workers=4
```

Before this fix, this reproduced the failure 8 out of 20 times with `Expected: 0, Received: 1` for the remaining note. The failure screenshot showed the app was still `disconnected | users: 0`.

## Validation

```powershell
$env:CI='true'; npx playwright test --repeat-each=5 --workers=4
```

All 20 test runs passed with the readiness wait.