### PR TITLE
Configure 7-day cooldown for external dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,8 @@ updates:
       - "/item-counter-spe"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       # To reduce noise, we bundle related dependencies into a single PR
       eslint:


### PR DESCRIPTION
## Description

Configure Dependabot with a 7-day cooldown for the weekly external dependency update check. This aligns Dependabot PR creation with the repository's 7-day quarantine period for external dependencies and avoids update conflicts during that window.

The daily Fluid Framework dependency check remains unchanged so those updates can continue to arrive promptly.