### PR TITLE
build: share example ESLint overrides

### DIFF
--- a/brainstorm/eslint.config.mts
+++ b/brainstorm/eslint.config.mts
@@ -1,43 +1,5 @@
 import { recommended } from "@fluidframework/eslint-config-fluid";
 
-export default [
-	...recommended,
-	{
-		rules: {
-			// Example apps use sub-path imports and relative imports with extensions.
-			"import-x/no-internal-modules": "off",
+import { exampleOverrides } from "../eslint.config.shared.mjs";
 
-			// Explicit return types add verbosity that hurts readability in example code.
-			"@typescript-eslint/explicit-function-return-type": "off",
-			"@typescript-eslint/explicit-module-boundary-types": "off",
-
-			// Existing files use snake_case naming; renaming would break project imports.
-			"unicorn/filename-case": "off",
-
-			// Allow == null checks, which cover both null and undefined.
-			"eqeqeq": ["error", "smart"],
-
-			// Common variable naming patterns in React and callback-heavy code.
-			"@typescript-eslint/no-shadow": "off",
-
-			// External APIs return loosely typed data; keep the examples focused on Fluid.
-			"@typescript-eslint/no-unsafe-assignment": "off",
-			"@typescript-eslint/no-unsafe-member-access": "off",
-			"@typescript-eslint/no-unsafe-argument": "off",
-			"@typescript-eslint/strict-boolean-expressions": "off",
-
-			// Some transitive dependencies are used directly in examples.
-			"import-x/no-extraneous-dependencies": "off",
-
-			// CSS side-effect imports are expected.
-			"import-x/no-unassigned-import": "off",
-
-			// null is used by external APIs and React patterns.
-			"unicorn/no-null": "off",
-			"@rushstack/no-new-null": "off",
-
-			// Top-level await does not work in all bundler configurations.
-			"unicorn/prefer-top-level-await": "off",
-		},
-	},
-];
+export default [...recommended, exampleOverrides];

--- a/eslint.config.shared.mts
+++ b/eslint.config.shared.mts
@@ -1,0 +1,38 @@
+export const exampleOverrides = {
+  rules: {
+    // Example apps use sub-path imports and relative imports with extensions.
+    "import-x/no-internal-modules": "off",
+
+    // Explicit return types add verbosity that hurts readability in example code.
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+
+    // Existing files use snake_case naming; renaming would break project imports.
+    "unicorn/filename-case": "off",
+
+    // Allow == null checks, which cover both null and undefined.
+    eqeqeq: ["error", "smart"],
+
+    // Common variable naming patterns in React and callback-heavy code.
+    "@typescript-eslint/no-shadow": "off",
+
+    // External APIs return loosely typed data; keep the examples focused on Fluid.
+    "@typescript-eslint/no-unsafe-assignment": "off",
+    "@typescript-eslint/no-unsafe-member-access": "off",
+    "@typescript-eslint/no-unsafe-argument": "off",
+    "@typescript-eslint/strict-boolean-expressions": "off",
+
+    // Some transitive dependencies are used directly in examples.
+    "import-x/no-extraneous-dependencies": "off",
+
+    // CSS side-effect imports are expected.
+    "import-x/no-unassigned-import": "off",
+
+    // null is used by external APIs and React patterns.
+    "unicorn/no-null": "off",
+    "@rushstack/no-new-null": "off",
+
+    // Top-level await does not work in all bundler configurations.
+    "unicorn/prefer-top-level-await": "off",
+  },
+};

--- a/item-counter-spe/eslint.config.mts
+++ b/item-counter-spe/eslint.config.mts
@@ -1,43 +1,5 @@
 import { recommended } from "@fluidframework/eslint-config-fluid";
 
-export default [
-	...recommended,
-	{
-		rules: {
-			// Example apps use sub-path imports and relative imports with extensions.
-			"import-x/no-internal-modules": "off",
+import { exampleOverrides } from "../eslint.config.shared.mjs";
 
-			// Explicit return types add verbosity that hurts readability in example code.
-			"@typescript-eslint/explicit-function-return-type": "off",
-			"@typescript-eslint/explicit-module-boundary-types": "off",
-
-			// Existing files use snake_case naming; renaming would break project imports.
-			"unicorn/filename-case": "off",
-
-			// Allow == null checks, which cover both null and undefined.
-			"eqeqeq": ["error", "smart"],
-
-			// Common variable naming patterns in React and callback-heavy code.
-			"@typescript-eslint/no-shadow": "off",
-
-			// External APIs return loosely typed data; keep the examples focused on Fluid.
-			"@typescript-eslint/no-unsafe-assignment": "off",
-			"@typescript-eslint/no-unsafe-member-access": "off",
-			"@typescript-eslint/no-unsafe-argument": "off",
-			"@typescript-eslint/strict-boolean-expressions": "off",
-
-			// Some transitive dependencies are used directly in examples.
-			"import-x/no-extraneous-dependencies": "off",
-
-			// CSS side-effect imports are expected.
-			"import-x/no-unassigned-import": "off",
-
-			// null is used by external APIs and React patterns.
-			"unicorn/no-null": "off",
-			"@rushstack/no-new-null": "off",
-
-			// Top-level await does not work in all bundler configurations.
-			"unicorn/prefer-top-level-await": "off",
-		},
-	},
-];
+export default [...recommended, exampleOverrides];

--- a/item-counter/eslint.config.mts
+++ b/item-counter/eslint.config.mts
@@ -1,43 +1,5 @@
 import { recommended } from "@fluidframework/eslint-config-fluid";
 
-export default [
-	...recommended,
-	{
-		rules: {
-			// Example apps use sub-path imports and relative imports with extensions.
-			"import-x/no-internal-modules": "off",
+import { exampleOverrides } from "../eslint.config.shared.mjs";
 
-			// Explicit return types add verbosity that hurts readability in example code.
-			"@typescript-eslint/explicit-function-return-type": "off",
-			"@typescript-eslint/explicit-module-boundary-types": "off",
-
-			// Existing files use snake_case naming; renaming would break project imports.
-			"unicorn/filename-case": "off",
-
-			// Allow == null checks, which cover both null and undefined.
-			"eqeqeq": ["error", "smart"],
-
-			// Common variable naming patterns in React and callback-heavy code.
-			"@typescript-eslint/no-shadow": "off",
-
-			// External APIs return loosely typed data; keep the examples focused on Fluid.
-			"@typescript-eslint/no-unsafe-assignment": "off",
-			"@typescript-eslint/no-unsafe-member-access": "off",
-			"@typescript-eslint/no-unsafe-argument": "off",
-			"@typescript-eslint/strict-boolean-expressions": "off",
-
-			// Some transitive dependencies are used directly in examples.
-			"import-x/no-extraneous-dependencies": "off",
-
-			// CSS side-effect imports are expected.
-			"import-x/no-unassigned-import": "off",
-
-			// null is used by external APIs and React patterns.
-			"unicorn/no-null": "off",
-			"@rushstack/no-new-null": "off",
-
-			// Top-level await does not work in all bundler configurations.
-			"unicorn/prefer-top-level-await": "off",
-		},
-	},
-];
+export default [...recommended, exampleOverrides];


### PR DESCRIPTION
## Summary
- extract the identical example-specific ESLint overrides into a shared root module
- keep each project config responsible for importing `@fluidframework/eslint-config-fluid` from its local dependencies
- reduce each project config to the shared `recommended` config plus the common overrides

Follow-up to #1975 and https://github.com/microsoft/FluidExamples/pull/1975#discussion_r3724842058.

## Validation
- `npm run lint` in `brainstorm`
- `npm run lint` in `item-counter`
- `npm run lint` in `item-counter-spe`

Lint results are unchanged and complete without errors.