### PR TITLE
fix(ci): install examples through Azure Artifacts

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -26,6 +26,11 @@ pr:
   - main
 variables:
   skipComponentGovernanceDetection: true
+  # Azure Artifacts feed used for every "npm ci" install below, instead of the public npm registry.
+  publicPackagesRegistryUrl: https://pkgs.dev.azure.com/fluidframework/public/_packaging/publicPackages/npm/registry/
+  # Temporary, authenticated .npmrc used by every "npm ci" install below so all package installs
+  # resolve through the Azure Artifacts feed instead of the public npm registry.
+  userNpmrcPath: $(Agent.TempDirectory)/example-packages.npmrc
 resources:
   repositories:
     - repository: 1ESPipelineTemplates
@@ -64,14 +69,40 @@ extends:
                 inputs:
                   version: 22.x
 
+              - task: Bash@3
+                displayName: Create .npmrc for Azure Artifacts feed
+                env:
+                  NPM_CONFIG_USERCONFIG: $(userNpmrcPath)
+                  PUBLIC_PACKAGES_REGISTRY_URL: $(publicPackagesRegistryUrl)
+                inputs:
+                  targetType: "inline"
+                  script: |
+                    set -eu -o pipefail
+                    # Overwrite (not append) so reruns on a reused agent don't duplicate entries.
+                    echo "registry=$PUBLIC_PACKAGES_REGISTRY_URL" > "$NPM_CONFIG_USERCONFIG"
+                    echo "always-auth=true" >> "$NPM_CONFIG_USERCONFIG"
+
+              - task: npmAuthenticate@0
+                displayName: Authenticate to Azure Artifacts feed
+                inputs:
+                  workingFile: $(userNpmrcPath)
+
               # Install, build, lint, and test each package
               - ${{ each parameter in parameters }}:
-                  - task: Npm@1
+                  # Npm@1 always overwrites the working directory's .npmrc with its own, so it
+                  # cannot be pointed at the authenticated userNpmrcPath above for a "custom ci"
+                  # command. Use Bash with an explicit --userconfig instead, so the install
+                  # resolves through the authenticated Azure Artifacts feed.
+                  - task: Bash@3
                     displayName: Install - ${{ parameter.Value }}
+                    env:
+                      NPM_CONFIG_USERCONFIG: $(userNpmrcPath)
                     inputs:
-                      command: "custom"
-                      workingDir: "${{ parameter.Value }}"
-                      customCommand: "ci"
+                      targetType: "inline"
+                      workingDirectory: ${{ parameter.Value }}
+                      script: |
+                        set -eu -o pipefail
+                        npm ci --userconfig "$NPM_CONFIG_USERCONFIG"
                   - task: CmdLine@2
                     displayName: Build - ${{ parameter.Value }}
                     inputs:

--- a/build.yml
+++ b/build.yml
@@ -25,12 +25,13 @@ trigger:
 pr:
   - main
 variables:
-  skipComponentGovernanceDetection: true
-  # Azure Artifacts feed used for every "npm ci" install below, instead of the public npm registry.
-  publicPackagesRegistryUrl: https://pkgs.dev.azure.com/fluidframework/public/_packaging/publicPackages/npm/registry/
+  - group: ado-feeds
+  - name: skipComponentGovernanceDetection
+    value: true
   # Temporary, authenticated .npmrc used by every "npm ci" install below so all package installs
-  # resolve through the Azure Artifacts feed instead of the public npm registry.
-  userNpmrcPath: $(Agent.TempDirectory)/example-packages.npmrc
+  # resolve through the approved Azure Artifacts feed instead of the public npm registry.
+  - name: userNpmrcPath
+    value: $(Agent.TempDirectory)/example-packages.npmrc
 resources:
   repositories:
     - repository: 1ESPipelineTemplates
@@ -73,13 +74,14 @@ extends:
                 displayName: Create .npmrc for Azure Artifacts feed
                 env:
                   NPM_CONFIG_USERCONFIG: $(userNpmrcPath)
-                  PUBLIC_PACKAGES_REGISTRY_URL: $(publicPackagesRegistryUrl)
+                  NPM_REGISTRY: $(ado-feeds-primary-registry)
                 inputs:
                   targetType: "inline"
                   script: |
                     set -eu -o pipefail
                     # Overwrite (not append) so reruns on a reused agent don't duplicate entries.
-                    echo "registry=$PUBLIC_PACKAGES_REGISTRY_URL" > "$NPM_CONFIG_USERCONFIG"
+                    echo "registry=$NPM_REGISTRY" > "$NPM_CONFIG_USERCONFIG"
+                    echo "replace-registry-host=always" >> "$NPM_CONFIG_USERCONFIG"
                     echo "always-auth=true" >> "$NPM_CONFIG_USERCONFIG"
 
               - task: npmAuthenticate@0


### PR DESCRIPTION
## Description

Route all three FluidExamples `npm ci` installations through the authenticated `publicPackages` Azure Artifacts feed instead of connecting directly to `registry.npmjs.org`.

The pipeline creates a temporary npm user configuration, authenticates it with `npmAuthenticate@0`, and passes it explicitly to the Brainstorm, Item Counter, and Item Counter SPE installs. Bash tasks are used because `Npm@1` replaces the npm configuration for custom commands.

Cold-cache pipeline validation and the CI readiness check were not run, as requested.

## Reviewer Guidance

Please verify that the public project build identity has access to the `publicPackages` feed and that the feed retains npmjs as an upstream source.