### PR TITLE
Add 7-day cooldown for Fluid dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       - "/item-counter-spe"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     allow:
       - dependency-name: "@fluidframework*"
       - dependency-name: "fluid-framework"


### PR DESCRIPTION
## Description

Apply the existing 7-day Dependabot cooldown to Fluid Framework dependency updates as well.

Although these packages are maintained internally, Fluid Framework updates can introduce external transitive dependencies. PR #1978 demonstrated this by adding external packages before they had completed the repository's 7-day quarantine period.

This keeps the daily update check while delaying eligible Fluid Framework versions until the quarantine window has elapsed.

Related: #1978
Follow-up to: #1981